### PR TITLE
chore: Enable graceful shutdown for zero-downtime rolling updates

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,9 @@ logging.level.org.springframework.security=DEBUG
 logging.level.org.hibernate.orm.jdbc.bind=OFF
 # Exception
 spring.web.error.include-stacktrace=never
+# Graceful shutdown — finish in-flight requests before pod is removed
+server.shutdown=graceful
+spring.lifecycle.timeout-per-shutdown-phase=60s
 # Actuator
 management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.probes.enabled=true


### PR DESCRIPTION
## Summary

- Add `server.shutdown=graceful` to enable Spring Boot graceful shutdown
- Set `spring.lifecycle.timeout-per-shutdown-phase=60s` to allow up to 60s for in-flight requests to complete before the pod is removed

## Background

The Kubernetes deployment was updated to run 2 replicas with a RollingUpdate strategy (`maxUnavailable=0`, `maxSurge=1`) and a `preStop` sleep of 15s. Without graceful shutdown enabled in Spring Boot, the app would immediately terminate on SIGTERM even while requests were in progress.

## Test plan

- [ ] Verify rolling update does not drop requests during deployment
- [ ] Verify `/actuator/health` returns `OUT_OF_SERVICE` on shutdown start