### PR TITLE
chore: standardize workflow names and update README

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -1,4 +1,4 @@
-name: Check code convention
+name: Code Check and Test
 on:
   push:
     branches-ignore:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Spring Boot Backend Application
+name: Deploy Docker Image
 on:
   pull_request:
     branches:

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The Dockerfile uses a multi-stage build with `eclipse-temurin:21-jre-alpine` as 
 
 | Workflow | Trigger | Actions |
 |---|---|---|
-| `codecheck.yml` | Push / PR | ktlint check, tests, JaCoCo coverage |
+| `code-check.yml` | Push / PR | ktlint check, tests, JaCoCo coverage |
 | `deploy.yml` | Merged PR / manual | Docker build & push, Kubernetes rolling restart |
 
 Deployment targets a Kubernetes cluster under the `hyuabot` namespace.


### PR DESCRIPTION
## Summary

- Renamed `codecheck.yml` → `code-check.yml` and set workflow name to `Code Check and Test`
- Updated deploy workflow name to `Deploy Docker Image`
- Updated CI/CD table in README to reflect new filename

## Test plan

- [ ] Verify `Code Check and Test` workflow triggers on push
- [ ] Verify `Deploy Docker Image` workflow triggers on merged PR