### PR TITLE
feat: Add departure log and arrivalTime support to bus arrival batch

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/bus/controller/BusDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/bus/controller/BusDataFetcher.kt
@@ -216,6 +216,7 @@ class BusDataFetcher(
                 routeID = routeStop.route.seq,
                 stopID = routeStop.stop.seq,
                 startStopID = routeStop.startStop.seq,
+                minuteFromStart = routeStop.minutes,
                 limit = limitMap[routeStop.route.seq to routeStop.stop.seq],
             )
         val dataLoader = dfe.getDataLoader<BusArrivalKey, List<BusArrival>>("busArrivalDataLoader")!!

--- a/src/main/kotlin/app/hyuabot/backend/bus/domain/BusArrivalKey.kt
+++ b/src/main/kotlin/app/hyuabot/backend/bus/domain/BusArrivalKey.kt
@@ -4,5 +4,6 @@ data class BusArrivalKey(
     val routeID: Int,
     val stopID: Int,
     val startStopID: Int,
+    val minuteFromStart: Int,
     val limit: Int?,
 )

--- a/src/main/kotlin/app/hyuabot/backend/bus/service/BusRealtimeService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/bus/service/BusRealtimeService.kt
@@ -113,19 +113,29 @@ class BusRealtimeService(
                     sort,
                 ).groupBy { it.routeID to it.startStopID }
         return keys.associateWith { key ->
-            val realtimeArrivals =
-                (realtimeGrouped[key.routeID to key.stopID] ?: emptyList())
-                    .map {
-                        BusArrival(
-                            stops = it.remainingStop,
-                            seats = it.remainingSeat,
-                            minutes = it.remainingTime.toMinutes().toInt(),
-                            lowFloor = it.isLowFloor,
-                            isRealtime = true,
-                        )
-                    }.sortedBy { it.minutes }
-            val lastRealtimeMinutes = realtimeArrivals.maxOfOrNull { it.minutes!! } ?: -10
+            val rawRealtimes = realtimeGrouped[key.routeID to key.stopID] ?: emptyList()
+            val sortedRealtimes = rawRealtimes.sortedBy { it.remainingTime.toMinutes().toInt() }
+            val lastRealtimeMinutes =
+                if (sortedRealtimes.isEmpty()) {
+                    -10
+                } else {
+                    sortedRealtimes
+                        .last()
+                        .remainingTime
+                        .toMinutes()
+                        .toInt()
+                }
             val cutoffMinutes = lastRealtimeMinutes + 10
+            val realtimeArrivals =
+                sortedRealtimes.map {
+                    BusArrival(
+                        stops = it.remainingStop,
+                        seats = it.remainingSeat,
+                        minutes = it.remainingTime.toMinutes().toInt(),
+                        lowFloor = it.isLowFloor,
+                        isRealtime = true,
+                    )
+                }
             val rawLogTimes =
                 (logGrouped[key.routeID to key.stopID] ?: emptyList())
                     .map { it.departureTime }

--- a/src/main/kotlin/app/hyuabot/backend/bus/service/BusRealtimeService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/bus/service/BusRealtimeService.kt
@@ -3,6 +3,7 @@ package app.hyuabot.backend.bus.service
 import app.hyuabot.backend.bus.domain.BusArrivalKey
 import app.hyuabot.backend.codegen.types.BusArrival
 import app.hyuabot.backend.database.entity.BusRealtime
+import app.hyuabot.backend.database.repository.BusDepartureLogRepository
 import app.hyuabot.backend.database.repository.BusRealtimeRepository
 import app.hyuabot.backend.database.repository.BusTimetableRepository
 import app.hyuabot.backend.holiday.service.PublicHolidayService
@@ -17,6 +18,7 @@ import java.time.ZoneId
 @Service
 class BusRealtimeService(
     private val realtimeRepository: BusRealtimeRepository,
+    private val departureLogRepository: BusDepartureLogRepository,
     private val timetableRepository: BusTimetableRepository,
     private val publicHolidayService: PublicHolidayService,
 ) {
@@ -31,10 +33,34 @@ class BusRealtimeService(
         }
     }
 
-    private fun toServiceMinutes(time: LocalTime): Int {
+    internal fun toServiceSeconds(time: LocalTime): Int {
         val seconds = time.toSecondOfDay()
         val threshold = serviceStartTime.toSecondOfDay()
         return if (seconds >= threshold) seconds else seconds + 24 * 60 * 60
+    }
+
+    internal fun clusterDepartureTimes(
+        times: List<LocalTime>,
+        thresholdMinutes: Int = 3,
+    ): List<LocalTime> {
+        if (times.isEmpty()) return emptyList()
+        val sorted = times.sortedBy { toServiceSeconds(it) }
+        val clusters = mutableListOf<MutableList<LocalTime>>()
+        var current = mutableListOf(sorted.first())
+        for (i in 1 until sorted.size) {
+            val diff = toServiceSeconds(sorted[i]) - toServiceSeconds(current.last())
+            if (diff <= thresholdMinutes * 60) {
+                current.add(sorted[i])
+            } else {
+                clusters.add(current)
+                current = mutableListOf(sorted[i])
+            }
+        }
+        clusters.add(current)
+        return clusters.map { cluster ->
+            val avgSeconds = cluster.map { toServiceSeconds(it).toLong() }.average().toLong()
+            LocalTime.ofSecondOfDay(avgSeconds % 86400L)
+        }
     }
 
     internal fun currentTime(): LocalDateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
@@ -61,7 +87,6 @@ class BusRealtimeService(
         if (keys.isEmpty()) return emptyMap()
         val now = currentTime()
         val currentTime = now.toLocalTime()
-        val sort = Sort.by(Sort.Order.asc("departureTime"))
         val routeIDs = keys.map { it.routeID }.distinct()
         val stopIDs = keys.map { it.stopID }.distinct()
         val startStopIDs = keys.map { it.startStopID }.distinct()
@@ -69,46 +94,24 @@ class BusRealtimeService(
             realtimeRepository
                 .findByRouteIDInAndStopIDIn(routeIDs, stopIDs)
                 .groupBy { it.routeID to it.stopID }
-        // Times before serviceStartTime (04:00) belong to the previous calendar day's service
         val serviceDate =
-            if (currentTime.isBefore(serviceStartTime)) {
-                now.toLocalDate().minusDays(1)
-            } else {
-                now.toLocalDate()
-            }
+            if (currentTime.isBefore(serviceStartTime)) now.toLocalDate().minusDays(1) else now.toLocalDate()
         val weekday = resolveWeekday(serviceDate)
-        val timetableEntries =
-            if (currentTime.isBefore(serviceStartTime)) {
-                // After midnight: remaining buses are between currentTime and serviceStartTime
-                timetableRepository
-                    .findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                        routeIDs,
-                        startStopIDs,
-                        weekday,
-                        currentTime,
-                        sort,
-                    ).filter { it.departureTime.isBefore(serviceStartTime) }
-            } else {
-                // Normal hours: buses from now until midnight + after-midnight buses (00:00–serviceStartTime)
-                val remaining =
-                    timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                        routeIDs,
-                        startStopIDs,
-                        weekday,
-                        currentTime,
-                        sort,
-                    )
-                val afterMidnight =
-                    timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeBefore(
-                        routeIDs,
-                        startStopIDs,
-                        weekday,
-                        serviceStartTime,
-                        sort,
-                    )
-                remaining + afterMidnight
-            }
-        val timetableGrouped = timetableEntries.groupBy { it.routeID to it.startStopID }
+        val sameDayDates = (1..4).map { serviceDate.minusWeeks(it.toLong()) }
+        val logGrouped =
+            departureLogRepository
+                .findByRouteIDInAndStopIDInAndDepartureDateIn(routeIDs, stopIDs, sameDayDates)
+                .groupBy { it.routeID to it.stopID }
+        val sort = Sort.by(Sort.Order.asc("routeID"), Sort.Order.asc("startStopID"), Sort.Order.asc("departureTime"))
+        val timetableGrouped =
+            timetableRepository
+                .findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
+                    routeIDs,
+                    startStopIDs,
+                    weekday,
+                    LocalTime.MIN,
+                    sort,
+                ).groupBy { it.routeID to it.startStopID }
         return keys.associateWith { key ->
             val realtimeArrivals =
                 (realtimeGrouped[key.routeID to key.stopID] ?: emptyList())
@@ -121,11 +124,32 @@ class BusRealtimeService(
                             isRealtime = true,
                         )
                     }.sortedBy { it.minutes }
-            val timetableArrivals =
-                (timetableGrouped[key.routeID to key.startStopID] ?: emptyList())
-                    .map { BusArrival(isRealtime = false, time = it.departureTime) }
-                    .sortedBy { toServiceMinutes(it.time!!) }
-            (realtimeArrivals + timetableArrivals).take(key.limit ?: Int.MAX_VALUE)
+            val lastRealtimeMinutes = realtimeArrivals.maxOfOrNull { it.minutes!! } ?: -10
+            val cutoffMinutes = lastRealtimeMinutes + 10
+            val rawLogTimes =
+                (logGrouped[key.routeID to key.stopID] ?: emptyList())
+                    .map { it.departureTime }
+            val logArrivals =
+                clusterDepartureTimes(rawLogTimes)
+                    .filter { time -> (toServiceSeconds(time) - toServiceSeconds(currentTime)) / 60 > cutoffMinutes }
+                    .map { logTime ->
+                        val terminalTime = logTime.minusMinutes(key.minuteFromStart.toLong())
+                        BusArrival(isRealtime = false, time = terminalTime, arrivalTime = logTime)
+                    }.sortedBy { toServiceSeconds(it.time!!) }
+            val scheduledArrivals =
+                if (logArrivals.isEmpty()) {
+                    (timetableGrouped[key.routeID to key.startStopID] ?: emptyList())
+                        .filter { timetable ->
+                            val estimatedArrival = timetable.departureTime.plusMinutes(key.minuteFromStart.toLong())
+                            (toServiceSeconds(estimatedArrival) - toServiceSeconds(currentTime)) / 60 > cutoffMinutes
+                        }.map { timetable ->
+                            val estimatedArrival = timetable.departureTime.plusMinutes(key.minuteFromStart.toLong())
+                            BusArrival(isRealtime = false, time = timetable.departureTime, arrivalTime = estimatedArrival)
+                        }.sortedBy { toServiceSeconds(it.arrivalTime!!) }
+                } else {
+                    logArrivals
+                }
+            (realtimeArrivals + scheduledArrivals).take(key.limit ?: Int.MAX_VALUE)
         }
     }
 }

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -282,6 +282,7 @@ type BusArrival {
     lowFloor: Boolean
     isRealtime: Boolean!
     time: LocalTime
+    arrivalTime: LocalTime
 }
 
 # 전철 정보를 반환하는 쿼리입니다.

