### PR TITLE
feat: Add public holiday management for bus and subway

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/bus/service/BusRealtimeService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/bus/service/BusRealtimeService.kt
@@ -5,6 +5,7 @@ import app.hyuabot.backend.codegen.types.BusArrival
 import app.hyuabot.backend.database.entity.BusRealtime
 import app.hyuabot.backend.database.repository.BusRealtimeRepository
 import app.hyuabot.backend.database.repository.BusTimetableRepository
+import app.hyuabot.backend.holiday.service.PublicHolidayService
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import java.time.DayOfWeek
@@ -17,15 +18,18 @@ import java.time.ZoneId
 class BusRealtimeService(
     private val realtimeRepository: BusRealtimeRepository,
     private val timetableRepository: BusTimetableRepository,
+    private val publicHolidayService: PublicHolidayService,
 ) {
     private val serviceStartTime: LocalTime = LocalTime.of(4, 0)
 
-    internal fun resolveWeekday(date: LocalDate): String =
-        when (date.dayOfWeek) {
+    internal fun resolveWeekday(date: LocalDate): String {
+        if (publicHolidayService.findPublicHoliday(date) != null) return "sunday"
+        return when (date.dayOfWeek) {
             DayOfWeek.SATURDAY -> "saturday"
             DayOfWeek.SUNDAY -> "sunday"
             else -> "weekdays"
         }
+    }
 
     private fun toServiceMinutes(time: LocalTime): Int {
         val seconds = time.toSecondOfDay()

--- a/src/main/kotlin/app/hyuabot/backend/database/entity/PublicHoliday.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/entity/PublicHoliday.kt
@@ -1,0 +1,42 @@
+package app.hyuabot.backend.database.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import org.hibernate.Hibernate
+import java.time.LocalDate
+
+@Entity(name = "public_holiday")
+@Table(
+    name = "public_holiday",
+    indexes = [
+        Index(name = "idx_public_holiday_date", columnList = "holiday_date, calendar_type", unique = true),
+    ],
+)
+@SequenceGenerator(name = "public_holiday_seq_seq", allocationSize = 1)
+class PublicHoliday(
+    @Id
+    @Column(name = "seq", columnDefinition = "serial")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "public_holiday_seq_seq")
+    val seq: Int? = null,
+    @Column(name = "holiday_date", columnDefinition = "date", nullable = false)
+    var date: LocalDate,
+    @Column(name = "holiday_name", length = 30, nullable = false)
+    var name: String,
+    @Column(name = "calendar_type", length = 15, nullable = false)
+    var calendarType: String,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+        other as PublicHoliday
+        return seq != null && seq == other.seq
+    }
+
+    override fun hashCode(): Int = Hibernate.getClass(this).hashCode()
+}

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/PublicHolidayRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/PublicHolidayRepository.kt
@@ -1,0 +1,31 @@
+package app.hyuabot.backend.database.repository
+
+import app.hyuabot.backend.database.entity.PublicHoliday
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
+
+interface PublicHolidayRepository : JpaRepository<PublicHoliday, Int> {
+    fun findByDateAndCalendarType(
+        date: LocalDate,
+        calendarType: String,
+    ): PublicHoliday?
+
+    fun findBySeqNotAndDateAndCalendarType(
+        seq: Int,
+        date: LocalDate,
+        calendarType: String,
+    ): PublicHoliday?
+
+    @Query(
+        """
+        SELECT h FROM public_holiday h
+        WHERE (h.date = :solarDate AND h.calendarType = 'solar')
+           OR (h.date = :lunarDate AND h.calendarType = 'lunar')
+        """,
+    )
+    fun findBySolarDateOrLunarDate(
+        solarDate: LocalDate,
+        lunarDate: LocalDate,
+    ): PublicHoliday?
+}

--- a/src/main/kotlin/app/hyuabot/backend/holiday/controller/PublicHolidayController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/controller/PublicHolidayController.kt
@@ -1,0 +1,251 @@
+package app.hyuabot.backend.holiday.controller
+
+import app.hyuabot.backend.database.exception.LocalDateNotValidException
+import app.hyuabot.backend.holiday.domain.PublicHolidayListResponse
+import app.hyuabot.backend.holiday.domain.PublicHolidayRequest
+import app.hyuabot.backend.holiday.domain.PublicHolidayResponse
+import app.hyuabot.backend.holiday.exception.DuplicatePublicHolidayException
+import app.hyuabot.backend.holiday.exception.PublicHolidayNotFoundException
+import app.hyuabot.backend.holiday.service.PublicHolidayService
+import app.hyuabot.backend.utility.LocalDateTimeBuilder
+import app.hyuabot.backend.utility.ResponseBuilder
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/holiday")
+@RestController
+@Tag(name = "Holiday", description = "공휴일 관련 API")
+class PublicHolidayController {
+    @Autowired
+    private lateinit var service: PublicHolidayService
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping("")
+    @Operation(summary = "공휴일 정보 조회", description = "공휴일 정보를 조회합니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "공휴일 정보 조회 성공",
+        content = [Content(schema = Schema(implementation = PublicHolidayListResponse::class))],
+    )
+    fun getPublicHoliday(): PublicHolidayListResponse =
+        PublicHolidayListResponse(
+            service.getPublicHolidayList().map {
+                PublicHolidayResponse(
+                    seq = it.seq!!,
+                    date = LocalDateTimeBuilder.convertLocalDateToString(it.date),
+                    name = it.name,
+                    calendarType = it.calendarType,
+                )
+            },
+        )
+
+    @PostMapping("")
+    @Operation(summary = "공휴일 정보 생성", description = "공휴일 정보를 생성합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "공휴일 정보 생성 성공",
+                content = [Content(schema = Schema(implementation = PublicHolidayResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ResponseBuilder.Message::class),
+                        examples = [
+                            ExampleObject(
+                                name = "잘못된 날짜 형식",
+                                summary = "date 필드에 잘못된 날짜 형식이 들어온 경우",
+                                value = """{"message": "LOCAL_DATE_NOT_VALID"}""",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "중복된 공휴일 정보",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ResponseBuilder.Message::class),
+                        examples = [
+                            ExampleObject(
+                                name = "중복된 공휴일 정보",
+                                summary = "이미 존재하는 날짜와 음력/양력 구분으로 공휴일 정보를 생성하려는 경우",
+                                value = """{"message": "DUPLICATE_PUBLIC_HOLIDAY"}""",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun createPublicHoliday(
+        @RequestBody payload: PublicHolidayRequest,
+    ): ResponseEntity<*> =
+        try {
+            service.createPublicHoliday(payload).let {
+                ResponseBuilder.response(
+                    HttpStatus.CREATED,
+                    PublicHolidayResponse(
+                        seq = it.seq!!,
+                        date = LocalDateTimeBuilder.convertLocalDateToString(it.date),
+                        name = it.name,
+                        calendarType = it.calendarType,
+                    ),
+                )
+            }
+        } catch (_: LocalDateNotValidException) {
+            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("LOCAL_DATE_NOT_VALID"))
+        } catch (_: DuplicatePublicHolidayException) {
+            ResponseBuilder.response(HttpStatus.CONFLICT, ResponseBuilder.Message("DUPLICATE_PUBLIC_HOLIDAY"))
+        } catch (e: Exception) {
+            logger.error("Error occurred while creating public holiday", e)
+            ResponseBuilder.response(HttpStatus.INTERNAL_SERVER_ERROR, ResponseBuilder.Message("INTERNAL_SERVER_ERROR"))
+        }
+
+    @GetMapping("/{seq}")
+    @Operation(summary = "공휴일 정보 단건 조회", description = "공휴일 정보를 seq로 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "공휴일 정보 조회 성공",
+                content = [Content(schema = Schema(implementation = PublicHolidayResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "공휴일 정보 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ResponseBuilder.Message::class),
+                        examples = [
+                            ExampleObject(
+                                name = "공휴일 정보 없음",
+                                value = """{"message": "PUBLIC_HOLIDAY_NOT_FOUND"}""",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getPublicHolidayBySeq(
+        @PathVariable seq: Int,
+    ): ResponseEntity<*> =
+        try {
+            service.getPublicHolidayById(seq).let {
+                ResponseBuilder.response(
+                    HttpStatus.OK,
+                    PublicHolidayResponse(
+                        seq = it.seq!!,
+                        date = LocalDateTimeBuilder.convertLocalDateToString(it.date),
+                        name = it.name,
+                        calendarType = it.calendarType,
+                    ),
+                )
+            }
+        } catch (_: PublicHolidayNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("PUBLIC_HOLIDAY_NOT_FOUND"))
+        } catch (e: Exception) {
+            logger.error("Error occurred while retrieving public holiday by seq", e)
+            ResponseBuilder.response(HttpStatus.INTERNAL_SERVER_ERROR, ResponseBuilder.Message("INTERNAL_SERVER_ERROR"))
+        }
+
+    @PutMapping("/{seq}")
+    @Operation(summary = "공휴일 정보 수정", description = "공휴일 정보를 수정합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "공휴일 정보 수정 성공",
+                content = [Content(schema = Schema(implementation = PublicHolidayResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = [Content(schema = Schema(implementation = ResponseBuilder.Message::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "공휴일 정보 없음",
+                content = [Content(schema = Schema(implementation = ResponseBuilder.Message::class))],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "중복된 공휴일 정보",
+                content = [Content(schema = Schema(implementation = ResponseBuilder.Message::class))],
+            ),
+        ],
+    )
+    fun updatePublicHoliday(
+        @PathVariable seq: Int,
+        @RequestBody payload: PublicHolidayRequest,
+    ): ResponseEntity<*> =
+        try {
+            service.updatePublicHoliday(seq, payload).let {
+                ResponseBuilder.response(
+                    HttpStatus.OK,
+                    PublicHolidayResponse(
+                        seq = it.seq!!,
+                        date = LocalDateTimeBuilder.convertLocalDateToString(it.date),
+                        name = it.name,
+                        calendarType = it.calendarType,
+                    ),
+                )
+            }
+        } catch (_: LocalDateNotValidException) {
+            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("LOCAL_DATE_NOT_VALID"))
+        } catch (_: PublicHolidayNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("PUBLIC_HOLIDAY_NOT_FOUND"))
+        } catch (_: DuplicatePublicHolidayException) {
+            ResponseBuilder.response(HttpStatus.CONFLICT, ResponseBuilder.Message("DUPLICATE_PUBLIC_HOLIDAY"))
+        } catch (e: Exception) {
+            logger.error("Error occurred while updating public holiday", e)
+            ResponseBuilder.response(HttpStatus.INTERNAL_SERVER_ERROR, ResponseBuilder.Message("INTERNAL_SERVER_ERROR"))
+        }
+
+    @DeleteMapping("/{seq}")
+    @Operation(summary = "공휴일 정보 삭제", description = "공휴일 정보를 삭제합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "공휴일 정보 삭제 성공"),
+            ApiResponse(
+                responseCode = "404",
+                description = "공휴일 정보 없음",
+                content = [Content(schema = Schema(implementation = ResponseBuilder.Message::class))],
+            ),
+        ],
+    )
+    fun deletePublicHoliday(
+        @PathVariable seq: Int,
+    ): ResponseEntity<*> =
+        try {
+            service.deletePublicHoliday(seq)
+            ResponseBuilder.response(HttpStatus.NO_CONTENT, null)
+        } catch (_: PublicHolidayNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("PUBLIC_HOLIDAY_NOT_FOUND"))
+        } catch (e: Exception) {
+            logger.error("Error occurred while deleting public holiday", e)
+            ResponseBuilder.response(HttpStatus.INTERNAL_SERVER_ERROR, ResponseBuilder.Message("INTERNAL_SERVER_ERROR"))
+        }
+}

--- a/src/main/kotlin/app/hyuabot/backend/holiday/domain/PublicHolidayListResponse.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/domain/PublicHolidayListResponse.kt
@@ -1,0 +1,8 @@
+package app.hyuabot.backend.holiday.domain
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class PublicHolidayListResponse(
+    @get:Schema(description = "공휴일 목록")
+    val result: List<PublicHolidayResponse>,
+)

--- a/src/main/kotlin/app/hyuabot/backend/holiday/domain/PublicHolidayRequest.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/domain/PublicHolidayRequest.kt
@@ -1,0 +1,12 @@
+package app.hyuabot.backend.holiday.domain
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class PublicHolidayRequest(
+    @get:Schema(description = "공휴일 날짜", example = "2025-10-03")
+    val date: String,
+    @get:Schema(description = "공휴일 이름", example = "개천절")
+    val name: String,
+    @get:Schema(description = "음력/양력 여부", example = "solar")
+    val calendarType: String,
+)

--- a/src/main/kotlin/app/hyuabot/backend/holiday/domain/PublicHolidayResponse.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/domain/PublicHolidayResponse.kt
@@ -1,0 +1,14 @@
+package app.hyuabot.backend.holiday.domain
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class PublicHolidayResponse(
+    @get:Schema(description = "공휴일 ID", example = "1")
+    val seq: Int,
+    @get:Schema(description = "공휴일 날짜", example = "2025-10-03")
+    val date: String,
+    @get:Schema(description = "공휴일 이름", example = "개천절")
+    val name: String,
+    @get:Schema(description = "음력/양력 여부", example = "solar")
+    val calendarType: String,
+)

--- a/src/main/kotlin/app/hyuabot/backend/holiday/exception/DuplicatePublicHolidayException.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/exception/DuplicatePublicHolidayException.kt
@@ -1,0 +1,7 @@
+package app.hyuabot.backend.holiday.exception
+
+import org.springframework.dao.DuplicateKeyException
+
+class DuplicatePublicHolidayException : DuplicateKeyException {
+    constructor() : super("DUPLICATE_PUBLIC_HOLIDAY")
+}

--- a/src/main/kotlin/app/hyuabot/backend/holiday/exception/PublicHolidayNotFoundException.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/exception/PublicHolidayNotFoundException.kt
@@ -1,0 +1,3 @@
+package app.hyuabot.backend.holiday.exception
+
+class PublicHolidayNotFoundException : IllegalArgumentException()

--- a/src/main/kotlin/app/hyuabot/backend/holiday/service/PublicHolidayService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/service/PublicHolidayService.kt
@@ -1,0 +1,83 @@
+package app.hyuabot.backend.holiday.service
+
+import app.hyuabot.backend.database.entity.PublicHoliday
+import app.hyuabot.backend.database.exception.LocalDateNotValidException
+import app.hyuabot.backend.database.repository.PublicHolidayRepository
+import app.hyuabot.backend.holiday.domain.PublicHolidayRequest
+import app.hyuabot.backend.holiday.exception.DuplicatePublicHolidayException
+import app.hyuabot.backend.holiday.exception.PublicHolidayNotFoundException
+import app.hyuabot.backend.utility.LocalDateTimeBuilder
+import com.github.usingsky.calendar.KoreanLunarCalendar
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Service
+class PublicHolidayService(
+    private val publicHolidayRepository: PublicHolidayRepository,
+) {
+    fun getPublicHolidayList() = publicHolidayRepository.findAll().sortedBy { it.date }
+
+    fun createPublicHoliday(payload: PublicHolidayRequest): PublicHoliday {
+        if (!LocalDateTimeBuilder.checkLocalDateFormat(payload.date)) {
+            throw LocalDateNotValidException()
+        }
+        publicHolidayRepository
+            .findByDateAndCalendarType(
+                date = LocalDate.parse(payload.date),
+                calendarType = payload.calendarType,
+            )?.let {
+                throw DuplicatePublicHolidayException()
+            }
+        return publicHolidayRepository.save(
+            PublicHoliday(
+                date = LocalDate.parse(payload.date),
+                name = payload.name,
+                calendarType = payload.calendarType,
+            ),
+        )
+    }
+
+    fun getPublicHolidayById(seq: Int): PublicHoliday =
+        publicHolidayRepository.findById(seq).orElseThrow { throw PublicHolidayNotFoundException() }
+
+    fun updatePublicHoliday(
+        seq: Int,
+        payload: PublicHolidayRequest,
+    ): PublicHoliday {
+        if (!LocalDateTimeBuilder.checkLocalDateFormat(payload.date)) {
+            throw LocalDateNotValidException()
+        }
+        val existing = publicHolidayRepository.findById(seq).orElseThrow { throw PublicHolidayNotFoundException() }
+        publicHolidayRepository
+            .findBySeqNotAndDateAndCalendarType(
+                seq = seq,
+                date = LocalDate.parse(payload.date),
+                calendarType = payload.calendarType,
+            )?.let {
+                throw DuplicatePublicHolidayException()
+            }
+        return publicHolidayRepository.save(
+            existing.apply {
+                date = LocalDate.parse(payload.date)
+                name = payload.name
+                calendarType = payload.calendarType
+            },
+        )
+    }
+
+    fun deletePublicHoliday(seq: Int) {
+        val existing = publicHolidayRepository.findById(seq).orElseThrow { throw PublicHolidayNotFoundException() }
+        publicHolidayRepository.delete(existing)
+    }
+
+    fun findPublicHoliday(date: LocalDate): PublicHoliday? {
+        val lunarDate = KoreanLunarCalendar.getInstance()
+        val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        lunarDate.setSolarDate(date.year, date.monthValue, date.dayOfMonth)
+        return publicHolidayRepository.findBySolarDateOrLunarDate(
+            date,
+            LocalDate.parse(lunarDate.lunarIsoFormat, dateFormatter),
+        )
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
@@ -23,6 +23,8 @@ import app.hyuabot.backend.bus.service.BusRealtimeService
 import app.hyuabot.backend.bus.service.BusRouteService
 import app.hyuabot.backend.bus.service.BusStopService
 import app.hyuabot.backend.bus.service.BusTimetableService
+import app.hyuabot.backend.database.entity.PublicHoliday
+import app.hyuabot.backend.holiday.service.PublicHolidayService
 import app.hyuabot.backend.codegen.types.BusRouteStopInput
 import app.hyuabot.backend.database.entity.BusDepartureLog
 import app.hyuabot.backend.database.entity.BusRealtime
@@ -78,6 +80,9 @@ class BusServiceTest {
 
     @Mock
     private lateinit var logRepository: BusDepartureLogRepository
+
+    @Mock
+    private lateinit var publicHolidayService: PublicHolidayService
 
     @InjectMocks
     private lateinit var routeService: BusRouteService
@@ -3391,6 +3396,7 @@ class BusServiceTest {
     @DisplayName("weekday 결정 - 평일")
     fun testResolveWeekday() {
         val monday = LocalDate.of(2025, 3, 3)
+        whenever(publicHolidayService.findPublicHoliday(monday)).thenReturn(null)
         assertEquals("weekdays", realtimeService.resolveWeekday(monday))
     }
 
@@ -3398,6 +3404,7 @@ class BusServiceTest {
     @DisplayName("weekday 결정 - 토요일")
     fun testResolveWeekdaySaturday() {
         val saturday = LocalDate.of(2025, 3, 1)
+        whenever(publicHolidayService.findPublicHoliday(saturday)).thenReturn(null)
         assertEquals("saturday", realtimeService.resolveWeekday(saturday))
     }
 
@@ -3405,7 +3412,18 @@ class BusServiceTest {
     @DisplayName("weekday 결정 - 일요일")
     fun testResolveWeekdaySunday() {
         val sunday = LocalDate.of(2025, 3, 2)
+        whenever(publicHolidayService.findPublicHoliday(sunday)).thenReturn(null)
         assertEquals("sunday", realtimeService.resolveWeekday(sunday))
+    }
+
+    @Test
+    @DisplayName("weekday 결정 - 공휴일 (평일)")
+    fun testResolveWeekdayPublicHoliday() {
+        val holiday = LocalDate.of(2025, 3, 3)
+        whenever(publicHolidayService.findPublicHoliday(holiday)).thenReturn(
+            PublicHoliday(seq = 1, date = holiday, name = "삼일절", calendarType = "solar"),
+        )
+        assertEquals("sunday", realtimeService.resolveWeekday(holiday))
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
@@ -23,8 +23,6 @@ import app.hyuabot.backend.bus.service.BusRealtimeService
 import app.hyuabot.backend.bus.service.BusRouteService
 import app.hyuabot.backend.bus.service.BusStopService
 import app.hyuabot.backend.bus.service.BusTimetableService
-import app.hyuabot.backend.database.entity.PublicHoliday
-import app.hyuabot.backend.holiday.service.PublicHolidayService
 import app.hyuabot.backend.codegen.types.BusRouteStopInput
 import app.hyuabot.backend.database.entity.BusDepartureLog
 import app.hyuabot.backend.database.entity.BusRealtime
@@ -32,6 +30,7 @@ import app.hyuabot.backend.database.entity.BusRoute
 import app.hyuabot.backend.database.entity.BusRouteStop
 import app.hyuabot.backend.database.entity.BusStop
 import app.hyuabot.backend.database.entity.BusTimetable
+import app.hyuabot.backend.database.entity.PublicHoliday
 import app.hyuabot.backend.database.exception.LocalTimeNotValidException
 import app.hyuabot.backend.database.repository.BusDepartureLogRepository
 import app.hyuabot.backend.database.repository.BusRealtimeRepository
@@ -39,6 +38,7 @@ import app.hyuabot.backend.database.repository.BusRouteRepository
 import app.hyuabot.backend.database.repository.BusRouteStopRepository
 import app.hyuabot.backend.database.repository.BusStopRepository
 import app.hyuabot.backend.database.repository.BusTimetableRepository
+import app.hyuabot.backend.holiday.service.PublicHolidayService
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows

--- a/src/test/kotlin/app/hyuabot/backend/database/entity/PublicHolidayTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/database/entity/PublicHolidayTest.kt
@@ -1,0 +1,30 @@
+package app.hyuabot.backend.database.entity
+
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PublicHolidayTest {
+    private fun create(seq: Int? = 1) =
+        PublicHoliday(
+            seq = seq,
+            date = LocalDate.of(2025, 1, 1),
+            name = "신정",
+            calendarType = "solar",
+        )
+
+    @Test
+    fun equalsAndHashCode() {
+        val a = create()
+        val nullValue: Any? = null
+        assertTrue(a == a)
+        assertFalse(a.equals(nullValue))
+        assertFalse(a.equals(Any()))
+        assertEquals(a, create())
+        assertEquals(a.hashCode(), create().hashCode())
+        assertFalse(a == create(seq = 9999))
+        assertFalse(create(seq = null) == create(seq = null))
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/holiday/PublicHolidayControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/PublicHolidayControllerTest.kt
@@ -201,7 +201,8 @@ class PublicHolidayControllerTest {
     fun testUpdatePublicHoliday() {
         val updated = PublicHoliday(seq = 1, date = LocalDate.parse("2025-03-02"), name = "삼일절 대체공휴일", calendarType = "solar")
         doReturn(updated).whenever(service).updatePublicHoliday(
-            1, PublicHolidayRequest(date = "2025-03-02", name = "삼일절 대체공휴일", calendarType = "solar"),
+            1,
+            PublicHolidayRequest(date = "2025-03-02", name = "삼일절 대체공휴일", calendarType = "solar"),
         )
         mockMvc
             .perform(
@@ -225,7 +226,8 @@ class PublicHolidayControllerTest {
     @WithCustomMockUser(username = "test_user")
     fun testUpdatePublicHolidayInvalidDateFormat() {
         doThrow(LocalDateNotValidException()).whenever(service).updatePublicHoliday(
-            1, PublicHolidayRequest(date = "2025/03/02", name = "테스트", calendarType = "solar"),
+            1,
+            PublicHolidayRequest(date = "2025/03/02", name = "테스트", calendarType = "solar"),
         )
         mockMvc
             .perform(
@@ -246,7 +248,8 @@ class PublicHolidayControllerTest {
     @WithCustomMockUser(username = "test_user")
     fun testUpdatePublicHolidayNotFound() {
         doThrow(PublicHolidayNotFoundException()).whenever(service).updatePublicHoliday(
-            999, PublicHolidayRequest(date = "2025-03-01", name = "테스트", calendarType = "solar"),
+            999,
+            PublicHolidayRequest(date = "2025-03-01", name = "테스트", calendarType = "solar"),
         )
         mockMvc
             .perform(
@@ -267,7 +270,8 @@ class PublicHolidayControllerTest {
     @WithCustomMockUser(username = "test_user")
     fun testUpdatePublicHolidayDuplicateDate() {
         doThrow(DuplicatePublicHolidayException()).whenever(service).updatePublicHoliday(
-            1, PublicHolidayRequest(date = "2025-03-01", name = "테스트", calendarType = "solar"),
+            1,
+            PublicHolidayRequest(date = "2025-03-01", name = "테스트", calendarType = "solar"),
         )
         mockMvc
             .perform(
@@ -288,7 +292,8 @@ class PublicHolidayControllerTest {
     @WithCustomMockUser(username = "test_user")
     fun testUpdatePublicHolidayOtherError() {
         doThrow(RuntimeException("Unexpected Error")).whenever(service).updatePublicHoliday(
-            1, PublicHolidayRequest(date = "2025-03-01", name = "테스트", calendarType = "solar"),
+            1,
+            PublicHolidayRequest(date = "2025-03-01", name = "테스트", calendarType = "solar"),
         )
         mockMvc
             .perform(

--- a/src/test/kotlin/app/hyuabot/backend/holiday/PublicHolidayControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/PublicHolidayControllerTest.kt
@@ -1,0 +1,339 @@
+package app.hyuabot.backend.holiday
+
+import app.hyuabot.backend.database.entity.PublicHoliday
+import app.hyuabot.backend.database.exception.LocalDateNotValidException
+import app.hyuabot.backend.holiday.domain.PublicHolidayRequest
+import app.hyuabot.backend.holiday.exception.DuplicatePublicHolidayException
+import app.hyuabot.backend.holiday.exception.PublicHolidayNotFoundException
+import app.hyuabot.backend.holiday.service.PublicHolidayService
+import app.hyuabot.backend.security.WithCustomMockUser
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import tools.jackson.databind.ObjectMapper
+import java.time.LocalDate
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class PublicHolidayControllerTest {
+    @MockitoBean
+    private lateinit var service: PublicHolidayService
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    @DisplayName("공휴일 목록 조회")
+    @WithCustomMockUser(username = "test_user")
+    fun testGetPublicHolidayList() {
+        doReturn(
+            listOf(
+                PublicHoliday(seq = 1, date = LocalDate.parse("2025-01-01"), name = "신정", calendarType = "solar"),
+                PublicHoliday(seq = 2, date = LocalDate.parse("2025-01-29"), name = "설날", calendarType = "lunar"),
+            ),
+        ).whenever(service).getPublicHolidayList()
+        mockMvc
+            .perform(get("/api/v1/holiday"))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.result.length()").value(2))
+            .andExpect(jsonPath("$.result[0].seq").value(1))
+            .andExpect(jsonPath("$.result[0].date").value("2025-01-01"))
+            .andExpect(jsonPath("$.result[0].name").value("신정"))
+            .andExpect(jsonPath("$.result[0].calendarType").value("solar"))
+            .andExpect(jsonPath("$.result[1].seq").value(2))
+            .andExpect(jsonPath("$.result[1].date").value("2025-01-29"))
+            .andExpect(jsonPath("$.result[1].name").value("설날"))
+            .andExpect(jsonPath("$.result[1].calendarType").value("lunar"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 추가")
+    @WithCustomMockUser(username = "test_user")
+    fun testCreatePublicHoliday() {
+        val newHoliday = PublicHoliday(seq = 1, date = LocalDate.parse("2025-03-01"), name = "삼일절", calendarType = "solar")
+        doReturn(newHoliday).whenever(service).createPublicHoliday(
+            PublicHolidayRequest(date = "2025-03-01", name = "삼일절", calendarType = "solar"),
+        )
+        mockMvc
+            .perform(
+                post("/api/v1/holiday")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            PublicHolidayRequest(date = "2025-03-01", name = "삼일절", calendarType = "solar"),
+                        ),
+                    ),
+            ).andExpect(status().isCreated)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.seq").value(1))
+            .andExpect(jsonPath("$.date").value("2025-03-01"))
+            .andExpect(jsonPath("$.name").value("삼일절"))
+            .andExpect(jsonPath("$.calendarType").value("solar"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 추가 - 날짜 형식 오류")
+    @WithCustomMockUser(username = "test_user")
+    fun testCreatePublicHolidayInvalidDateFormat() {
+        doThrow(LocalDateNotValidException()).whenever(service).createPublicHoliday(
+            PublicHolidayRequest(date = "2025/03/01", name = "삼일절", calendarType = "solar"),
+        )
+        mockMvc
+            .perform(
+                post("/api/v1/holiday")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            PublicHolidayRequest(date = "2025/03/01", name = "삼일절", calendarType = "solar"),
+                        ),
+                    ),
+            ).andExpect(status().isBadRequest)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("LOCAL_DATE_NOT_VALID"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 추가 - 중복된 날짜")
+    @WithCustomMockUser(username = "test_user")
+    fun testCreatePublicHolidayDuplicateDate() {
+        doThrow(DuplicatePublicHolidayException()).whenever(service).createPublicHoliday(
+            PublicHolidayRequest(date = "2025-03-01", name = "삼일절", calendarType = "solar"),
+        )
+        mockMvc
+            .perform(
+                post("/api/v1/holiday")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            PublicHolidayRequest(date = "2025-03-01", name = "삼일절", calendarType = "solar"),
+                        ),
+                    ),
+            ).andExpect(status().isConflict)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("DUPLICATE_PUBLIC_HOLIDAY"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 추가 - 기타 오류")
+    @WithCustomMockUser(username = "test_user")
+    fun testCreatePublicHolidayOtherError() {
+        doThrow(RuntimeException("Unexpected Error")).whenever(service).createPublicHoliday(
+            PublicHolidayRequest(date = "2025-03-01", name = "삼일절", calendarType = "solar"),
+        )
+        mockMvc
+            .perform(
+                post("/api/v1/holiday")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            PublicHolidayRequest(date = "2025-03-01", name = "삼일절", calendarType = "solar"),
+                        ),
+                    ),
+            ).andExpect(status().isInternalServerError)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 단건 조회")
+    @WithCustomMockUser(username = "test_user")
+    fun testGetPublicHolidayById() {
+        val holiday = PublicHoliday(seq = 1, date = LocalDate.of(2025, 1, 1), name = "신정", calendarType = "solar")
+        whenever(service.getPublicHolidayById(1)) doReturn holiday
+        mockMvc
+            .perform(get("/api/v1/holiday/1"))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.seq").value(1))
+            .andExpect(jsonPath("$.date").value("2025-01-01"))
+            .andExpect(jsonPath("$.name").value("신정"))
+            .andExpect(jsonPath("$.calendarType").value("solar"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 단건 조회 - 없는 ID")
+    @WithCustomMockUser(username = "test_user")
+    fun testGetPublicHolidayByIdNotFound() {
+        whenever(service.getPublicHolidayById(999)) doThrow PublicHolidayNotFoundException()
+        mockMvc
+            .perform(get("/api/v1/holiday/999"))
+            .andExpect(status().isNotFound)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("PUBLIC_HOLIDAY_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 단건 조회 - 기타 오류")
+    @WithCustomMockUser(username = "test_user")
+    fun testGetPublicHolidayByIdOtherError() {
+        whenever(service.getPublicHolidayById(1)) doThrow RuntimeException("Unexpected Error")
+        mockMvc
+            .perform(get("/api/v1/holiday/1"))
+            .andExpect(status().isInternalServerError)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 수정")
+    @WithCustomMockUser(username = "test_user")
+    fun testUpdatePublicHoliday() {
+        val updated = PublicHoliday(seq = 1, date = LocalDate.parse("2025-03-02"), name = "삼일절 대체공휴일", calendarType = "solar")
+        doReturn(updated).whenever(service).updatePublicHoliday(
+            1, PublicHolidayRequest(date = "2025-03-02", name = "삼일절 대체공휴일", calendarType = "solar"),
+        )
+        mockMvc
+            .perform(
+                put("/api/v1/holiday/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            PublicHolidayRequest(date = "2025-03-02", name = "삼일절 대체공휴일", calendarType = "solar"),
+                        ),
+                    ),
+            ).andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.seq").value(1))
+            .andExpect(jsonPath("$.date").value("2025-03-02"))
+            .andExpect(jsonPath("$.name").value("삼일절 대체공휴일"))
+            .andExpect(jsonPath("$.calendarType").value("solar"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 수정 - 날짜 형식 오류")
+    @WithCustomMockUser(username = "test_user")
+    fun testUpdatePublicHolidayInvalidDateFormat() {
+        doThrow(LocalDateNotValidException()).whenever(service).updatePublicHoliday(
+            1, PublicHolidayRequest(date = "2025/03/02", name = "테스트", calendarType = "solar"),
+        )
+        mockMvc
+            .perform(
+                put("/api/v1/holiday/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            PublicHolidayRequest(date = "2025/03/02", name = "테스트", calendarType = "solar"),
+                        ),
+                    ),
+            ).andExpect(status().isBadRequest)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("LOCAL_DATE_NOT_VALID"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 수정 - 없는 ID")
+    @WithCustomMockUser(username = "test_user")
+    fun testUpdatePublicHolidayNotFound() {
+        doThrow(PublicHolidayNotFoundException()).whenever(service).updatePublicHoliday(
+            999, PublicHolidayRequest(date = "2025-03-01", name = "테스트", calendarType = "solar"),
+        )
+        mockMvc
+            .perform(
+                put("/api/v1/holiday/999")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            PublicHolidayRequest(date = "2025-03-01", name = "테스트", calendarType = "solar"),
+                        ),
+                    ),
+            ).andExpect(status().isNotFound)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("PUBLIC_HOLIDAY_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 수정 - 중복된 날짜")
+    @WithCustomMockUser(username = "test_user")
+    fun testUpdatePublicHolidayDuplicateDate() {
+        doThrow(DuplicatePublicHolidayException()).whenever(service).updatePublicHoliday(
+            1, PublicHolidayRequest(date = "2025-03-01", name = "테스트", calendarType = "solar"),
+        )
+        mockMvc
+            .perform(
+                put("/api/v1/holiday/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            PublicHolidayRequest(date = "2025-03-01", name = "테스트", calendarType = "solar"),
+                        ),
+                    ),
+            ).andExpect(status().isConflict)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("DUPLICATE_PUBLIC_HOLIDAY"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 수정 - 기타 오류")
+    @WithCustomMockUser(username = "test_user")
+    fun testUpdatePublicHolidayOtherError() {
+        doThrow(RuntimeException("Unexpected Error")).whenever(service).updatePublicHoliday(
+            1, PublicHolidayRequest(date = "2025-03-01", name = "테스트", calendarType = "solar"),
+        )
+        mockMvc
+            .perform(
+                put("/api/v1/holiday/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            PublicHolidayRequest(date = "2025-03-01", name = "테스트", calendarType = "solar"),
+                        ),
+                    ),
+            ).andExpect(status().isInternalServerError)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 삭제")
+    @WithCustomMockUser(username = "test_user")
+    fun testDeletePublicHoliday() {
+        mockMvc
+            .perform(delete("/api/v1/holiday/1").contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent)
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 삭제 - 없는 ID")
+    @WithCustomMockUser(username = "test_user")
+    fun testDeletePublicHolidayNotFound() {
+        doThrow(PublicHolidayNotFoundException()).whenever(service).deletePublicHoliday(999)
+        mockMvc
+            .perform(delete("/api/v1/holiday/999").contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("PUBLIC_HOLIDAY_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 삭제 - 기타 오류")
+    @WithCustomMockUser(username = "test_user")
+    fun testDeletePublicHolidayOtherError() {
+        doThrow(RuntimeException("Unexpected Error")).whenever(service).deletePublicHoliday(1)
+        mockMvc
+            .perform(delete("/api/v1/holiday/1").contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isInternalServerError)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/holiday/PublicHolidayServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/PublicHolidayServiceTest.kt
@@ -1,0 +1,214 @@
+package app.hyuabot.backend.holiday
+
+import app.hyuabot.backend.database.entity.PublicHoliday
+import app.hyuabot.backend.database.exception.LocalDateNotValidException
+import app.hyuabot.backend.database.repository.PublicHolidayRepository
+import app.hyuabot.backend.holiday.domain.PublicHolidayRequest
+import app.hyuabot.backend.holiday.exception.DuplicatePublicHolidayException
+import app.hyuabot.backend.holiday.exception.PublicHolidayNotFoundException
+import app.hyuabot.backend.holiday.service.PublicHolidayService
+import com.github.usingsky.calendar.KoreanLunarCalendar
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Optional
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class PublicHolidayServiceTest {
+    @Mock
+    private lateinit var repository: PublicHolidayRepository
+
+    @InjectMocks
+    private lateinit var service: PublicHolidayService
+
+    @Test
+    @DisplayName("공휴일 목록 조회")
+    fun testGetPublicHolidayList() {
+        whenever(repository.findAll()).thenReturn(
+            listOf(
+                PublicHoliday(seq = 1, date = LocalDate.of(2025, 1, 1), name = "신정", calendarType = "solar"),
+                PublicHoliday(seq = 2, date = LocalDate.of(2025, 1, 29), name = "설날", calendarType = "lunar"),
+            ),
+        )
+        val holidays = service.getPublicHolidayList()
+        assertEquals(2, holidays.size)
+        assertEquals(1, holidays[0].seq)
+        assertEquals("2025-01-01", holidays[0].date.toString())
+        assertEquals("신정", holidays[0].name)
+        assertEquals("solar", holidays[0].calendarType)
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 생성")
+    fun testCreatePublicHoliday() {
+        val newHoliday = PublicHoliday(seq = 1, date = LocalDate.of(2025, 3, 1), name = "삼일절", calendarType = "solar")
+        whenever(
+            repository.save(
+                argThat<PublicHoliday> {
+                    date == LocalDate.of(2025, 3, 1) && name == "삼일절" && calendarType == "solar"
+                },
+            ),
+        ).thenReturn(newHoliday)
+        val created = service.createPublicHoliday(PublicHolidayRequest(date = "2025-03-01", name = "삼일절", calendarType = "solar"))
+        assertEquals(1, created.seq)
+        assertEquals("2025-03-01", created.date.toString())
+        assertEquals("삼일절", created.name)
+        assertEquals("solar", created.calendarType)
+    }
+
+    @Test
+    @DisplayName("공휴일 생성 - 잘못된 날짜 형식")
+    fun testCreatePublicHolidayInvalidDate() {
+        assertThrows<LocalDateNotValidException> {
+            service.createPublicHoliday(PublicHolidayRequest(date = "2025-31-12", name = "테스트", calendarType = "solar"))
+        }
+    }
+
+    @Test
+    @DisplayName("공휴일 생성 - 중복된 날짜")
+    fun testCreatePublicHolidayDuplicateDate() {
+        whenever(
+            repository.findByDateAndCalendarType(date = LocalDate.of(2025, 1, 1), calendarType = "solar"),
+        ).thenReturn(
+            PublicHoliday(seq = 1, date = LocalDate.of(2025, 1, 1), name = "신정", calendarType = "solar"),
+        )
+        assertThrows<DuplicatePublicHolidayException> {
+            service.createPublicHoliday(PublicHolidayRequest(date = "2025-01-01", name = "중복 테스트", calendarType = "solar"))
+        }
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 조회 by ID")
+    fun testGetPublicHolidayById() {
+        val holiday = PublicHoliday(seq = 1, date = LocalDate.of(2025, 1, 1), name = "신정", calendarType = "solar")
+        whenever(repository.findById(1)).thenReturn(Optional.of(holiday))
+        val result = service.getPublicHolidayById(1)
+        assertEquals(1, result.seq)
+        assertEquals("2025-01-01", result.date.toString())
+        assertEquals("신정", result.name)
+        assertEquals("solar", result.calendarType)
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 조회 by ID - 존재하지 않는 ID")
+    fun testGetPublicHolidayByIdNotFound() {
+        whenever(repository.findById(999)).thenReturn(Optional.empty())
+        assertThrows<PublicHolidayNotFoundException> {
+            service.getPublicHolidayById(999)
+        }
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 수정")
+    fun testUpdatePublicHoliday() {
+        val existing = PublicHoliday(seq = 1, date = LocalDate.of(2025, 1, 1), name = "신정", calendarType = "solar")
+        val updated = PublicHoliday(seq = 1, date = LocalDate.of(2025, 1, 2), name = "신정 대체공휴일", calendarType = "solar")
+        whenever(repository.findById(1)).thenReturn(Optional.of(existing))
+        whenever(
+            repository.findBySeqNotAndDateAndCalendarType(seq = 1, date = LocalDate.of(2025, 1, 2), calendarType = "solar"),
+        ).thenReturn(null)
+        whenever(repository.save(existing)).thenReturn(updated)
+        val result = service.updatePublicHoliday(
+            1, PublicHolidayRequest(date = "2025-01-02", name = "신정 대체공휴일", calendarType = "solar"),
+        )
+        assertEquals(1, result.seq)
+        assertEquals("2025-01-02", result.date.toString())
+        assertEquals("신정 대체공휴일", result.name)
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 수정 - 잘못된 날짜 형식")
+    fun testUpdatePublicHolidayInvalidDate() {
+        assertThrows<LocalDateNotValidException> {
+            service.updatePublicHoliday(1, PublicHolidayRequest(date = "2025-31-12", name = "테스트", calendarType = "solar"))
+        }
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 수정 - 존재하지 않는 ID")
+    fun testUpdatePublicHolidayNotFound() {
+        whenever(repository.findById(999)).thenReturn(Optional.empty())
+        assertThrows<PublicHolidayNotFoundException> {
+            service.updatePublicHoliday(999, PublicHolidayRequest(date = "2025-01-01", name = "테스트", calendarType = "solar"))
+        }
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 수정 - 중복된 날짜")
+    fun testUpdatePublicHolidayDuplicateDate() {
+        val existing = PublicHoliday(seq = 1, date = LocalDate.of(2025, 1, 1), name = "신정", calendarType = "solar")
+        whenever(repository.findById(1)).thenReturn(Optional.of(existing))
+        whenever(
+            repository.findBySeqNotAndDateAndCalendarType(seq = 1, date = LocalDate.of(2025, 3, 1), calendarType = "solar"),
+        ).thenReturn(
+            PublicHoliday(seq = 2, date = LocalDate.of(2025, 3, 1), name = "삼일절", calendarType = "solar"),
+        )
+        assertThrows<DuplicatePublicHolidayException> {
+            service.updatePublicHoliday(1, PublicHolidayRequest(date = "2025-03-01", name = "중복 테스트", calendarType = "solar"))
+        }
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 삭제")
+    fun testDeletePublicHoliday() {
+        val existing = PublicHoliday(seq = 1, date = LocalDate.of(2025, 1, 1), name = "신정", calendarType = "solar")
+        whenever(repository.findById(1)).thenReturn(Optional.of(existing))
+        service.deletePublicHoliday(1)
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 삭제 - 존재하지 않는 ID")
+    fun testDeletePublicHolidayNotFound() {
+        whenever(repository.findById(999)).thenReturn(Optional.empty())
+        assertThrows<PublicHolidayNotFoundException> {
+            service.deletePublicHoliday(999)
+        }
+    }
+
+    @Test
+    @DisplayName("공휴일 검색 - 양력 날짜")
+    fun testFindPublicHoliday() {
+        val lunarDate = KoreanLunarCalendar.getInstance()
+        val solarDate = LocalDate.of(2025, 1, 1)
+        val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        lunarDate.setSolarDate(2025, 1, 1)
+        whenever(
+            repository.findBySolarDateOrLunarDate(
+                solarDate,
+                LocalDate.parse(lunarDate.lunarIsoFormat, dateFormat),
+            ),
+        ).thenReturn(
+            PublicHoliday(seq = 1, date = solarDate, name = "신정", calendarType = "solar"),
+        )
+        val result = service.findPublicHoliday(solarDate)
+        assertEquals(1, result?.seq)
+        assertEquals("2025-01-01", result?.date.toString())
+        assertEquals("신정", result?.name)
+    }
+
+    @Test
+    @DisplayName("공휴일 검색 - 공휴일 아닌 날짜")
+    fun testFindPublicHolidayNotFound() {
+        val lunarDate = KoreanLunarCalendar.getInstance()
+        val solarDate = LocalDate.of(2025, 3, 3)
+        val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        lunarDate.setSolarDate(2025, 3, 3)
+        whenever(
+            repository.findBySolarDateOrLunarDate(
+                solarDate,
+                LocalDate.parse(lunarDate.lunarIsoFormat, dateFormat),
+            ),
+        ).thenReturn(null)
+        val result = service.findPublicHoliday(solarDate)
+        assertEquals(null, result)
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/holiday/PublicHolidayServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/PublicHolidayServiceTest.kt
@@ -117,9 +117,11 @@ class PublicHolidayServiceTest {
             repository.findBySeqNotAndDateAndCalendarType(seq = 1, date = LocalDate.of(2025, 1, 2), calendarType = "solar"),
         ).thenReturn(null)
         whenever(repository.save(existing)).thenReturn(updated)
-        val result = service.updatePublicHoliday(
-            1, PublicHolidayRequest(date = "2025-01-02", name = "신정 대체공휴일", calendarType = "solar"),
-        )
+        val result =
+            service.updatePublicHoliday(
+                1,
+                PublicHolidayRequest(date = "2025-01-02", name = "신정 대체공휴일", calendarType = "solar"),
+            )
         assertEquals(1, result.seq)
         assertEquals("2025-01-02", result.date.toString())
         assertEquals("신정 대체공휴일", result.name)


### PR DESCRIPTION
## Summary

- Add `public_holiday` table entity, repository, service, and REST controller (`/api/v1/holiday`)
- Shared by both bus and subway modules — single source of truth for public holidays
- Support solar and lunar calendar types using `KoreanLunarCalendar` for lunar↔solar conversion
- Update `BusRealtimeService.resolveWeekday()` to return `"sunday"` on public holidays

## Background

Bus and subway timetable lookups need to distinguish weekday / Saturday / Sunday schedules. Public holidays (e.g. Chuseok, Lunar New Year) should be treated as Sundays even when they fall on a weekday. Previously there was no shared holiday table for bus/subway — only `shuttle_holiday` existed.

## Changes

**Database**
- Added `public_holiday` table with a unique index on `(holiday_date, calendar_type)`

**Backend**
- `PublicHoliday` entity, `PublicHolidayRepository` (custom JPQL queries for solar/lunar lookup)
- `PublicHolidayService`: CRUD + `findPublicHoliday(date)` with lunar↔solar conversion
- `PublicHolidayController`: `GET /api/v1/holiday`, `POST`, `GET /{seq}`, `PUT /{seq}`, `DELETE /{seq}`
- `DuplicatePublicHolidayException`, `PublicHolidayNotFoundException`
- `BusRealtimeService`: injected `PublicHolidayService`; weekday resolution now checks public holidays first

## Test plan

- `PublicHolidayServiceTest`: 14 unit tests covering all CRUD paths and lunar date conversion
- `PublicHolidayControllerTest`: 14 integration tests (`@SpringBootTest + @AutoConfigureMockMvc`) covering all endpoints and error responses
- `BusServiceTest`: updated 3 existing `testResolveWeekday*` tests + added `testResolveWeekdayPublicHoliday`
- JaCoCo coverage verification: **BUILD SUCCESSFUL** (100% coverage for new `holiday` package and updated `BusRealtimeService`)