### PR TITLE
fix: Correct subway numeric direction mapping

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
@@ -158,15 +158,15 @@ class SubwayDataFetcher(
 
     private fun normalizeSubwayDirection(direction: String): String =
         when (direction) {
-            "1" -> "up"
-            "0" -> "down"
+            "0" -> "up"
+            "1" -> "down"
             else -> direction
         }
 
     private fun subwayDirectionAliases(direction: String): List<String> =
         when (normalizeSubwayDirection(direction)) {
-            "up" -> listOf("up", "1")
-            "down" -> listOf("down", "0")
+            "up" -> listOf("up", "0")
+            "down" -> listOf("down", "1")
             else -> listOf(direction)
         }
 }

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
@@ -201,7 +201,7 @@ class SubwayDataFetcherTest {
     @DisplayName("전철 도착 정보 조회 (정상, 역 정보 + 실시간 정보 + 시간표 + 도착 정보)")
     fun testSubwayFullInfo() {
         whenever(subwayService.getStationViews(listOf(station.id))).thenReturn(listOf(createStationView()))
-        whenever(subwayService.getRealtimeList(station.id, directions = listOf("up", "1"))).thenReturn(
+        whenever(subwayService.getRealtimeList(station.id, directions = listOf("up", "0"))).thenReturn(
             listOf(
                 createRealtime(
                     terminalStation = terminalStation,
@@ -257,7 +257,7 @@ class SubwayDataFetcherTest {
         whenever(
             subwayService.getArrival(
                 eq(station.id),
-                directions = eq(listOf("1")),
+                directions = eq(listOf("0")),
                 weekday = eq("weekdays"),
                 limit = isNull(),
                 currentTime = any(),
@@ -434,7 +434,7 @@ class SubwayDataFetcherTest {
         whenever(
             subwayService.getArrival(
                 eq(station.id),
-                directions = eq(listOf("1")),
+                directions = eq(listOf("0")),
                 weekday = eq("weekends"),
                 limit = isNull(),
                 currentTime = any(),
@@ -487,7 +487,7 @@ class SubwayDataFetcherTest {
         whenever(
             subwayService.getArrival(
                 eq(station.id),
-                directions = eq(listOf("1")),
+                directions = eq(listOf("0")),
                 weekday = eq("weekdays"),
                 limit = isNull(),
                 currentTime = any(),
@@ -540,7 +540,7 @@ class SubwayDataFetcherTest {
         whenever(
             subwayService.getArrival(
                 eq(station.id),
-                directions = eq(listOf("1")),
+                directions = eq(listOf("0")),
                 weekday = eq("weekends"),
                 limit = isNull(),
                 currentTime = any(),
@@ -614,7 +614,7 @@ class SubwayDataFetcherTest {
         whenever(
             subwayService.getArrival(
                 eq(station.id),
-                directions = eq(listOf("1")),
+                directions = eq(listOf("0")),
                 weekday = eq("weekdays"),
                 limit = isNull(),
                 currentTime = any(),
@@ -622,7 +622,7 @@ class SubwayDataFetcherTest {
         ).thenReturn(
             listOf(
                 SubwayArrivalGroup(
-                    direction = "1",
+                    direction = "0",
                     entries =
                         listOf(
                             SubwayArrival(
@@ -644,7 +644,7 @@ class SubwayDataFetcherTest {
                     subway(input: {
                         keys: [{
                             stationID: "K449",
-                            direction: ["1"],
+                            direction: ["0"],
                             weekdays: ["weekdays"],
                             limit: 10
                         }],
@@ -705,7 +705,7 @@ class SubwayDataFetcherTest {
         whenever(
             subwayService.getArrival(
                 eq(station.id),
-                directions = eq(listOf("0")),
+                directions = eq(listOf("1")),
                 weekday = eq("weekends"),
                 limit = isNull(),
                 currentTime = any(),
@@ -719,7 +719,7 @@ class SubwayDataFetcherTest {
                     subway(input: {
                         keys: [{
                             stationID: "K449",
-                            direction: ["0"],
+                            direction: ["1"],
                             weekdays: ["sunday"],
                             limit: null
                         }],


### PR DESCRIPTION
## Summary
- Corrects numeric subway direction aliases so 0 maps to up and 1 maps to down.
- Keeps legacy text aliases supported by querying both text and numeric values.
- Updates GraphQL data fetcher tests for the corrected alias mapping.

## Validation
- ./gradlew test jacocoTestReport
- Jacoco line coverage: 305/305 included source files at 100%%.