--- a/src/test/kotlin/app/hyuabot/backend/bus/BusDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/bus/BusDataFetcherTest.kt
@@ -501,6 +501,7 @@ class BusDataFetcherTest {
                     routeID = route.id,
                     stopID = stop.id,
                     startStopID = startStop.id,
+                    minuteFromStart = 1,
                     limit = null,
                 ) to
                     listOf(
@@ -557,6 +558,7 @@ class BusDataFetcherTest {
                     routeID = route.id,
                     stopID = stop.id,
                     startStopID = startStop.id,
+                    minuteFromStart = 1,
                     limit = 2,
                 ) to
                     listOf(
@@ -597,6 +599,7 @@ class BusDataFetcherTest {
                     routeID = route.id,
                     stopID = stop.id,
                     startStopID = startStop.id,
+                    minuteFromStart = 1,
                     limit = null,
                 ) to emptyList(),
             ),

--- a/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
@@ -3642,4 +3642,173 @@ class BusServiceTest {
         assertEquals(LocalTime.parse("23:30:00"), arrivals[1].time)
         assertEquals(LocalTime.parse("00:30:00"), arrivals[2].time)
     }
+
+    @Test
+    @DisplayName("출발 시간 클러스터링 - 단일 항목")
+    fun testClusterDepartureTimesSingleItem() {
+        val result = realtimeService.clusterDepartureTimes(listOf(LocalTime.parse("08:00:00")))
+        assertEquals(1, result.size)
+        assertEquals(LocalTime.parse("08:00:00"), result[0])
+    }
+
+    @Test
+    @DisplayName("출발 시간 클러스터링 - 임계값 이내 (1개 클러스터로 병합)")
+    fun testClusterDepartureTimesWithinThreshold() {
+        val result =
+            realtimeService.clusterDepartureTimes(
+                listOf(LocalTime.parse("08:00:00"), LocalTime.parse("08:01:00")),
+            )
+        assertEquals(1, result.size)
+        assertEquals(LocalTime.parse("08:00:30"), result[0])
+    }
+
+    @Test
+    @DisplayName("출발 시간 클러스터링 - 임계값 초과 (2개 클러스터로 분리)")
+    fun testClusterDepartureTimesMultipleClusters() {
+        val result =
+            realtimeService.clusterDepartureTimes(
+                listOf(LocalTime.parse("08:00:00"), LocalTime.parse("09:00:00")),
+            )
+        assertEquals(2, result.size)
+        assertEquals(LocalTime.parse("08:00:00"), result[0])
+        assertEquals(LocalTime.parse("09:00:00"), result[1])
+    }
+
+    @Test
+    @DisplayName("버스 도착 정보 배치 조회 - 도착 로그가 cutoff 이내로 필터링됨 (시간표 fallback 사용)")
+    fun testGetArrivalBatchLogFilteredByCutoff() {
+        val fixedNow = LocalDateTime.of(2025, 3, 3, 7, 0)
+        val spyService = spy(realtimeService)
+        doReturn(fixedNow).whenever(spyService).currentTime()
+
+        val key =
+            BusArrivalKey(
+                routeID = 216000068,
+                stopID = 216000138,
+                startStopID = 216000358,
+                minuteFromStart = 0,
+                limit = null,
+            )
+        whenever(
+            realtimeRepository.findByRouteIDInAndStopIDIn(any(), any()),
+        ).thenReturn(
+            listOf(
+                BusRealtime(
+                    routeID = 216000068,
+                    stopID = 216000138,
+                    order = 1,
+                    remainingTime = Duration.ofMinutes(20),
+                    remainingStop = 3,
+                    remainingSeat = 30,
+                    isLowFloor = false,
+                    updatedAt = ZonedDateTime.now(),
+                    routeStop = null,
+                ),
+            ),
+        )
+        // cutoffMinutes = 20 + 10 = 30; log at 07:25 is only 25 min away → filtered out
+        whenever(
+            logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any()),
+        ).thenReturn(
+            listOf(
+                BusDepartureLog(
+                    seq = 1,
+                    routeID = 216000068,
+                    stopID = 216000138,
+                    departureDate = LocalDate.of(2025, 2, 24),
+                    departureTime = LocalTime.parse("07:25:00"),
+                    vehicleID = "1000001",
+                    routeStop = null,
+                ),
+            ),
+        )
+        whenever(
+            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            ),
+        ).thenReturn(
+            listOf(
+                BusTimetable(
+                    seq = 1,
+                    routeID = 216000068,
+                    startStopID = 216000358,
+                    weekday = "weekdays",
+                    departureTime = LocalTime.parse("08:00:00"),
+                ),
+            ),
+        )
+
+        val result = spyService.getArrivalBatch(setOf(key))
+
+        val arrivals = result[key]!!
+        // realtime(20min) + timetable fallback (log filtered, arrivalTime=08:00 which is 60min > 30min cutoff)
+        assertEquals(2, arrivals.size)
+        assertEquals(true, arrivals[0].isRealtime)
+        assertEquals(false, arrivals[1].isRealtime)
+        assertEquals(LocalTime.parse("08:00:00"), arrivals[1].time)
+    }
+
+    @Test
+    @DisplayName("버스 도착 정보 배치 조회 - 도착 로그 기반 (시간표 fallback 미사용)")
+    fun testGetArrivalBatchWithLogs() {
+        val fixedNow = LocalDateTime.of(2025, 3, 3, 7, 0)
+        val spyService = spy(realtimeService)
+        doReturn(fixedNow).whenever(spyService).currentTime()
+
+        val key =
+            BusArrivalKey(
+                routeID = 216000068,
+                stopID = 216000138,
+                startStopID = 216000358,
+                minuteFromStart = 10,
+                limit = null,
+            )
+        whenever(realtimeRepository.findByRouteIDInAndStopIDIn(any(), any())).thenReturn(emptyList())
+        whenever(
+            logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any()),
+        ).thenReturn(
+            listOf(
+                BusDepartureLog(
+                    seq = 1,
+                    routeID = 216000068,
+                    stopID = 216000138,
+                    departureDate = LocalDate.of(2025, 2, 24),
+                    departureTime = LocalTime.parse("08:00:00"),
+                    vehicleID = "1000001",
+                    routeStop = null,
+                ),
+            ),
+        )
+        whenever(
+            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            ),
+        ).thenReturn(
+            listOf(
+                BusTimetable(
+                    seq = 1,
+                    routeID = 216000068,
+                    startStopID = 216000358,
+                    weekday = "weekdays",
+                    departureTime = LocalTime.parse("07:30:00"),
+                ),
+            ),
+        )
+
+        val result = spyService.getArrivalBatch(setOf(key))
+
+        val arrivals = result[key]!!
+        assertEquals(1, arrivals.size)
+        assertEquals(false, arrivals[0].isRealtime)
+        assertEquals(LocalTime.parse("07:50:00"), arrivals[0].time)
+        assertEquals(LocalTime.parse("08:00:00"), arrivals[0].arrivalTime)
+    }
 }

