### PR TITLE
fix: Arrival limit not applied properly when fetch bus arrival

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/bus/controller/BusDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/bus/controller/BusDataFetcher.kt
@@ -192,7 +192,7 @@ class BusDataFetcher(
                 routeID = routeStop.route.seq,
                 stopID = routeStop.stop.seq,
                 startStopID = routeStop.startStop.seq,
-                limit = limitMap[routeStop.route.seq to routeStop.order],
+                limit = limitMap[routeStop.route.seq to routeStop.stop.seq],
             )
         val dataLoader = dfe.getDataLoader<BusArrivalKey, List<BusArrival>>("busArrivalDataLoader")!!
         return dataLoader.load(key)


### PR DESCRIPTION
## Changes
- Limit 인자를 넣었을 때 Bus Arrival 항목 개수의 제한에 걸리지 않는 오류 수정