### PR TITLE
feat: Apply public holiday override to subway arrival weekday resolution

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
@@ -7,6 +7,7 @@ import app.hyuabot.backend.codegen.types.SubwayRealtime
 import app.hyuabot.backend.codegen.types.SubwayStation
 import app.hyuabot.backend.codegen.types.SubwayTimetable
 import app.hyuabot.backend.database.entity.SubwayRouteStation
+import app.hyuabot.backend.holiday.service.PublicHolidayService
 import app.hyuabot.backend.subway.domain.SubwayTimetableKey
 import app.hyuabot.backend.subway.service.SubwayService
 import app.hyuabot.backend.utility.LocalDateTimeBuilder
@@ -15,11 +16,13 @@ import com.netflix.graphql.dgs.DgsData
 import com.netflix.graphql.dgs.DgsDataFetchingEnvironment
 import com.netflix.graphql.dgs.DgsQuery
 import com.netflix.graphql.dgs.InputArgument
+import java.time.LocalDate
 import java.util.concurrent.CompletableFuture
 
 @DgsComponent
 class SubwayDataFetcher(
     private val subwayService: SubwayService,
+    private val publicHolidayService: PublicHolidayService,
 ) {
     @DgsQuery
     fun subway(
@@ -103,7 +106,8 @@ class SubwayDataFetcher(
                 "arrival query expects exactly one weekday, but got: $weekdays for station ${station.stationID}",
             )
         }
-        val weekday = weekdays.first()
+        val today = LocalDate.now()
+        val weekday = if (publicHolidayService.findPublicHoliday(today) != null) "weekends" else weekdays.first()
         val limitMap = dfe.graphQlContext.get<Map<String, Int>>("limitMap")
         return subwayService
             .getArrival(

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
@@ -3,9 +3,11 @@ package app.hyuabot.backend.subway
 import app.hyuabot.backend.codegen.types.SubwayArrival
 import app.hyuabot.backend.codegen.types.SubwayArrivalGroup
 import app.hyuabot.backend.codegen.types.SubwayOriginTerminal
+import app.hyuabot.backend.database.entity.PublicHoliday
 import app.hyuabot.backend.database.entity.SubwayRealtime
 import app.hyuabot.backend.database.entity.SubwayRoute
 import app.hyuabot.backend.database.entity.SubwayRouteStation
+import app.hyuabot.backend.holiday.service.PublicHolidayService
 import app.hyuabot.backend.subway.controller.SubwayDataFetcher
 import app.hyuabot.backend.subway.controller.SubwayTimetableDataLoader
 import app.hyuabot.backend.subway.domain.SubwayTimetableKey
@@ -22,6 +24,7 @@ import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
 import java.time.Duration
+import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZonedDateTime
 import kotlin.test.Test
@@ -37,6 +40,8 @@ class SubwayDataFetcherTest {
     @Autowired private lateinit var dgsQueryExecutor: DgsQueryExecutor
 
     @MockitoBean private lateinit var subwayService: SubwayService
+
+    @MockitoBean private lateinit var publicHolidayService: PublicHolidayService
 
     private fun createRoute(
         id: Int = 1004,
@@ -390,6 +395,97 @@ class SubwayDataFetcherTest {
         val station = result[0] as Map<*, *>
         val arrival = station["arrival"] as List<*>
         assertEquals(0, arrival.size)
+    }
+
+    @Test
+    @DisplayName("전철 도착 정보 조회 - 공휴일에 weekends로 오버라이드")
+    fun testSubwayArrivalOnPublicHoliday() {
+        whenever(publicHolidayService.findPublicHoliday(any())).thenReturn(
+            PublicHoliday(
+                seq = 1,
+                date = LocalDate.now(),
+                name = "임시공휴일",
+                calendarType = "solar",
+            ),
+        )
+        whenever(subwayService.getStationViews(listOf(station.id))).thenReturn(listOf(createStationView()))
+        whenever(
+            subwayService.getArrival(
+                station.id,
+                directions = listOf("up"),
+                weekday = "weekends",
+            ),
+        ).thenReturn(emptyList())
+
+        val result =
+            dgsQueryExecutor.executeAndExtractJsonPath<List<Map<String, Any>>>(
+                """
+                {
+                    subway(input: {
+                        keys: [{
+                            stationID: "K449",
+                            direction: ["up"],
+                            weekdays: ["weekdays"],
+                            limit: 10
+                        }],
+                    }) {
+                        stationID
+                        arrival {
+                            direction
+                            entries {
+                                minutes
+                            }
+                        }
+                    }
+                }
+                """.trimIndent(),
+                "data.subway",
+            )
+        assertNotNull(result)
+        assertEquals(1, result.size)
+        assertEquals("K449", result[0]["stationID"])
+    }
+
+    @Test
+    @DisplayName("전철 도착 정보 조회 - 공휴일 아닌 경우 weekday 그대로 사용")
+    fun testSubwayArrivalOnNonHoliday() {
+        whenever(publicHolidayService.findPublicHoliday(any())).thenReturn(null)
+        whenever(subwayService.getStationViews(listOf(station.id))).thenReturn(listOf(createStationView()))
+        whenever(
+            subwayService.getArrival(
+                station.id,
+                directions = listOf("up"),
+                weekday = "weekdays",
+            ),
+        ).thenReturn(emptyList())
+
+        val result =
+            dgsQueryExecutor.executeAndExtractJsonPath<List<Map<String, Any>>>(
+                """
+                {
+                    subway(input: {
+                        keys: [{
+                            stationID: "K449",
+                            direction: ["up"],
+                            weekdays: ["weekdays"],
+                            limit: 10
+                        }],
+                    }) {
+                        stationID
+                        arrival {
+                            direction
+                            entries {
+                                minutes
+                            }
+                        }
+                    }
+                }
+                """.trimIndent(),
+                "data.subway",
+            )
+        assertNotNull(result)
+        assertEquals(1, result.size)
+        assertEquals("K449", result[0]["stationID"])
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Inject `PublicHolidayService` into `SubwayDataFetcher` to override the client-provided weekday when today is a public holiday
- When a public holiday is detected, the weekday is forced to `"weekends"` regardless of what the client sends, so the correct Sunday-equivalent timetable is applied
- Mirrors the existing behavior in `BusRealtimeService.resolveWeekday()` which returns `"sunday"` on public holidays

## Background

`BusRealtimeService` already uses `PublicHolidayService` to auto-detect public holidays and apply the Sunday timetable. However, `SubwayDataFetcher` relied entirely on the client passing the correct weekday value — meaning mobile apps would show weekday timetables on public holidays unless they explicitly sent `"weekends"`.

This change centralizes the public holiday logic on the server side for subway arrivals, consistent with how bus arrivals work.

## Changes

- `SubwayDataFetcher`: added `PublicHolidayService` constructor dependency; `arrival()` now resolves the effective weekday via `publicHolidayService.findPublicHoliday(LocalDate.now())` before querying

## Test plan

- `SubwayDataFetcherTest`: added two new test cases
  - `testSubwayArrivalOnPublicHoliday`: verifies that `"weekdays"` sent by client is overridden to `"weekends"` when a public holiday is present
  - `testSubwayArrivalOnNonHoliday`: verifies that `"weekdays"` is preserved when no public holiday is found
- JaCoCo coverage verification: **BUILD SUCCESSFUL**