### PR TITLE
Normalize subway weekday aliases

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
@@ -36,7 +36,7 @@ class SubwayDataFetcher(
                     it.stationID
                 }.mapValues { (_, keys) ->
                     val directions = keys.flatMap { it.direction }.distinct()
-                    val weekdays = keys.flatMap { it.weekdays }.distinct()
+                    val weekdays = keys.flatMap { it.weekdays }.map(::normalizeSubwayWeekday).distinct()
                     directions to weekdays
                 }
         dfe.graphQlContext.put("filterMap", filterMap)
@@ -123,4 +123,10 @@ class SubwayDataFetcher(
             stationID = id,
             name = name,
         )
+
+    private fun normalizeSubwayWeekday(weekday: String): String =
+        when (weekday) {
+            "saturday", "sunday" -> "weekends"
+            else -> weekday
+        }
 }

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
@@ -18,6 +18,7 @@ import com.netflix.graphql.dgs.test.EnableDgsTest
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.assertNotNull
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
@@ -486,6 +487,71 @@ class SubwayDataFetcherTest {
         assertNotNull(result)
         assertEquals(1, result.size)
         assertEquals("K449", result[0]["stationID"])
+    }
+
+    @Test
+    @DisplayName("전철 도착 정보 조회 - 토요일 요일 필터를 weekends로 정규화")
+    fun testSubwayArrivalNormalizesSaturday() {
+        whenever(publicHolidayService.findPublicHoliday(any())).thenReturn(null)
+        whenever(subwayService.getStationViews(listOf(station.id))).thenReturn(listOf(createStationView()))
+        whenever(
+            subwayService.getArrival(
+                eq(station.id),
+                directions = eq(listOf("up")),
+                weekday = eq("weekends"),
+                limit = eq(10),
+                currentTime = any(),
+            ),
+        ).thenReturn(
+            listOf(
+                SubwayArrivalGroup(
+                    direction = "up",
+                    entries =
+                        listOf(
+                            SubwayArrival(
+                                minutes = 4,
+                                terminal = SubwayOriginTerminal(stationID = terminalStation.id, name = terminalStation.name),
+                                isRealtime = true,
+                                location = "고잔",
+                                stops = 2,
+                            ),
+                        ),
+                ),
+            ),
+        )
+
+        val result =
+            dgsQueryExecutor.executeAndExtractJsonPath<List<Map<String, Any>>>(
+                """
+                {
+                    subway(input: {
+                        keys: [{
+                            stationID: "K449",
+                            direction: ["up"],
+                            weekdays: ["saturday"],
+                            limit: 10
+                        }],
+                    }) {
+                        stationID
+                        arrival {
+                            direction
+                            entries {
+                                minutes
+                                location
+                            }
+                        }
+                    }
+                }
+                """.trimIndent(),
+                "data.subway",
+            )
+
+        val arrival = result[0]["arrival"] as List<*>
+        val group = arrival[0] as Map<*, *>
+        val entries = group["entries"] as List<*>
+        val entry = entries[0] as Map<*, *>
+        assertEquals(4, entry["minutes"])
+        assertEquals("고잔", entry["location"])
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Normalize subway GraphQL weekday inputs so `saturday` and `sunday` are treated as `weekends`.
- Add a DGS regression test covering `weekdays: ["saturday"]` for subway arrivals.

## Root Cause
The mobile shuttle transfer query can send bus-style weekday values such as `saturday`, while subway timetable and realtime data is keyed by `weekdays` and `weekends`. The backend passed the weekday input through unchanged, causing weekend subway arrivals to return empty entries.

## Validation
- `./gradlew test --tests app.hyuabot.backend.subway.SubwayDataFetcherTest`
- `./gradlew test`
- `./gradlew test --warning-mode all --tests app.hyuabot.backend.subway.SubwayDataFetcherTest`

Note: Gradle reports an existing deprecation warning for auto-provisioned toolchains without configured toolchain repositories; this PR does not modify build configuration.