### PR TITLE
feat: Replace bus timetable fallback with departure log clustering

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/bus/controller/BusDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/bus/controller/BusDataFetcher.kt
@@ -215,7 +215,6 @@ class BusDataFetcher(
             BusArrivalKey(
                 routeID = routeStop.route.seq,
                 stopID = routeStop.stop.seq,
-                startStopID = routeStop.startStop.seq,
                 limit = limitMap[routeStop.route.seq to routeStop.stop.seq],
             )
         val dataLoader = dfe.getDataLoader<BusArrivalKey, List<BusArrival>>("busArrivalDataLoader")!!

--- a/src/main/kotlin/app/hyuabot/backend/bus/domain/BusArrivalKey.kt
+++ b/src/main/kotlin/app/hyuabot/backend/bus/domain/BusArrivalKey.kt
@@ -3,6 +3,5 @@ package app.hyuabot.backend.bus.domain
 data class BusArrivalKey(
     val routeID: Int,
     val stopID: Int,
-    val startStopID: Int,
     val limit: Int?,
 )

--- a/src/main/kotlin/app/hyuabot/backend/bus/service/BusRealtimeService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/bus/service/BusRealtimeService.kt
@@ -3,10 +3,9 @@ package app.hyuabot.backend.bus.service
 import app.hyuabot.backend.bus.domain.BusArrivalKey
 import app.hyuabot.backend.codegen.types.BusArrival
 import app.hyuabot.backend.database.entity.BusRealtime
+import app.hyuabot.backend.database.repository.BusDepartureLogRepository
 import app.hyuabot.backend.database.repository.BusRealtimeRepository
-import app.hyuabot.backend.database.repository.BusTimetableRepository
 import app.hyuabot.backend.holiday.service.PublicHolidayService
-import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -17,7 +16,7 @@ import java.time.ZoneId
 @Service
 class BusRealtimeService(
     private val realtimeRepository: BusRealtimeRepository,
-    private val timetableRepository: BusTimetableRepository,
+    private val departureLogRepository: BusDepartureLogRepository,
     private val publicHolidayService: PublicHolidayService,
 ) {
     private val serviceStartTime: LocalTime = LocalTime.of(4, 0)
@@ -31,10 +30,34 @@ class BusRealtimeService(
         }
     }
 
-    private fun toServiceMinutes(time: LocalTime): Int {
+    internal fun toServiceSeconds(time: LocalTime): Int {
         val seconds = time.toSecondOfDay()
         val threshold = serviceStartTime.toSecondOfDay()
         return if (seconds >= threshold) seconds else seconds + 24 * 60 * 60
+    }
+
+    internal fun clusterDepartureTimes(
+        times: List<LocalTime>,
+        thresholdMinutes: Int = 3,
+    ): List<LocalTime> {
+        if (times.isEmpty()) return emptyList()
+        val sorted = times.sortedBy { toServiceSeconds(it) }
+        val clusters = mutableListOf<MutableList<LocalTime>>()
+        var current = mutableListOf(sorted.first())
+        for (i in 1 until sorted.size) {
+            val diff = toServiceSeconds(sorted[i]) - toServiceSeconds(current.last())
+            if (diff <= thresholdMinutes * 60) {
+                current.add(sorted[i])
+            } else {
+                clusters.add(current)
+                current = mutableListOf(sorted[i])
+            }
+        }
+        clusters.add(current)
+        return clusters.map { cluster ->
+            val avgSeconds = cluster.map { toServiceSeconds(it).toLong() }.average().toLong()
+            LocalTime.ofSecondOfDay(avgSeconds % 86400L)
+        }
     }
 
     internal fun currentTime(): LocalDateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
@@ -61,54 +84,20 @@ class BusRealtimeService(
         if (keys.isEmpty()) return emptyMap()
         val now = currentTime()
         val currentTime = now.toLocalTime()
-        val sort = Sort.by(Sort.Order.asc("departureTime"))
         val routeIDs = keys.map { it.routeID }.distinct()
         val stopIDs = keys.map { it.stopID }.distinct()
-        val startStopIDs = keys.map { it.startStopID }.distinct()
         val realtimeGrouped =
             realtimeRepository
                 .findByRouteIDInAndStopIDIn(routeIDs, stopIDs)
                 .groupBy { it.routeID to it.stopID }
         // Times before serviceStartTime (04:00) belong to the previous calendar day's service
         val serviceDate =
-            if (currentTime.isBefore(serviceStartTime)) {
-                now.toLocalDate().minusDays(1)
-            } else {
-                now.toLocalDate()
-            }
-        val weekday = resolveWeekday(serviceDate)
-        val timetableEntries =
-            if (currentTime.isBefore(serviceStartTime)) {
-                // After midnight: remaining buses are between currentTime and serviceStartTime
-                timetableRepository
-                    .findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                        routeIDs,
-                        startStopIDs,
-                        weekday,
-                        currentTime,
-                        sort,
-                    ).filter { it.departureTime.isBefore(serviceStartTime) }
-            } else {
-                // Normal hours: buses from now until midnight + after-midnight buses (00:00–serviceStartTime)
-                val remaining =
-                    timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                        routeIDs,
-                        startStopIDs,
-                        weekday,
-                        currentTime,
-                        sort,
-                    )
-                val afterMidnight =
-                    timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeBefore(
-                        routeIDs,
-                        startStopIDs,
-                        weekday,
-                        serviceStartTime,
-                        sort,
-                    )
-                remaining + afterMidnight
-            }
-        val timetableGrouped = timetableEntries.groupBy { it.routeID to it.startStopID }
+            if (currentTime.isBefore(serviceStartTime)) now.toLocalDate().minusDays(1) else now.toLocalDate()
+        val sameDayDates = (1..4).map { serviceDate.minusWeeks(it.toLong()) }
+        val logGrouped =
+            departureLogRepository
+                .findByRouteIDInAndStopIDInAndDepartureDateIn(routeIDs, stopIDs, sameDayDates)
+                .groupBy { it.routeID to it.stopID }
         return keys.associateWith { key ->
             val realtimeArrivals =
                 (realtimeGrouped[key.routeID to key.stopID] ?: emptyList())
@@ -121,11 +110,18 @@ class BusRealtimeService(
                             isRealtime = true,
                         )
                     }.sortedBy { it.minutes }
-            val timetableArrivals =
-                (timetableGrouped[key.routeID to key.startStopID] ?: emptyList())
-                    .map { BusArrival(isRealtime = false, time = it.departureTime) }
-                    .sortedBy { toServiceMinutes(it.time!!) }
-            (realtimeArrivals + timetableArrivals).take(key.limit ?: Int.MAX_VALUE)
+            val lastRealtimeMinutes = realtimeArrivals.maxOfOrNull { it.minutes!! } ?: -10
+            val cutoffMinutes = lastRealtimeMinutes + 10
+            val rawLogTimes =
+                (logGrouped[key.routeID to key.stopID] ?: emptyList())
+                    .map { it.departureTime }
+            val logArrivals =
+                clusterDepartureTimes(rawLogTimes)
+                    .filter { time ->
+                        (toServiceSeconds(time) - toServiceSeconds(currentTime)) / 60 > cutoffMinutes
+                    }.map { BusArrival(isRealtime = false, time = it) }
+                    .sortedBy { toServiceSeconds(it.time!!) }
+            (realtimeArrivals + logArrivals).take(key.limit ?: Int.MAX_VALUE)
         }
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/bus/BusDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/bus/BusDataFetcherTest.kt
@@ -500,7 +500,6 @@ class BusDataFetcherTest {
                 BusArrivalKey(
                     routeID = route.id,
                     stopID = stop.id,
-                    startStopID = startStop.id,
                     limit = null,
                 ) to
                     listOf(
@@ -556,7 +555,6 @@ class BusDataFetcherTest {
                 BusArrivalKey(
                     routeID = route.id,
                     stopID = stop.id,
-                    startStopID = startStop.id,
                     limit = 2,
                 ) to
                     listOf(
@@ -596,7 +594,6 @@ class BusDataFetcherTest {
                 BusArrivalKey(
                     routeID = route.id,
                     stopID = stop.id,
-                    startStopID = startStop.id,
                     limit = null,
                 ) to emptyList(),
             ),

--- a/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
@@ -2959,13 +2959,63 @@ class BusServiceTest {
     }
 
     @Test
-    @DisplayName("버스 도착 정보 배치 조회 - 실시간 + 시간표")
+    @DisplayName("toServiceSeconds - 일반 시간")
+    fun testToServiceSecondsNormal() {
+        assertEquals(36000, realtimeService.toServiceSeconds(LocalTime.of(10, 0, 0)))
+    }
+
+    @Test
+    @DisplayName("toServiceSeconds - 자정 이후 시간")
+    fun testToServiceSecondsAfterMidnight() {
+        assertEquals(90000, realtimeService.toServiceSeconds(LocalTime.of(1, 0, 0)))
+    }
+
+    @Test
+    @DisplayName("클러스터링 - 빈 목록")
+    fun testClusterDepartureTimesEmpty() {
+        assertEquals(0, realtimeService.clusterDepartureTimes(emptyList()).size)
+    }
+
+    @Test
+    @DisplayName("클러스터링 - 단일 항목")
+    fun testClusterDepartureTimesSingleItem() {
+        val result = realtimeService.clusterDepartureTimes(listOf(LocalTime.of(10, 0)))
+        assertEquals(1, result.size)
+        assertEquals(LocalTime.of(10, 0), result[0])
+    }
+
+    @Test
+    @DisplayName("클러스터링 - 임계값 내 단일 클러스터")
+    fun testClusterDepartureTimesWithinThreshold() {
+        val result =
+            realtimeService.clusterDepartureTimes(
+                listOf(LocalTime.of(10, 0), LocalTime.of(10, 1), LocalTime.of(10, 2)),
+            )
+        assertEquals(1, result.size)
+        assertEquals(LocalTime.of(10, 1), result[0])
+    }
+
+    @Test
+    @DisplayName("클러스터링 - 복수 클러스터")
+    fun testClusterDepartureTimesMultipleClusters() {
+        val result =
+            realtimeService.clusterDepartureTimes(
+                listOf(LocalTime.of(10, 0), LocalTime.of(10, 1), LocalTime.of(11, 0), LocalTime.of(11, 1)),
+            )
+        assertEquals(2, result.size)
+        assertEquals(LocalTime.of(10, 0, 30), result[0])
+        assertEquals(LocalTime.of(11, 0, 30), result[1])
+    }
+
+    @Test
+    @DisplayName("버스 도착 정보 배치 조회 - 실시간 + 도착 로그")
     fun testGetArrivalBatch() {
+        val spyService = spy(realtimeService)
+        doReturn(LocalDateTime.of(2025, 3, 3, 10, 0)).whenever(spyService).currentTime()
         val key =
             BusArrivalKey(
                 routeID = 216000068,
                 stopID = 216000138,
-                startStopID = 216000358,
                 limit = null,
             )
         whenever(
@@ -2999,69 +3049,40 @@ class BusServiceTest {
                 ),
             ),
         )
+        // 4 logs at 10:29 → cluster avg = 10:29 → 29min from now, cutoff=25 → passes
+        // 4 logs at 10:59 → cluster avg = 10:59 → 59min from now → passes
         whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
+            logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any()),
         ).thenReturn(
             listOf(
-                BusTimetable(
-                    seq = 1,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("05:30:00"),
-                ),
-                BusTimetable(
-                    seq = 2,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("06:00:00"),
-                ),
-                BusTimetable(
-                    seq = 3,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("07:00:00"),
-                ),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 24), LocalTime.of(10, 29), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 17), LocalTime.of(10, 29), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 10), LocalTime.of(10, 29), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 3), LocalTime.of(10, 29), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 24), LocalTime.of(10, 59), "V2", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 17), LocalTime.of(10, 59), "V2", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 10), LocalTime.of(10, 59), "V2", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 3), LocalTime.of(10, 59), "V2", null),
             ),
         )
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeBefore(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(emptyList())
 
-        val result = realtimeService.getArrivalBatch(setOf(key))
+        val result = spyService.getArrivalBatch(setOf(key))
 
         assertEquals(1, result.size)
         val arrivals = result[key]!!
-        assertEquals(5, arrivals.size)
+        assertEquals(4, arrivals.size)
         assertEquals(true, arrivals[0].isRealtime)
         assertEquals(true, arrivals[1].isRealtime)
         assertEquals(false, arrivals[2].isRealtime)
+        assertEquals(false, arrivals[3].isRealtime)
     }
 
     @Test
     @DisplayName("버스 도착 정보 배치 조회 - limit 적용")
     fun testGetArrivalBatchWithLimit() {
-        val key =
-            BusArrivalKey(
-                routeID = 216000068,
-                stopID = 216000138,
-                startStopID = 216000358,
-                limit = 2,
-            )
+        val spyService = spy(realtimeService)
+        doReturn(LocalDateTime.of(2025, 3, 3, 10, 0)).whenever(spyService).currentTime()
+        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, limit = 2)
         whenever(
             realtimeRepository.findByRouteIDInAndStopIDIn(
                 listOf(216000068),
@@ -3076,7 +3097,7 @@ class BusServiceTest {
                     remainingTime = Duration.ofMinutes(5),
                     remainingStop = 2,
                     remainingSeat = 40,
-                    isLowFloor = true,
+                    isLowFloor = false,
                     updatedAt = ZonedDateTime.now(),
                     routeStop = null,
                 ),
@@ -3094,26 +3115,17 @@ class BusServiceTest {
             ),
         )
         whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
+            logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any()),
         ).thenReturn(
             listOf(
-                BusTimetable(
-                    seq = 1,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("05:30:00"),
-                ),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 24), LocalTime.of(10, 29), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 17), LocalTime.of(10, 29), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 10), LocalTime.of(10, 29), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 3), LocalTime.of(10, 29), "V1", null),
             ),
         )
 
