### PR TITLE
feat: Add bulk delete and bulk create API for subway timetables

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/database/repository/SubwayTimetableRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/SubwayTimetableRepository.kt
@@ -3,6 +3,7 @@ package app.hyuabot.backend.database.repository
 import app.hyuabot.backend.database.entity.SubwayTimetable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalTime
 
 interface SubwayTimetableRepository : JpaRepository<SubwayTimetable, Int> {
@@ -87,4 +88,29 @@ interface SubwayTimetableRepository : JpaRepository<SubwayTimetable, Int> {
         weekday: String,
         departureTime: LocalTime,
     ): SubwayTimetable?
+
+    @Transactional
+    fun deleteAllBySeqIn(seqList: List<Int>)
+
+    @Transactional
+    fun deleteAllByStationIDIn(stationIDs: List<String>)
+
+    @Transactional
+    fun deleteAllByStationIDInAndHeading(
+        stationIDs: List<String>,
+        heading: String,
+    )
+
+    @Transactional
+    fun deleteAllByStationIDInAndWeekday(
+        stationIDs: List<String>,
+        weekday: String,
+    )
+
+    @Transactional
+    fun deleteAllByStationIDInAndHeadingAndWeekday(
+        stationIDs: List<String>,
+        heading: String,
+        weekday: String,
+    )
 }

--- a/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayTimetableController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayTimetableController.kt
@@ -1,16 +1,30 @@
 package app.hyuabot.backend.subway.controller
 
+import app.hyuabot.backend.database.exception.LocalTimeNotValidException
+import app.hyuabot.backend.subway.domain.BulkSubwayTimetableCreateRequest
+import app.hyuabot.backend.subway.domain.BulkSubwayTimetableDeleteRequest
 import app.hyuabot.backend.subway.domain.SubwayTimetableListResponse
 import app.hyuabot.backend.subway.domain.SubwayTimetableResponse
+import app.hyuabot.backend.subway.exception.SubwayStartStationNotFoundException
+import app.hyuabot.backend.subway.exception.SubwayStationNotFoundException
+import app.hyuabot.backend.subway.exception.SubwayTerminalStationNotFoundException
 import app.hyuabot.backend.subway.service.SubwayService
 import app.hyuabot.backend.utility.LocalDateTimeBuilder
+import app.hyuabot.backend.utility.ResponseBuilder
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -19,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "Subway", description = "지하철 관련 API")
 class SubwayTimetableController {
     @Autowired private lateinit var service: SubwayService
+    private val logger = LoggerFactory.getLogger(javaClass)
 
     @GetMapping("")
     @Operation(summary = "지하철 시간표 정보 조회", description = "지하철 시간표 정보를 조회합니다.")
@@ -41,4 +56,83 @@ class SubwayTimetableController {
                 )
             },
         )
+
+    @DeleteMapping("")
+    @Operation(summary = "지하철 시간표 일괄 삭제", description = "SEQ 목록 또는 역 ID 목록+조건으로 시간표를 일괄 삭제합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "지하철 시간표 일괄 삭제 성공"),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = [Content(schema = Schema(implementation = ResponseBuilder.Message::class))],
+            ),
+        ],
+    )
+    fun deleteBulkSubwayTimetable(
+        @RequestBody payload: BulkSubwayTimetableDeleteRequest,
+    ): ResponseEntity<*> =
+        try {
+            service.deleteTimetablesBulk(payload)
+            ResponseBuilder.response(HttpStatus.NO_CONTENT, null)
+        } catch (_: IllegalArgumentException) {
+            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("INVALID_REQUEST"))
+        } catch (e: Exception) {
+            logger.error("Error bulk deleting subway timetables", e)
+            ResponseBuilder.response(HttpStatus.INTERNAL_SERVER_ERROR, ResponseBuilder.Message("INTERNAL_SERVER_ERROR"))
+        }
+
+    @PostMapping("/bulk")
+    @Operation(summary = "지하철 시간표 일괄 생성", description = "여러 역의 시간표를 한꺼번에 생성합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "지하철 시간표 일괄 생성 성공",
+                content = [Content(schema = Schema(implementation = SubwayTimetableListResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = [Content(schema = Schema(implementation = ResponseBuilder.Message::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "역을 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ResponseBuilder.Message::class))],
+            ),
+        ],
+    )
+    fun createBulkSubwayTimetable(
+        @RequestBody payloads: List<BulkSubwayTimetableCreateRequest>,
+    ): ResponseEntity<*> =
+        try {
+            ResponseBuilder.response(
+                HttpStatus.CREATED,
+                SubwayTimetableListResponse(
+                    service.createTimetablesBulk(payloads).map {
+                        SubwayTimetableResponse(
+                            seq = it.seq!!,
+                            stationID = it.stationID,
+                            startStationID = it.startStationID,
+                            terminalStationID = it.terminalStationID,
+                            departureTime = LocalDateTimeBuilder.convertLocalTimeToString(it.departureTime),
+                            weekday = it.weekday,
+                            direction = it.heading,
+                        )
+                    },
+                ),
+            )
+        } catch (_: LocalTimeNotValidException) {
+            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("INVALID_TIME_FORMAT"))
+        } catch (_: SubwayStationNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("SUBWAY_STATION_NOT_FOUND"))
+        } catch (_: SubwayStartStationNotFoundException) {
+            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("SUBWAY_START_STATION_NOT_FOUND"))
+        } catch (_: SubwayTerminalStationNotFoundException) {
+            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("SUBWAY_TERMINAL_STATION_NOT_FOUND"))
+        } catch (e: Exception) {
+            logger.error("Error bulk creating subway timetables", e)
+            ResponseBuilder.response(HttpStatus.INTERNAL_SERVER_ERROR, ResponseBuilder.Message("INTERNAL_SERVER_ERROR"))
+        }
 }