--- a/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
@@ -2961,11 +2961,16 @@ class BusServiceTest {
     @Test
     @DisplayName("버스 도착 정보 배치 조회 - 실시간 + 시간표")
     fun testGetArrivalBatch() {
+        val fixedNow = LocalDateTime.of(2025, 3, 3, 4, 0)
+        val spyService = spy(realtimeService)
+        doReturn(fixedNow).whenever(spyService).currentTime()
+
         val key =
             BusArrivalKey(
                 routeID = 216000068,
                 stopID = 216000138,
                 startStopID = 216000358,
+                minuteFromStart = 0,
                 limit = null,
             )
         whenever(
@@ -3000,6 +3005,9 @@ class BusServiceTest {
             ),
         )
         whenever(
+            logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any()),
+        ).thenReturn(emptyList())
+        whenever(
             timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
                 any(),
                 any(),
@@ -3032,17 +3040,8 @@ class BusServiceTest {
                 ),
             ),
         )
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeBefore(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(emptyList())
 
-        val result = realtimeService.getArrivalBatch(setOf(key))
+        val result = spyService.getArrivalBatch(setOf(key))
 
         assertEquals(1, result.size)
         val arrivals = result[key]!!
@@ -3055,11 +3054,16 @@ class BusServiceTest {
     @Test
     @DisplayName("버스 도착 정보 배치 조회 - limit 적용")
     fun testGetArrivalBatchWithLimit() {
+        val fixedNow = LocalDateTime.of(2025, 3, 3, 4, 0)
+        val spyService = spy(realtimeService)
+        doReturn(fixedNow).whenever(spyService).currentTime()
+
         val key =
             BusArrivalKey(
                 routeID = 216000068,
                 stopID = 216000138,
                 startStopID = 216000358,
+                minuteFromStart = 0,
                 limit = 2,
             )
         whenever(
@@ -3094,6 +3098,9 @@ class BusServiceTest {
             ),
         )
         whenever(
+            logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any()),
+        ).thenReturn(emptyList())
+        whenever(
             timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
                 any(),
                 any(),
@@ -3113,7 +3120,7 @@ class BusServiceTest {
             ),
         )
 
-        val result = realtimeService.getArrivalBatch(setOf(key))
+        val result = spyService.getArrivalBatch(setOf(key))
 
         val arrivals = result[key]!!
         assertEquals(2, arrivals.size)
@@ -3129,6 +3136,7 @@ class BusServiceTest {
                 routeID = 216000068,
                 stopID = 216000999,
                 startStopID = 216000358,
+                minuteFromStart = 0,
                 limit = null,
             )
         whenever(
@@ -3136,6 +3144,9 @@ class BusServiceTest {
                 listOf(216000068),
                 listOf(216000999),
             ),
+        ).thenReturn(emptyList())
+        whenever(
+            logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any()),
         ).thenReturn(emptyList())
         whenever(
             timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
@@ -3161,6 +3172,7 @@ class BusServiceTest {
                 routeID = 216000068,
                 stopID = 216000138,
                 startStopID = 216000358,
+                minuteFromStart = 0,
                 limit = null,
             )
         val key2 =
@@ -3168,6 +3180,7 @@ class BusServiceTest {
                 routeID = 216000069,
                 stopID = 216000358,
                 startStopID = 216000138,
+                minuteFromStart = 0,
                 limit = null,
             )
         whenever(
@@ -3202,6 +3215,9 @@ class BusServiceTest {
             ),
         )
         whenever(
+            logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any()),
+        ).thenReturn(emptyList())
+        whenever(
             timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
                 any(),
                 any(),
@@ -3232,21 +3248,19 @@ class BusServiceTest {
         val spyService = spy(realtimeService)
         doReturn(fixedNow).whenever(spyService).currentTime()
 
-        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, startStopID = 216000358, limit = null)
+        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, startStopID = 216000358, minuteFromStart = 0, limit = null)
         whenever(realtimeRepository.findByRouteIDInAndStopIDIn(any(), any())).thenReturn(emptyList())
-        // The code calls findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter with weekday="sunday"
-        // and then filters departureTime < SERVICE_DAY_START (04:00)
+        whenever(logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any())).thenReturn(emptyList())
         whenever(
             timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                listOf(216000068),
-                listOf(216000358),
-                "sunday",
-                LocalTime.of(1, 30),
-                Sort.by(Sort.Order.asc("departureTime")),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
             ),
         ).thenReturn(
             listOf(
-                // departureTime < 04:00 → kept after filter
                 BusTimetable(
                     seq = 1,
                     routeID = 216000068,
@@ -3261,7 +3275,6 @@ class BusServiceTest {
                     weekday = "sunday",
                     departureTime = LocalTime.parse("02:30:00"),
                 ),
-                // departureTime >= 04:00 → removed by filter
                 BusTimetable(
                     seq = 3,
                     routeID = 216000068,
@@ -3288,15 +3301,16 @@ class BusServiceTest {
         val spyService = spy(realtimeService)
         doReturn(fixedNow).whenever(spyService).currentTime()
 
-        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, startStopID = 216000358, limit = null)
+        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, startStopID = 216000358, minuteFromStart = 0, limit = null)
         whenever(realtimeRepository.findByRouteIDInAndStopIDIn(any(), any())).thenReturn(emptyList())
+        whenever(logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any())).thenReturn(emptyList())
         whenever(
             timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
-                listOf(216000068),
-                listOf(216000358),
-                "saturday",
-                LocalTime.of(1, 0),
-                Sort.by(Sort.Order.asc("departureTime")),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
             ),
         ).thenReturn(
             listOf(
@@ -3332,8 +3346,9 @@ class BusServiceTest {
         val spyService = spy(realtimeService)
         doReturn(fixedNow).whenever(spyService).currentTime()
 
-        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, startStopID = 216000358, limit = 1)
+        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, startStopID = 216000358, minuteFromStart = 0, limit = 1)
         whenever(realtimeRepository.findByRouteIDInAndStopIDIn(any(), any())).thenReturn(emptyList())
+        whenever(logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any())).thenReturn(emptyList())
         whenever(
             timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
                 any(),
@@ -3376,8 +3391,9 @@ class BusServiceTest {
         val spyService = spy(realtimeService)
         doReturn(fixedNow).whenever(spyService).currentTime()
 
-        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, startStopID = 216000358, limit = null)
+        val key = BusArrivalKey(routeID = 216000068, stopID = 216000138, startStopID = 216000358, minuteFromStart = 0, limit = null)
         whenever(realtimeRepository.findByRouteIDInAndStopIDIn(any(), any())).thenReturn(emptyList())
+        whenever(logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any())).thenReturn(emptyList())
         whenever(
             timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
                 any(),
@@ -3429,11 +3445,16 @@ class BusServiceTest {
     @Test
     @DisplayName("버스 도착 정보 배치 조회 - 자정 이후 버스 포함")
     fun testGetArrivalBatchIncludesAfterMidnightBuses() {
+        val fixedNow = LocalDateTime.of(2025, 3, 3, 15, 0)
+        val spyService = spy(realtimeService)
+        doReturn(fixedNow).whenever(spyService).currentTime()
+
         val key =
             BusArrivalKey(
                 routeID = 216000068,
                 stopID = 216000138,
                 startStopID = 216000358,
+                minuteFromStart = 0,
                 limit = null,
             )
         whenever(
@@ -3442,6 +3463,7 @@ class BusServiceTest {
                 listOf(216000138),
             ),
         ).thenReturn(emptyList())
+        whenever(logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any())).thenReturn(emptyList())
         whenever(
             timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
                 any(),
@@ -3466,19 +3488,6 @@ class BusServiceTest {
                     weekday = "weekdays",
                     departureTime = LocalTime.parse("23:50:00"),
                 ),
-            ),
-        )
-        // After-midnight buses returned by DepartureTimeBefore(04:00) query
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeBefore(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(
-            listOf(
                 BusTimetable(
                     seq = 3,
                     routeID = 216000068,
@@ -3496,7 +3505,7 @@ class BusServiceTest {
             ),
         )
 
-        val result = realtimeService.getArrivalBatch(setOf(key))
+        val result = spyService.getArrivalBatch(setOf(key))
 
         assertEquals(1, result.size)
         val arrivals = result[key]!!
@@ -3512,16 +3521,22 @@ class BusServiceTest {
     @Test
     @DisplayName("버스 도착 정보 배치 조회 - 자정 이후 버스 정렬 순서 검증")
     fun testGetArrivalBatchAfterMidnightSorting() {
+        val fixedNow = LocalDateTime.of(2025, 3, 3, 15, 0)
+        val spyService = spy(realtimeService)
+        doReturn(fixedNow).whenever(spyService).currentTime()
+
         val key =
             BusArrivalKey(
                 routeID = 216000068,
                 stopID = 216000138,
                 startStopID = 216000358,
+                minuteFromStart = 0,
                 limit = null,
             )
         whenever(
             realtimeRepository.findByRouteIDInAndStopIDIn(any(), any()),
         ).thenReturn(emptyList())
+        whenever(logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any())).thenReturn(emptyList())
         whenever(
             timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
                 any(),
@@ -3539,18 +3554,6 @@ class BusServiceTest {
                     weekday = "weekdays",
                     departureTime = LocalTime.parse("22:00:00"),
                 ),
-            ),
-        )
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeBefore(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(
-            listOf(
                 BusTimetable(
                     seq = 2,
                     routeID = 216000068,
@@ -3561,7 +3564,7 @@ class BusServiceTest {
             ),
         )
 
-        val result = realtimeService.getArrivalBatch(setOf(key))
+        val result = spyService.getArrivalBatch(setOf(key))
         val arrivals = result[key]!!
 
         assertEquals(2, arrivals.size)
@@ -3573,16 +3576,22 @@ class BusServiceTest {
     @Test
     @DisplayName("버스 도착 정보 배치 조회 - limit 적용 시 자정 이후 버스 포함")
     fun testGetArrivalBatchLimitWithAfterMidnightBuses() {
+        val fixedNow = LocalDateTime.of(2025, 3, 3, 15, 0)
+        val spyService = spy(realtimeService)
+        doReturn(fixedNow).whenever(spyService).currentTime()
+
         val key =
             BusArrivalKey(
                 routeID = 216000068,
                 stopID = 216000138,
                 startStopID = 216000358,
+                minuteFromStart = 0,
                 limit = 3,
             )
         whenever(
             realtimeRepository.findByRouteIDInAndStopIDIn(any(), any()),
         ).thenReturn(emptyList())
+        whenever(logRepository.findByRouteIDInAndStopIDInAndDepartureDateIn(any(), any(), any())).thenReturn(emptyList())
         whenever(
             timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeAfter(
                 any(),
@@ -3607,25 +3616,12 @@ class BusServiceTest {
                     weekday = "weekdays",
                     departureTime = LocalTime.parse("23:30:00"),
                 ),
-            ),
-        )
-        whenever(
-            timetableRepository.findByRouteIDInAndStartStopIDInAndWeekdayAndDepartureTimeBefore(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            ),
-        ).thenReturn(
-            listOf(
                 BusTimetable(
                     seq = 3,
                     routeID = 216000068,
                     startStopID = 216000358,
                     weekday = "weekdays",
-                    departureTime =
-                        LocalTime.parse("00:30:00"),
+                    departureTime = LocalTime.parse("00:30:00"),
                 ),
                 BusTimetable(
                     seq = 4,
@@ -3637,7 +3633,7 @@ class BusServiceTest {
             ),
         )
 
-        val result = realtimeService.getArrivalBatch(setOf(key))
+        val result = spyService.getArrivalBatch(setOf(key))
         val arrivals = result[key]!!
 
         // limit = 3: 23:00, 23:30, 00:30 (01:00 cut off)


### PR DESCRIPTION
## Summary

- Add `minuteFromStart` to `BusArrivalKey` (travel time from terminal to observed stop)
- Add `arrivalTime: LocalTime` (nullable) to `BusArrival` GraphQL schema
- Rewrite `getArrivalBatch` to use departure logs as primary scheduled-arrival source, with timetable as fallback
- Compute `arrivalTime` as estimated/actual stop arrival time; keep `time` as terminal departure time for backward compatibility

## Background

The reverted PR #72 removed `startStopID` from `BusArrivalKey` and dropped timetable fallback entirely. This version restores both:
- `startStopID` is needed for timetable fallback lookup
- `minuteFromStart` is needed to compute `arrivalTime = logTime - minuteFromStart` (log path) or `arrivalTime = departureTime + minuteFromStart` (timetable path)

Departure logs from the last 4 same-weekday dates are clustered (3-minute threshold) and shown when they fall outside the realtime cutoff window. If no logs exist, timetable entries are used as fallback.

## Changes

- `BusArrivalKey`: added `minuteFromStart: Int`
- `schema.graphqls`: added `time: LocalTime` and `arrivalTime: LocalTime` to `BusArrival`
- `BusRealtimeService.getArrivalBatch()`: log-based arrivals → timetable fallback pipeline; both paths populate `arrivalTime`
- `BusDataFetcher.arrival()`: pass `minuteFromStart = routeStop.minutes` to key
- Tests: updated `BusArrivalKey` construction, added `logRepository` mocks, removed stale `DepartureTimeBefore` stubs, added clock-fixed spies for deterministic filter assertions

## Test plan

- `./gradlew ktlintCheck`: **BUILD SUCCESSFUL**
- `./gradlew test jacocoTestReport jacocoTestCoverageVerification`: **BUILD SUCCESSFUL**