-        val result = realtimeService.getArrivalBatch(setOf(key))
+        val result = spyService.getArrivalBatch(setOf(key))
 
         val arrivals = result[key]!!
         assertEquals(2, arrivals.size)
@@ -3122,58 +3134,15 @@ class BusServiceTest {
     }
 
     @Test
-    @DisplayName("버스 도착 정보 배치 조회 - 결과 없음")
-    fun testGetArrivalBatchNoResult() {
-        val key =
-            BusArrivalKey(
-                routeID = 216000068,
-                stopID = 216000999,
-                startStopID = 216000358,
-                limit = null,
-            )
+    @DisplayName("버스 도착 정보 배치 조회 - 도착 로그 없음")
+    fun testGetArrivalBatchNoLogData() {
+        val spyService = spy(realtimeService)
+        doReturn(LocalDateTime.of(2025, 3, 3, 10, 0)).whenever(spyService).currentTime()
+        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, limit = null)
         whenever(
             realtimeRepository.findByRouteIDInAndStopIDIn(
                 listOf(216000068),
-                listOf(216000999),
-            ),
-        ).thenReturn(emptyList())
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(emptyList())
-
-        val result = realtimeService.getArrivalBatch(setOf(key))
-
-        assertEquals(1, result.size)
-        assertEquals(0, result[key]!!.size)
-    }
-
-    @Test
-    @DisplayName("버스 도착 정보 배치 조회 - 다중 키")
-    fun testGetArrivalBatchMultipleKeys() {
-        val key1 =
-            BusArrivalKey(
-                routeID = 216000068,
-                stopID = 216000138,
-                startStopID = 216000358,
-                limit = null,
-            )
-        val key2 =
-            BusArrivalKey(
-                routeID = 216000069,
-                stopID = 216000358,
-                startStopID = 216000138,
-                limit = null,
-            )
-        whenever(
-            realtimeRepository.findByRouteIDInAndStopIDIn(
-                listOf(216000068, 216000069),
-                listOf(216000138, 216000358),
+                listOf(216000138),
             ),
         ).thenReturn(
             listOf(
@@ -3184,7 +3153,107 @@ class BusServiceTest {
                     remainingTime = Duration.ofMinutes(5),
                     remainingStop = 2,
                     remainingSeat = 40,
-                    isLowFloor = true,
+                    isLowFloor = false,
+                    updatedAt = ZonedDateTime.now(),
+                    routeStop = null,
+                ),
+                BusRealtime(
+                    routeID = 216000068,
+                    stopID = 216000138,
+                    order = 2,
+                    remainingTime = Duration.ofMinutes(15),
+                    remainingStop = 5,
+                    remainingSeat = 20,
+                    isLowFloor = false,
+                    updatedAt = ZonedDateTime.now(),
+                    routeStop = null,
+                ),
+            ),
+        )
+        whenever(
+            logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any()),
+        ).thenReturn(emptyList())
+
+        val result = spyService.getArrivalBatch(setOf(key))
+
+        val arrivals = result[key]!!
+        assertEquals(2, arrivals.size)
+        assertEquals(true, arrivals[0].isRealtime)
+        assertEquals(true, arrivals[1].isRealtime)
+    }
+
+    @Test
+    @DisplayName("버스 도착 정보 배치 조회 - 실시간 없음, 로그만")
+    fun testGetArrivalBatchNoRealtime() {
+        val spyService = spy(realtimeService)
+        doReturn(LocalDateTime.of(2025, 3, 3, 10, 0)).whenever(spyService).currentTime()
+        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, limit = null)
+        whenever(
+            realtimeRepository.findByRouteIDInAndStopIDIn(
+                listOf(216000068),
+                listOf(216000138),
+            ),
+        ).thenReturn(emptyList())
+        // lastRealtime=-10, cutoff=0 → any positive minutesFromNow passes
+        // Cluster A: all 10:14 → avg=10:14 → 14min from now → passes
+        // Cluster B: all 10:44 → avg=10:44 → 44min from now → passes
+        whenever(
+            logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any()),
+        ).thenReturn(
+            listOf(
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 24), LocalTime.of(10, 14), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 17), LocalTime.of(10, 14), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 10), LocalTime.of(10, 14), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 3), LocalTime.of(10, 14), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 24), LocalTime.of(10, 44), "V2", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 17), LocalTime.of(10, 44), "V2", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 10), LocalTime.of(10, 44), "V2", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 3), LocalTime.of(10, 44), "V2", null),
+            ),
+        )
+
+        val result = spyService.getArrivalBatch(setOf(key))
+
+        val arrivals = result[key]!!
+        assertEquals(2, arrivals.size)
+        assertEquals(false, arrivals[0].isRealtime)
+        assertEquals(false, arrivals[1].isRealtime)
+        assertEquals(LocalTime.of(10, 14), arrivals[0].time)
+        assertEquals(LocalTime.of(10, 44), arrivals[1].time)
+    }
+
+    @Test
+    @DisplayName("버스 도착 정보 배치 조회 - 결과 없음")
+    fun testGetArrivalBatchNoResult() {
+        val spyService = spy(realtimeService)
+        doReturn(LocalDateTime.of(2025, 3, 3, 10, 0)).whenever(spyService).currentTime()
+        val key = BusArrivalKey(routeID = 216000068, stopID = 216000999, limit = null)
+        whenever(realtimeRepository.findByRouteIDInAndStopIDIn(any(), any())).thenReturn(emptyList())
+        whenever(logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any())).thenReturn(emptyList())
+
+        val result = spyService.getArrivalBatch(setOf(key))
+
+        assertEquals(1, result.size)
+        assertEquals(0, result[key]!!.size)
+    }
+
+    @Test
+    @DisplayName("버스 도착 정보 배치 조회 - 다중 키")
+    fun testGetArrivalBatchMultipleKeys() {
+        val spyService = spy(realtimeService)
+        doReturn(LocalDateTime.of(2025, 3, 3, 10, 0)).whenever(spyService).currentTime()
+        val key1 = BusArrivalKey(routeID = 216000068, stopID = 216000138, limit = null)
+        val key2 = BusArrivalKey(routeID = 216000069, stopID = 216000358, limit = null)
+        whenever(realtimeRepository.findByRouteIDInAndStopIDIn(any(), any())).thenReturn(
+            listOf(
+                BusRealtime(
+                    routeID = 216000068,
+                    stopID = 216000138,
+                    order = 1,
+                    remainingTime = Duration.ofMinutes(5),
+                    remainingStop = 2,
+                    remainingSeat = 40,
+                    isLowFloor = false,
                     updatedAt = ZonedDateTime.now(),
                     routeStop = null,
                 ),
@@ -3201,17 +3270,9 @@ class BusServiceTest {
                 ),
             ),
         )
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(emptyList())
+        whenever(logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any())).thenReturn(emptyList())
 