--- a/src/main/kotlin/app/hyuabot/backend/subway/domain/BulkSubwayTimetableCreateRequest.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/domain/BulkSubwayTimetableCreateRequest.kt
@@ -1,0 +1,18 @@
+package app.hyuabot.backend.subway.domain
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class BulkSubwayTimetableCreateRequest(
+    @get:Schema(description = "역 ID", example = "K251")
+    val stationID: String,
+    @get:Schema(description = "시점 ID", example = "K209")
+    val startStationID: String,
+    @get:Schema(description = "종점 ID", example = "K271")
+    val terminalStationID: String,
+    @get:Schema(description = "출발 시간", example = "05:30:00")
+    val departureTime: String,
+    @get:Schema(description = "평일/주말 구분", example = "weekdays")
+    val weekday: String,
+    @get:Schema(description = "상행/하행 구분", example = "up")
+    val direction: String,
+)

--- a/src/main/kotlin/app/hyuabot/backend/subway/domain/BulkSubwayTimetableDeleteRequest.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/domain/BulkSubwayTimetableDeleteRequest.kt
@@ -1,0 +1,14 @@
+package app.hyuabot.backend.subway.domain
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class BulkSubwayTimetableDeleteRequest(
+    @get:Schema(description = "삭제할 시간표 SEQ 목록 (seqList 또는 stationIDs 중 하나 필수)")
+    val seqList: List<Int>? = null,
+    @get:Schema(description = "삭제할 역 ID 목록")
+    val stationIDs: List<String>? = null,
+    @get:Schema(description = "행선 필터 (up/down, stationIDs와 함께 사용)")
+    val direction: String? = null,
+    @get:Schema(description = "요일 필터 (weekdays/weekends, stationIDs와 함께 사용)")
+    val weekday: String? = null,
+)

--- a/src/main/kotlin/app/hyuabot/backend/subway/service/SubwayService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/service/SubwayService.kt
@@ -15,6 +15,8 @@ import app.hyuabot.backend.database.repository.SubwayRouteRepository
 import app.hyuabot.backend.database.repository.SubwayStationNameRepository
 import app.hyuabot.backend.database.repository.SubwayStationRepository
 import app.hyuabot.backend.database.repository.SubwayTimetableRepository
+import app.hyuabot.backend.subway.domain.BulkSubwayTimetableCreateRequest
+import app.hyuabot.backend.subway.domain.BulkSubwayTimetableDeleteRequest
 import app.hyuabot.backend.subway.domain.CreateSubwayRouteRequest
 import app.hyuabot.backend.subway.domain.CreateSubwayStationRequest
 import app.hyuabot.backend.subway.domain.SubwayTimetableKey
@@ -369,6 +371,61 @@ class SubwayService(
             throw SubwayTimetableNotFoundException()
         }
         timetableRepository.delete(timetable)
