### PR TITLE
Improve deploy transfer workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,9 @@ on:
         required: false
         default: false
         type: boolean
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
 jobs:
   select-build-runner:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
@@ -65,6 +68,8 @@ jobs:
     if: needs.select-build-runner.outputs.use_mac == 'true'
     runs-on: ["self-hosted", "ARM64", "macOS"]
     environment: production
+    outputs:
+      jar_transferred: ${{ steps.transfer.outputs.transferred }}
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
@@ -99,7 +104,27 @@ jobs:
         run: |
           ./gradlew --no-daemon bootJar -x test
           cp "$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -n 1)" build/libs/app.jar
+      - name: Transfer application jar to Oracle runner
+        id: transfer
+        env:
+          ORACLE_TRANSFER_TARGET: ${{ secrets.ORACLE_TRANSFER_TARGET }}
+          TRANSFER_DIR: /tmp/hyuabot-deploy/${{ github.run_id }}
+        run: |
+          if [ -z "$ORACLE_TRANSFER_TARGET" ]; then
+            echo "ORACLE_TRANSFER_TARGET is not set; falling back to artifact transfer."
+            echo "transferred=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ssh -o BatchMode=yes -o ConnectTimeout=10 "$ORACLE_TRANSFER_TARGET" "mkdir -p '$TRANSFER_DIR'" &&
+             rsync -az --timeout=30 -e "ssh -o BatchMode=yes -o ConnectTimeout=10" build/libs/app.jar "$ORACLE_TRANSFER_TARGET:$TRANSFER_DIR/app.jar"; then
+            echo "transferred=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Direct transfer failed; falling back to artifact transfer."
+            echo "transferred=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Upload application jar
+        if: steps.transfer.outputs.transferred != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: app-jar
@@ -164,7 +189,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+      - name: Copy transferred application jar
+        if: needs.build-jar-mac.outputs.jar_transferred == 'true'
+        run: |
+          mkdir -p build/libs
+          cp /tmp/hyuabot-deploy/${{ github.run_id }}/app.jar build/libs/app.jar
       - name: Download application jar
+        if: needs.build-jar-mac.outputs.jar_transferred != 'true'
         uses: actions/download-artifact@v8
         with:
           name: app-jar
@@ -190,6 +221,10 @@ jobs:
         run: |
           docker image rm ${{ env.IMAGE_NAME }} || true
           docker image prune -f
+      - name: Clean transferred application jar
+        if: always() && needs.build-jar-mac.outputs.jar_transferred == 'true'
+        run: |
+          rm -rf /tmp/hyuabot-deploy/${{ github.run_id }}
   restart:
     if: always() && github.event_name == 'workflow_dispatch' && needs.deploy.result == 'success'
     needs: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,7 +119,7 @@ jobs:
           TRANSFER_HOST="${SSH_HOST#*@}"
           TRANSFER_TARGET="ubuntu@$TRANSFER_HOST"
           if ssh -o BatchMode=yes -o ConnectTimeout=10 "$TRANSFER_TARGET" "mkdir -p '$TRANSFER_DIR'" &&
-             rsync -az --timeout=30 -e "ssh -o BatchMode=yes -o ConnectTimeout=10" build/libs/app.jar "$TRANSFER_TARGET:$TRANSFER_DIR/app.jar"; then
+             scp -o BatchMode=yes -o ConnectTimeout=10 build/libs/app.jar "$TRANSFER_TARGET:$TRANSFER_DIR/app.jar"; then
             echo "transferred=true" >> "$GITHUB_OUTPUT"
           else
             echo "Direct transfer failed; falling back to artifact transfer."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,22 +107,17 @@ jobs:
       - name: Transfer application jar to Oracle runner
         id: transfer
         env:
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-          ORACLE_TRANSFER_TARGET: ${{ secrets.ORACLE_TRANSFER_TARGET }}
+          SSH_HOST: ${{ secrets.SSH_HOST || secrets.ORACLE_TRANSFER_TARGET }}
           TRANSFER_DIR: /tmp/hyuabot-deploy/${{ github.run_id }}
         run: |
-          if [ -n "$SSH_HOST" ]; then
-            TRANSFER_TARGET="ubuntu@$SSH_HOST"
-          else
-            TRANSFER_TARGET="$ORACLE_TRANSFER_TARGET"
-          fi
-
-          if [ -z "$TRANSFER_TARGET" ]; then
-            echo "SSH_HOST or ORACLE_TRANSFER_TARGET is not set; falling back to artifact transfer."
+          if [ -z "$SSH_HOST" ]; then
+            echo "SSH_HOST is not set; falling back to artifact transfer."
             echo "transferred=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          TRANSFER_HOST="${SSH_HOST#*@}"
+          TRANSFER_TARGET="ubuntu@$TRANSFER_HOST"
           if ssh -o BatchMode=yes -o ConnectTimeout=10 "$TRANSFER_TARGET" "mkdir -p '$TRANSFER_DIR'" &&
              rsync -az --timeout=30 -e "ssh -o BatchMode=yes -o ConnectTimeout=10" build/libs/app.jar "$TRANSFER_TARGET:$TRANSFER_DIR/app.jar"; then
             echo "transferred=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,17 +107,24 @@ jobs:
       - name: Transfer application jar to Oracle runner
         id: transfer
         env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
           ORACLE_TRANSFER_TARGET: ${{ secrets.ORACLE_TRANSFER_TARGET }}
           TRANSFER_DIR: /tmp/hyuabot-deploy/${{ github.run_id }}
         run: |
-          if [ -z "$ORACLE_TRANSFER_TARGET" ]; then
-            echo "ORACLE_TRANSFER_TARGET is not set; falling back to artifact transfer."
+          if [ -n "$SSH_HOST" ]; then
+            TRANSFER_TARGET="ubuntu@$SSH_HOST"
+          else
+            TRANSFER_TARGET="$ORACLE_TRANSFER_TARGET"
+          fi
+
+          if [ -z "$TRANSFER_TARGET" ]; then
+            echo "SSH_HOST or ORACLE_TRANSFER_TARGET is not set; falling back to artifact transfer."
             echo "transferred=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if ssh -o BatchMode=yes -o ConnectTimeout=10 "$ORACLE_TRANSFER_TARGET" "mkdir -p '$TRANSFER_DIR'" &&
-             rsync -az --timeout=30 -e "ssh -o BatchMode=yes -o ConnectTimeout=10" build/libs/app.jar "$ORACLE_TRANSFER_TARGET:$TRANSFER_DIR/app.jar"; then
+          if ssh -o BatchMode=yes -o ConnectTimeout=10 "$TRANSFER_TARGET" "mkdir -p '$TRANSFER_DIR'" &&
+             rsync -az --timeout=30 -e "ssh -o BatchMode=yes -o ConnectTimeout=10" build/libs/app.jar "$TRANSFER_TARGET:$TRANSFER_DIR/app.jar"; then
             echo "transferred=true" >> "$GITHUB_OUTPUT"
           else
             echo "Direct transfer failed; falling back to artifact transfer."


### PR DESCRIPTION
Updates deployment to avoid concurrent production deploys and transfer built artifacts directly between self-hosted runners with fallback behavior.\n\nValidated with YAML parsing, diff checks, and a manual deployment run using the direct transfer path.