-        val result = realtimeService.getArrivalBatch(setOf(key1, key2))
+        val result = spyService.getArrivalBatch(setOf(key1, key2))
 
         assertEquals(2, result.size)
         assertEquals(1, result[key1]!!.size)
@@ -3220,176 +3281,97 @@ class BusServiceTest {
         assertEquals(true, result[key2]!![0].isRealtime)
     }
 
-    // ── After-midnight branch (currentTime < SERVICE_DAY_START = 04:00) ─────────
-    // Uses spy(realtimeService) + doReturn(fixedTime).whenever(spy).currentTime()
-    // to control the clock without changing the production API.
-
     @Test
-    @DisplayName("버스 도착 정보 배치 조회 - 자정 이후 (01:30): 이전 서비스 날 weekday 사용")
-    fun testGetArrivalBatchAfterMidnightUsesServiceDayWeekday() {
-        // Monday 2025-03-03 01:30 KST → serviceDate = Sunday 2025-03-02 → weekday = "sunday"
-        val fixedNow = LocalDateTime.of(2025, 3, 3, 1, 30)
+    @DisplayName("버스 도착 정보 배치 조회 - 10분 간격 필터")
+    fun testGetArrivalBatch10MinCutoff() {
         val spyService = spy(realtimeService)
-        doReturn(fixedNow).whenever(spyService).currentTime()
-
-        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, startStopID = 216000358, limit = null)
-        whenever(realtimeRepository.findByRouteIDInAndStopIDIn(any(), any())).thenReturn(emptyList())
-        // The code calls findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter with weekday="sunday"
-        // and then filters departureTime < SERVICE_DAY_START (04:00)
+        doReturn(LocalDateTime.of(2025, 3, 3, 10, 0)).whenever(spyService).currentTime()
+        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, limit = null)
         whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
