### PR TITLE
fix: Remove duplicated shuttle timetable items by order

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/shuttle/service/ShuttleTimetableService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/service/ShuttleTimetableService.kt
@@ -179,7 +179,8 @@ class ShuttleTimetableService(
                                 },
                         )
                     }.sortedBy { it.time }
-            val order = if (key.limit.order != null) entries.take(key.limit.order) else entries
+            val orderEntries = entries.distinctBy { it.seq }
+            val order = if (key.limit.order != null) orderEntries.take(key.limit.order) else orderEntries
             val destination =
                 entries
                     .groupBy { it.group }

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleTimetableServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleTimetableServiceTest.kt
@@ -248,6 +248,7 @@ class ShuttleTimetableServiceTest {
         )
         val result = shuttleTimetableService.getShuttleTimetableBatch(setOf(key))
         val timetable = result[key]!!
+        assertEquals(1, timetable.order.size)
         assertEquals(2, timetable.destination.size)
         assertEquals("STATION", timetable.destination.keys.first())
         assertEquals("TERMINAL", timetable.destination.keys.last())


### PR DESCRIPTION
## Changes
- 시간별 셔틀버스 시간표를 조회할 때 중복되는 항목이 나오는 문제 수정