### PR TITLE
fix: Subway timetable query not works when limit value is null

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
@@ -38,7 +38,9 @@ class SubwayDataFetcher(
                     directions to weekdays
                 }
         dfe.graphQlContext.put("filterMap", filterMap)
-        dfe.graphQlContext.put("limit", input.limit)
+        if (input.limit != null) {
+            dfe.graphQlContext.put("limit", input.limit)
+        }
         return subwayService.getStations(input.keys.map { it.stationID }).map { station ->
             SubwayStation(
                 stationID = station.id,

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
@@ -421,7 +421,7 @@ class SubwayDataFetcherTest {
                             direction: ["up"],
                             weekdays: ["weekdays", "weekends"]
                         }],
-                        limit: 10
+                        limit: null
                     }) {
                         stationID
                         name


### PR DESCRIPTION
## Changes
- 전철 쿼리시 limit 값이 null인 경우, 쿼리가 이루어지지 않는 문제 수정