+            realtimeRepository.findByRouteIDInAndStopIDIn(
                 listOf(216000068),
-                listOf(216000358),
-                "sunday",
-                LocalTime.of(1, 30),
-                Sort.by(Sort.Order.asc("departureTime")),
+                listOf(216000138),
             ),
         ).thenReturn(
             listOf(
-                // departureTime < 04:00 → kept after filter
-                BusTimetable(
-                    seq = 1,
+                BusRealtime(
                     routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "sunday",
-                    departureTime = LocalTime.parse("02:00:00"),
+                    stopID = 216000138,
+                    order = 1,
+                    remainingTime = Duration.ofMinutes(5),
+                    remainingStop = 2,
+                    remainingSeat = 40,
+                    isLowFloor = false,
+                    updatedAt = ZonedDateTime.now(),
+                    routeStop = null,
                 ),
-                BusTimetable(
-                    seq = 2,
+                BusRealtime(
                     routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "sunday",
-                    departureTime = LocalTime.parse("02:30:00"),
+                    stopID = 216000138,
+                    order = 2,
+                    remainingTime = Duration.ofMinutes(20),
+                    remainingStop = 5,
+                    remainingSeat = 20,
+                    isLowFloor = false,
+                    updatedAt = ZonedDateTime.now(),
+                    routeStop = null,
                 ),
-                // departureTime >= 04:00 → removed by filter
-                BusTimetable(
-                    seq = 3,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "sunday",
-                    departureTime = LocalTime.parse("05:00:00"),
-                ),
+            ),
+        )
+        // lastRealtime=20, cutoff=30
+        // Cluster A: 10:24 → 24min from now → 24 > 30? NO → filtered
+        // Cluster B: 10:39 → 39min from now → 39 > 30? YES → passes
+        whenever(
+            logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any()),
+        ).thenReturn(
+            listOf(
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 24), LocalTime.of(10, 24), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 17), LocalTime.of(10, 24), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 10), LocalTime.of(10, 24), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 3), LocalTime.of(10, 24), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 24), LocalTime.of(10, 39), "V2", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 17), LocalTime.of(10, 39), "V2", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 10), LocalTime.of(10, 39), "V2", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 3), LocalTime.of(10, 39), "V2", null),
             ),
         )
 
         val result = spyService.getArrivalBatch(setOf(key))