+    }
+
+    @CacheEvict(cacheNames = ["subwayTimetable"], allEntries = true)
+    @Transactional
+    fun deleteTimetablesBulk(request: BulkSubwayTimetableDeleteRequest) {
+        when {
+            request.seqList != null -> timetableRepository.deleteAllBySeqIn(request.seqList)
+            request.stationIDs != null ->
+                when {
+                    request.direction != null && request.weekday != null ->
+                        timetableRepository.deleteAllByStationIDInAndHeadingAndWeekday(
+                            request.stationIDs,
+                            request.direction,
+                            request.weekday,
+                        )
+                    request.direction != null ->
+                        timetableRepository.deleteAllByStationIDInAndHeading(request.stationIDs, request.direction)
+                    request.weekday != null ->
+                        timetableRepository.deleteAllByStationIDInAndWeekday(request.stationIDs, request.weekday)
+                    else -> timetableRepository.deleteAllByStationIDIn(request.stationIDs)
+                }
+            else -> throw IllegalArgumentException("seqList 또는 stationIDs 중 하나는 필수입니다.")
+        }
+    }
+
+    @CacheEvict(cacheNames = ["subwayTimetable"], allEntries = true)
+    @Transactional
+    fun createTimetablesBulk(payloads: List<BulkSubwayTimetableCreateRequest>): List<SubwayTimetable> {
+        val allStationIDs =
+            (
+                payloads.map { it.stationID } +
+                    payloads.map { it.startStationID } +
+                    payloads.map { it.terminalStationID }
+            ).distinct()
+        val stationsById = stationRepository.findByIdIn(allStationIDs).associateBy { it.id }
+
+        val entities =
+            payloads.map { payload ->
+                if (!LocalDateTimeBuilder.checkLocalTimeFormat(payload.departureTime)) throw LocalTimeNotValidException()
+                stationsById[payload.stationID] ?: throw SubwayStationNotFoundException()
+                stationsById[payload.startStationID] ?: throw SubwayStartStationNotFoundException()
+                stationsById[payload.terminalStationID] ?: throw SubwayTerminalStationNotFoundException()
+                SubwayTimetable(
+                    stationID = payload.stationID,
+                    startStationID = payload.startStationID,
+                    terminalStationID = payload.terminalStationID,
+                    departureTime = LocalTime.parse(payload.departureTime),
+                    weekday = payload.weekday,
+                    heading = payload.direction,
+                    station = null,
+                    startStation = null,
+                    terminalStation = null,
+                )
+            }
+        return timetableRepository.saveAll(entities)
     }
 
     fun getRealtimeList() = realtimeRepository.findAll()

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayControllerTest.kt
@@ -7,6 +7,8 @@ import app.hyuabot.backend.database.entity.SubwayTimetable
 import app.hyuabot.backend.database.exception.DurationNotValidException
 import app.hyuabot.backend.database.exception.LocalTimeNotValidException
 import app.hyuabot.backend.security.WithCustomMockUser
+import app.hyuabot.backend.subway.domain.BulkSubwayTimetableCreateRequest
+import app.hyuabot.backend.subway.domain.BulkSubwayTimetableDeleteRequest
 import app.hyuabot.backend.subway.domain.CreateSubwayRouteRequest
 import app.hyuabot.backend.subway.domain.CreateSubwayStationRequest
 import app.hyuabot.backend.subway.domain.SubwayTimetableRequest