-        val arrivals = result[key]!!
 
-        assertEquals(2, arrivals.size)
-        assertEquals(LocalTime.parse("02:00:00"), arrivals[0].time)
-        assertEquals(LocalTime.parse("02:30:00"), arrivals[1].time)
+        val arrivals = result[key]!!
+        assertEquals(3, arrivals.size)
+        assertEquals(true, arrivals[0].isRealtime)
+        assertEquals(true, arrivals[1].isRealtime)
+        assertEquals(false, arrivals[2].isRealtime)
     }
 
     @Test
-    @DisplayName("버스 도착 정보 배치 조회 - 자정 이후 (01:30): 자정 이후 버스만 반환")
-    fun testGetArrivalBatchAfterMidnightReturnsOnlyRemainingBuses() {
-        // Sunday 2025-03-02 01:00 KST → serviceDate = Saturday 2025-03-01 → weekday = "saturday"
-        val fixedNow = LocalDateTime.of(2025, 3, 2, 1, 0)
+    @DisplayName("버스 도착 정보 배치 조회 - 자정 이후 서비스 날짜 계산")
+    fun testGetArrivalBatchAfterMidnight() {
+        // 03-03 01:00 KST (before 04:00) → serviceDate = 03-02
+        // sameDayDates = [2025-02-23, 2025-02-16, 2025-02-09, 2025-02-02]
         val spyService = spy(realtimeService)
-        doReturn(fixedNow).whenever(spyService).currentTime()
-
-        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, startStopID = 216000358, limit = null)
+        doReturn(LocalDateTime.of(2025, 3, 3, 1, 0)).whenever(spyService).currentTime()
+        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, limit = null)
         whenever(realtimeRepository.findByRouteIDInAndStopIDIn(any(), any())).thenReturn(emptyList())
+        // Cluster: all 01:19 → avg=01:19 → toServiceSeconds(01:19)=91140, toServiceSeconds(01:00)=90000
+        // (91140 - 90000) / 60 = 19 > 0 → passes
         whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                listOf(216000068),
-                listOf(216000358),
-                "saturday",
-                LocalTime.of(1, 0),
-                Sort.by(Sort.Order.asc("departureTime")),
-            ),
+            logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any()),
         ).thenReturn(
             listOf(
-                BusTimetable(
-                    seq = 1,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "saturday",
-                    departureTime = LocalTime.parse("01:30:00"),
-                ),
-                BusTimetable(
-                    seq = 2,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "saturday",
-                    departureTime = LocalTime.parse("02:00:00"),
-                ),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 23), LocalTime.of(1, 19), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 16), LocalTime.of(1, 19), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 9), LocalTime.of(1, 19), "V1", null),
+                BusDepartureLog(null, 216000068, 216000138, LocalDate.of(2025, 2, 2), LocalTime.of(1, 19), "V1", null),
             ),
         )
 
         val result = spyService.getArrivalBatch(setOf(key))
-        val arrivals = result[key]!!
 
-        assertEquals(2, arrivals.size)
-        assertEquals(LocalTime.parse("01:30:00"), arrivals[0].time)
-        assertEquals(LocalTime.parse("02:00:00"), arrivals[1].time)
-    }
-
-    @Test
-    @DisplayName("버스 도착 정보 배치 조회 - 자정 이후 (01:30): limit 적용")
-    fun testGetArrivalBatchAfterMidnightWithLimit() {
-        val fixedNow = LocalDateTime.of(2025, 3, 3, 1, 0)
-        val spyService = spy(realtimeService)
-        doReturn(fixedNow).whenever(spyService).currentTime()
-
-        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, startStopID = 216000358, limit = 1)
-        whenever(realtimeRepository.findByRouteIDInAndStopIDIn(any(), any())).thenReturn(emptyList())
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(
-            listOf(
-                BusTimetable(
-                    seq = 1,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "sunday",
-                    departureTime = LocalTime.parse("01:30:00"),
-                ),
-                BusTimetable(
-                    seq = 2,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "sunday",
-                    departureTime = LocalTime.parse("02:00:00"),
-                ),
-            ),
-        )
-
-        val result = spyService.getArrivalBatch(setOf(key))
-        val arrivals = result[key]!!
-
-        assertEquals(1, arrivals.size)
-        assertEquals(LocalTime.parse("01:30:00"), arrivals[0].time)
-    }
-
-    @Test
-    @DisplayName("버스 도착 정보 배치 조회 - 자정 이후 (01:30): 결과 없음")
-    fun testGetArrivalBatchAfterMidnightNoResult() {
-        // 03:50 - just before service day start, no more buses
-        val fixedNow = LocalDateTime.of(2025, 3, 3, 3, 50)
-        val spyService = spy(realtimeService)
-        doReturn(fixedNow).whenever(spyService).currentTime()
-
-        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, startStopID = 216000358, limit = null)
-        whenever(realtimeRepository.findByRouteIDInAndStopIDIn(any(), any())).thenReturn(emptyList())
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(emptyList())
-
-        val result = spyService.getArrivalBatch(setOf(key))
-        assertEquals(0, result[key]!!.size)
+        assertEquals(1, result[key]!!.size)
+        assertEquals(false, result[key]!![0].isRealtime)
+        assertEquals(LocalTime.of(1, 19), result[key]!![0].time)
     }
 
     @Test