@@ -1487,5 +1489,257 @@ class SubwayControllerTest {
             .andExpect(jsonPath("$.result[1].isExpress").value(false))
             .andExpect(jsonPath("$.result[1].isLast").value(true))
             .andExpect(jsonPath("$.result[1].status").value(100))
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 삭제 - seqList로 삭제")
+    @WithCustomMockUser(username = "test_user")
+    fun testBulkDeleteSubwayTimetableBySeqList() {
+        val payload = BulkSubwayTimetableDeleteRequest(seqList = listOf(1, 2, 3))
+        mockMvc
+            .perform(
+                delete("/api/v1/subway/timetable")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload)),
+            ).andExpect(status().isNoContent)
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 삭제 - stationIDs로 삭제")
+    @WithCustomMockUser(username = "test_user")
+    fun testBulkDeleteSubwayTimetableByStationIDs() {
+        val payload = BulkSubwayTimetableDeleteRequest(stationIDs = listOf("K450", "K451"))
+        mockMvc
+            .perform(
+                delete("/api/v1/subway/timetable")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload)),
+            ).andExpect(status().isNoContent)
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 삭제 - stationIDs + direction + weekday")
+    @WithCustomMockUser(username = "test_user")
+    fun testBulkDeleteSubwayTimetableByStationIDsAndDirectionAndWeekday() {
+        val payload =
+            BulkSubwayTimetableDeleteRequest(
+                stationIDs = listOf("K450"),
+                direction = "up",
+                weekday = "weekdays",
+            )
+        mockMvc
+            .perform(
+                delete("/api/v1/subway/timetable")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload)),
+            ).andExpect(status().isNoContent)
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 삭제 - seqList/stationIDs 둘 다 null")
+    @WithCustomMockUser(username = "test_user")
+    fun testBulkDeleteSubwayTimetableInvalidRequest() {
+        val payload = BulkSubwayTimetableDeleteRequest()
+        doThrow(IllegalArgumentException()).whenever(service).deleteTimetablesBulk(payload)
+        mockMvc
+            .perform(
+                delete("/api/v1/subway/timetable")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("INVALID_REQUEST"))
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 삭제 - 기타 예외")
+    @WithCustomMockUser(username = "test_user")
+    fun testBulkDeleteSubwayTimetableOtherException() {
+        val payload = BulkSubwayTimetableDeleteRequest(seqList = listOf(1))
+        doThrow(RuntimeException()).whenever(service).deleteTimetablesBulk(payload)
+        mockMvc
+            .perform(
+                delete("/api/v1/subway/timetable")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload)),
+            ).andExpect(status().isInternalServerError)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 생성")
+    @WithCustomMockUser(username = "test_user")
+    fun testBulkCreateSubwayTimetable() {
+        val payloads =
+            listOf(
+                BulkSubwayTimetableCreateRequest(
+                    stationID = "K450",
+                    startStationID = "K410",
+                    terminalStationID = "K456",
+                    departureTime = "09:00:00",
+                    weekday = "weekdays",
+                    direction = "up",
+                ),
+            )
+        doReturn(
+            listOf(
+                SubwayTimetable(
+                    seq = 1,
+                    stationID = "K450",
+                    startStationID = "K410",
+                    terminalStationID = "K456",
+                    departureTime = LocalTime.parse("09:00"),
+                    weekday = "weekdays",
+                    heading = "up",
+                    station = null,
+                    startStation = null,
+                    terminalStation = null,
+                ),
+            ),
+        ).whenever(service).createTimetablesBulk(payloads)
+        mockMvc
+            .perform(
+                post("/api/v1/subway/timetable/bulk")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payloads)),
+            ).andExpect(status().isCreated)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.result").isArray)
+            .andExpect(jsonPath("$.result[0].seq").value(1))
+            .andExpect(jsonPath("$.result[0].stationID").value("K450"))
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 생성 - 역 없음")
+    @WithCustomMockUser(username = "test_user")
+    fun testBulkCreateSubwayTimetableStationNotFound() {
+        val payloads =
+            listOf(
+                BulkSubwayTimetableCreateRequest(
+                    stationID = "K999",
+                    startStationID = "K410",
+                    terminalStationID = "K456",
+                    departureTime = "09:00:00",
+                    weekday = "weekdays",
+                    direction = "up",
+                ),
+            )
+        doThrow(SubwayStationNotFoundException()).whenever(service).createTimetablesBulk(payloads)
+        mockMvc
+            .perform(
+                post("/api/v1/subway/timetable/bulk")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payloads)),
+            ).andExpect(status().isNotFound)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("SUBWAY_STATION_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 생성 - 출발역 없음")
+    @WithCustomMockUser(username = "test_user")
+    fun testBulkCreateSubwayTimetableStartStationNotFound() {
+        val payloads =
+            listOf(
+                BulkSubwayTimetableCreateRequest(
+                    stationID = "K450",
+                    startStationID = "K999",
+                    terminalStationID = "K456",
+                    departureTime = "09:00:00",
+                    weekday = "weekdays",
+                    direction = "up",
+                ),
+            )
+        doThrow(SubwayStartStationNotFoundException()).whenever(service).createTimetablesBulk(payloads)
+        mockMvc
+            .perform(
+                post("/api/v1/subway/timetable/bulk")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payloads)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("SUBWAY_START_STATION_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 생성 - 종착역 없음")
+    @WithCustomMockUser(username = "test_user")
+    fun testBulkCreateSubwayTimetableTerminalStationNotFound() {
+        val payloads =
+            listOf(
+                BulkSubwayTimetableCreateRequest(
+                    stationID = "K450",
+                    startStationID = "K410",
+                    terminalStationID = "K999",
+                    departureTime = "09:00:00",
+                    weekday = "weekdays",
+                    direction = "up",
+                ),
+            )
+        doThrow(SubwayTerminalStationNotFoundException()).whenever(service).createTimetablesBulk(payloads)
+        mockMvc
+            .perform(
+                post("/api/v1/subway/timetable/bulk")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payloads)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("SUBWAY_TERMINAL_STATION_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 생성 - 잘못된 시간 형식")
+    @WithCustomMockUser(username = "test_user")
+    fun testBulkCreateSubwayTimetableInvalidTimeFormat() {
+        val payloads =
+            listOf(
+                BulkSubwayTimetableCreateRequest(
+                    stationID = "K450",
+                    startStationID = "K410",
+                    terminalStationID = "K456",
+                    departureTime = "invalid",
+                    weekday = "weekdays",
+                    direction = "up",
+                ),
+            )
+        doThrow(
+            app.hyuabot.backend.database.exception
+                .LocalTimeNotValidException(),
+        ).whenever(service).createTimetablesBulk(payloads)
+        mockMvc
+            .perform(
+                post("/api/v1/subway/timetable/bulk")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payloads)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("INVALID_TIME_FORMAT"))
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 생성 - 기타 예외")
+    @WithCustomMockUser(username = "test_user")
+    fun testBulkCreateSubwayTimetableOtherException() {
+        val payloads =
+            listOf(
+                BulkSubwayTimetableCreateRequest(
+                    stationID = "K450",
+                    startStationID = "K410",
+                    terminalStationID = "K456",
+                    departureTime = "09:00:00",
+                    weekday = "weekdays",
+                    direction = "up",
+                ),
+            )
+        doThrow(RuntimeException()).whenever(service).createTimetablesBulk(payloads)
+        mockMvc
+            .perform(
+                post("/api/v1/subway/timetable/bulk")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payloads)),
+            ).andExpect(status().isInternalServerError)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayServiceTest.kt
@@ -13,6 +13,8 @@ import app.hyuabot.backend.database.repository.SubwayRouteRepository
 import app.hyuabot.backend.database.repository.SubwayStationNameRepository
 import app.hyuabot.backend.database.repository.SubwayStationRepository
 import app.hyuabot.backend.database.repository.SubwayTimetableRepository
+import app.hyuabot.backend.subway.domain.BulkSubwayTimetableCreateRequest
+import app.hyuabot.backend.subway.domain.BulkSubwayTimetableDeleteRequest
 import app.hyuabot.backend.subway.domain.CreateSubwayRouteRequest
 import app.hyuabot.backend.subway.domain.CreateSubwayStationRequest
 import app.hyuabot.backend.subway.domain.SubwayTimetableKey
@@ -38,6 +40,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -3171,5 +3174,237 @@ class SubwayServiceTest {
         ).thenReturn(emptyList())
         val key = SubwayTimetableKey(stationID = "K449", directions = listOf("up"), weekdays = listOf("weekdays"))
         assertEquals(0, service.getTimetableViews(setOf(key)).getValue(key).size)
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 삭제 - seqList")
+    fun testDeleteTimetablesBulkBySeqList() {
+        val request = BulkSubwayTimetableDeleteRequest(seqList = listOf(1, 2, 3))
+        doNothing().whenever(timetableRepository).deleteAllBySeqIn(listOf(1, 2, 3))
+        service.deleteTimetablesBulk(request)
+        verify(timetableRepository).deleteAllBySeqIn(listOf(1, 2, 3))
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 삭제 - stationIDs만")
+    fun testDeleteTimetablesBulkByStationIDs() {
+        val request = BulkSubwayTimetableDeleteRequest(stationIDs = listOf("K450", "K451"))
+        doNothing().whenever(timetableRepository).deleteAllByStationIDIn(listOf("K450", "K451"))
+        service.deleteTimetablesBulk(request)
+        verify(timetableRepository).deleteAllByStationIDIn(listOf("K450", "K451"))
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 삭제 - stationIDs + direction")
+    fun testDeleteTimetablesBulkByStationIDsAndDirection() {
+        val request = BulkSubwayTimetableDeleteRequest(stationIDs = listOf("K450"), direction = "up")
+        doNothing().whenever(timetableRepository).deleteAllByStationIDInAndHeading(listOf("K450"), "up")
+        service.deleteTimetablesBulk(request)
+        verify(timetableRepository).deleteAllByStationIDInAndHeading(listOf("K450"), "up")
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 삭제 - stationIDs + weekday")
+    fun testDeleteTimetablesBulkByStationIDsAndWeekday() {
+        val request = BulkSubwayTimetableDeleteRequest(stationIDs = listOf("K450"), weekday = "weekdays")
+        doNothing().whenever(timetableRepository).deleteAllByStationIDInAndWeekday(listOf("K450"), "weekdays")
+        service.deleteTimetablesBulk(request)
+        verify(timetableRepository).deleteAllByStationIDInAndWeekday(listOf("K450"), "weekdays")
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 삭제 - stationIDs + direction + weekday")
+    fun testDeleteTimetablesBulkByStationIDsAndDirectionAndWeekday() {
+        val request = BulkSubwayTimetableDeleteRequest(stationIDs = listOf("K450"), direction = "up", weekday = "weekdays")
+        doNothing().whenever(timetableRepository).deleteAllByStationIDInAndHeadingAndWeekday(listOf("K450"), "up", "weekdays")
+        service.deleteTimetablesBulk(request)
+        verify(timetableRepository).deleteAllByStationIDInAndHeadingAndWeekday(listOf("K450"), "up", "weekdays")
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 삭제 - seqList/stationIDs 둘 다 null")
+    fun testDeleteTimetablesBulkInvalidRequest() {
+        val request = BulkSubwayTimetableDeleteRequest()
+        assertThrows<IllegalArgumentException> { service.deleteTimetablesBulk(request) }
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 생성")
+    fun testCreateTimetablesBulk() {
+        val payloads =
+            listOf(
+                BulkSubwayTimetableCreateRequest(
+                    stationID = "K450",
+                    startStationID = "K410",
+                    terminalStationID = "K456",
+                    departureTime = "09:00:00",
+                    weekday = "weekdays",
+                    direction = "up",
+                ),
+            )
+        val station =
+            SubwayRouteStation(
+                id = "K450",
+                routeID = 1,
+                name = "한양대",
+                order = 1,
+                cumulativeTime = Duration.ZERO,
+                route = null,
+                stationName = null,
+                realtime = mutableListOf(),
+                timetable = mutableListOf(),
+            )
+        val startStation =
+            SubwayRouteStation(
+                id = "K410",
+                routeID = 1,
+                name = "오이도",
+                order = 2,
+                cumulativeTime = Duration.ZERO,
+                route = null,
+                stationName = null,
+                realtime = mutableListOf(),
+                timetable = mutableListOf(),
+            )
+        val terminalStation =
+            SubwayRouteStation(
+                id = "K456",
+                routeID = 1,
+                name = "소사",
+                order = 3,
+                cumulativeTime = Duration.ZERO,
+                route = null,
+                stationName = null,
+                realtime = mutableListOf(),
+                timetable = mutableListOf(),
+            )
+        whenever(stationRepository.findByIdIn(any())).thenReturn(listOf(station, startStation, terminalStation))
+        whenever(timetableRepository.saveAll(any<List<SubwayTimetable>>())).thenReturn(
+            listOf(
+                SubwayTimetable(
+                    seq = 1,
+                    stationID = "K450",
+                    startStationID = "K410",
+                    terminalStationID = "K456",
+                    departureTime = LocalTime.parse("09:00"),
+                    weekday = "weekdays",
+                    heading = "up",
+                    station = null,
+                    startStation = null,
+                    terminalStation = null,
+                ),
+            ),
+        )
+        val result = service.createTimetablesBulk(payloads)
+        assertEquals(1, result.size)
+        assertEquals("K450", result[0].stationID)
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 생성 - 잘못된 시간 형식")
+    fun testCreateTimetablesBulkInvalidTimeFormat() {
+        val payloads =
+            listOf(
+                BulkSubwayTimetableCreateRequest(
+                    stationID = "K450",
+                    startStationID = "K410",
+                    terminalStationID = "K456",
+                    departureTime = "invalid",
+                    weekday = "weekdays",
+                    direction = "up",
+                ),
+            )
+        whenever(stationRepository.findByIdIn(any())).thenReturn(emptyList())
+        assertThrows<LocalTimeNotValidException> { service.createTimetablesBulk(payloads) }
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 생성 - 역 없음")
+    fun testCreateTimetablesBulkStationNotFound() {
+        val payloads =
+            listOf(
+                BulkSubwayTimetableCreateRequest(
+                    stationID = "K999",
+                    startStationID = "K410",
+                    terminalStationID = "K456",
+                    departureTime = "09:00:00",
+                    weekday = "weekdays",
+                    direction = "up",
+                ),
+            )
+        whenever(stationRepository.findByIdIn(any())).thenReturn(emptyList())
+        assertThrows<SubwayStationNotFoundException> { service.createTimetablesBulk(payloads) }
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 생성 - 출발역 없음")
+    fun testCreateTimetablesBulkStartStationNotFound() {
+        val payloads =
+            listOf(
+                BulkSubwayTimetableCreateRequest(
+                    stationID = "K450",
+                    startStationID = "K999",
+                    terminalStationID = "K456",
+                    departureTime = "09:00:00",
+                    weekday = "weekdays",
+                    direction = "up",
+                ),
+            )
+        val station =
+            SubwayRouteStation(
+                id = "K450",
+                routeID = 1,
+                name = "한양대",
+                order = 1,
+                cumulativeTime = Duration.ZERO,
+                route = null,
+                stationName = null,
+                realtime = mutableListOf(),
+                timetable = mutableListOf(),
+            )
+        whenever(stationRepository.findByIdIn(any())).thenReturn(listOf(station))
+        assertThrows<SubwayStartStationNotFoundException> { service.createTimetablesBulk(payloads) }
+    }
+
+    @Test
+    @DisplayName("지하철 시간표 일괄 생성 - 종착역 없음")
+    fun testCreateTimetablesBulkTerminalStationNotFound() {
+        val payloads =
+            listOf(
+                BulkSubwayTimetableCreateRequest(
+                    stationID = "K450",
+                    startStationID = "K410",
+                    terminalStationID = "K999",
+                    departureTime = "09:00:00",
+                    weekday = "weekdays",
+                    direction = "up",
+                ),
+            )
+        val station =
+            SubwayRouteStation(
+                id = "K450",
+                routeID = 1,
+                name = "한양대",
+                order = 1,
+                cumulativeTime = Duration.ZERO,
+                route = null,
+                stationName = null,
+                realtime = mutableListOf(),
+                timetable = mutableListOf(),
+            )
+        val startStation =
+            SubwayRouteStation(
+                id = "K410",
+                routeID = 1,
+                name = "오이도",
+                order = 2,
+                cumulativeTime = Duration.ZERO,
+                route = null,
+                stationName = null,
+                realtime = mutableListOf(),
+                timetable = mutableListOf(),
+            )
+        whenever(stationRepository.findByIdIn(any())).thenReturn(listOf(station, startStation))
+        assertThrows<SubwayTerminalStationNotFoundException> { service.createTimetablesBulk(payloads) }
     }
 }


### PR DESCRIPTION
## Summary

- Add `DELETE /api/v1/subway/timetable` for bulk deletion by seq list or station IDs with optional direction/weekday filter
- Add `POST /api/v1/subway/timetable/bulk` for batch insertion of timetables across multiple stations in a single request
- Reduces request count from O(stations × timetables) to O(1) for Excel upload scenarios

## Changes

- `BulkSubwayTimetableDeleteRequest`: New DTO supporting `seqList` (direct seq targeting) or `stationIDs` + optional `direction`/`weekday` filters
- `BulkSubwayTimetableCreateRequest`: New DTO with `stationID` field added to existing timetable fields
- `SubwayTimetableRepository`: Add `deleteAllBySeqIn`, `deleteAllByStationIDIn`, and three direction/weekday filter variants
- `SubwayService`: Add `deleteTimetablesBulk` (when-branch routing to appropriate repository method) and `createTimetablesBulk` (batch station lookup + `saveAll`)
- `SubwayTimetableController`: Add two new endpoints with full Swagger annotations and exception handling

## Coverage

`SubwayTimetableController`: INSTRUCTION 100%
`SubwayService` (subway): INSTRUCTION 100%