@@ -3424,226 +3406,5 @@ class BusServiceTest {
             PublicHoliday(seq = 1, date = holiday, name = "삼일절", calendarType = "solar"),
         )
         assertEquals("sunday", realtimeService.resolveWeekday(holiday))
-    }
-
-    @Test
-    @DisplayName("버스 도착 정보 배치 조회 - 자정 이후 버스 포함")
-    fun testGetArrivalBatchIncludesAfterMidnightBuses() {
-        val key =
-            BusArrivalKey(
-                routeID = 216000068,
-                stopID = 216000138,
-                startStopID = 216000358,
-                limit = null,
-            )
-        whenever(
-            realtimeRepository.findByRouteIDInAndStopIDIn(
-                listOf(216000068),
-                listOf(216000138),
-            ),
-        ).thenReturn(emptyList())
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(
-            listOf(
-                BusTimetable(
-                    seq = 1,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("23:30:00"),
-                ),
-                BusTimetable(
-                    seq = 2,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("23:50:00"),
-                ),
-            ),
-        )
-        // After-midnight buses returned by DepartureTimeBefore(04:00) query
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeBefore(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(
-            listOf(
-                BusTimetable(
-                    seq = 3,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("00:30:00"),
-                ),
-                BusTimetable(
-                    seq = 4,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("01:00:00"),
-                ),
-            ),
-        )
-
-        val result = realtimeService.getArrivalBatch(setOf(key))
-
-        assertEquals(1, result.size)
-        val arrivals = result[key]!!
-        assertEquals(4, arrivals.size)
-        assertEquals(false, arrivals[0].isRealtime)
-        // Service-day ordering: 23:30, 23:50 come before 00:30, 01:00
-        assertEquals(LocalTime.parse("23:30:00"), arrivals[0].time)
-        assertEquals(LocalTime.parse("23:50:00"), arrivals[1].time)
-        assertEquals(LocalTime.parse("00:30:00"), arrivals[2].time)
-        assertEquals(LocalTime.parse("01:00:00"), arrivals[3].time)
-    }
-
-    @Test
-    @DisplayName("버스 도착 정보 배치 조회 - 자정 이후 버스 정렬 순서 검증")
-    fun testGetArrivalBatchAfterMidnightSorting() {
-        val key =
-            BusArrivalKey(
-                routeID = 216000068,
-                stopID = 216000138,
-                startStopID = 216000358,
-                limit = null,
-            )
-        whenever(
-            realtimeRepository.findByRouteIDInAndStopIDIn(any(), any()),
-        ).thenReturn(emptyList())
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(
-            listOf(
-                BusTimetable(
-                    seq = 1,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("22:00:00"),
-                ),
-            ),
-        )
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeBefore(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(
-            listOf(
-                BusTimetable(
-                    seq = 2,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("01:00:00"),
-                ),
-            ),
-        )
-
-        val result = realtimeService.getArrivalBatch(setOf(key))
-        val arrivals = result[key]!!
-
-        assertEquals(2, arrivals.size)
-        // 22:00 comes before 01:00 in service-day order (01:00 = next-day continuation)
-        assertEquals(LocalTime.parse("22:00:00"), arrivals[0].time)
-        assertEquals(LocalTime.parse("01:00:00"), arrivals[1].time)
-    }
-
-    @Test
-    @DisplayName("버스 도착 정보 배치 조회 - limit 적용 시 자정 이후 버스 포함")
-    fun testGetArrivalBatchLimitWithAfterMidnightBuses() {
-        val key =
-            BusArrivalKey(
-                routeID = 216000068,
-                stopID = 216000138,
-                startStopID = 216000358,
-                limit = 3,
-            )
-        whenever(
-            realtimeRepository.findByRouteIDInAndStopIDIn(any(), any()),
-        ).thenReturn(emptyList())
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(
-            listOf(
-                BusTimetable(
-                    seq = 1,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("23:00:00"),
-                ),
-                BusTimetable(
-                    seq = 2,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("23:30:00"),
-                ),
-            ),
-        )
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeBefore(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(
-            listOf(
-                BusTimetable(
-                    seq = 3,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime =
-                        LocalTime.parse("00:30:00"),
-                ),
-                BusTimetable(
-                    seq = 4,
-                    routeID = 216000068,
-                    startStopID = 216000358,
-                    weekday = "weekdays",
-                    departureTime = LocalTime.parse("01:00:00"),
-                ),
-            ),
-        )
-
-        val result = realtimeService.getArrivalBatch(setOf(key))
-        val arrivals = result[key]!!
-
-        // limit = 3: 23:00, 23:30, 00:30 (01:00 cut off)
-        assertEquals(3, arrivals.size)
-        assertEquals(LocalTime.parse("23:00:00"), arrivals[0].time)
-        assertEquals(LocalTime.parse("23:30:00"), arrivals[1].time)
-        assertEquals(LocalTime.parse("00:30:00"), arrivals[2].time)
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
@@ -57,9 +57,11 @@ import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.Optional
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @ExtendWith(MockitoExtension::class)
 class BusServiceTest {
@@ -2949,6 +2951,16 @@ class BusServiceTest {
 
         assertEquals(1, result.size)
         assertEquals(0, result[216000068 to 216000999]?.size)
+    }
+
+    @Test
+    @DisplayName("currentTime - 서울 시간대 현재 시각 반환")
+    fun testCurrentTime() {
+        val before = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusSeconds(1)
+        val result = realtimeService.currentTime()
+        val after = LocalDateTime.now(ZoneId.of("Asia/Seoul")).plusSeconds(1)
+        assertTrue(result.isAfter(before))
+        assertTrue(result.isBefore(after))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Remove `BusTimetableRepository` dependency from `BusRealtimeService`; replace with `BusDepartureLogRepository`
- Sample the last 4 same-weekday departure logs per stop+route and cluster them with a greedy 3-minute threshold
- Apply a 10-minute gap rule: log-derived arrivals must be more than `lastRealtimeMinutes + 10` minutes away to be shown
- Remove `startStopID` from `BusArrivalKey` (no longer needed since departure logs are recorded at the user's waiting stop)

## Background

The previous fallback used static timetable data (which requires manual entry and becomes stale). Departure logs reflect actual vehicle behaviour and are collected automatically, making them a more accurate and maintainable source for non-realtime arrivals.

The minimum headway among served routes is 15 minutes, so a 3-minute clustering threshold safely merges per-vehicle variation without collapsing distinct departures.

## Changes

- `BusRealtimeService`: replaced timetable fallback with `clusterDepartureTimes()` + 10-min filter; renamed `toServiceMinutes` → `toServiceSeconds` for accuracy; removed `startStopID` from arrival key lookup
- `BusArrivalKey`: removed `startStopID` field
- `BusDataFetcher`: removed `startStopID` from `BusArrivalKey` construction

## Test plan

- `BusServiceTest`: rewrote all `getArrivalBatch` tests to mock `logRepository`; added unit tests for `toServiceSeconds` and `clusterDepartureTimes` (empty, single item, within-threshold, multiple clusters)
- `BusDataFetcherTest`: removed `startStopID` from `BusArrivalKey` in arrival fetch tests
- `./gradlew ktlintCheck`: **BUILD SUCCESSFUL**
- `./gradlew test jacocoTestReport jacocoTestCoverageVerification`: **BUILD SUCCESSFUL**