### PR TITLE
Add shuttle Live Activity push support

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/config/LiveActivitySchedulerConfig.kt
+++ b/src/main/kotlin/app/hyuabot/backend/config/LiveActivitySchedulerConfig.kt
@@ -1,0 +1,17 @@
+package app.hyuabot.backend.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+
+@Configuration
+class LiveActivitySchedulerConfig {
+    @Bean
+    fun liveActivityTaskScheduler(): TaskScheduler =
+        ThreadPoolTaskScheduler().apply {
+            setPoolSize(2)
+            setThreadNamePrefix("live-activity-")
+            initialize()
+        }
+}

--- a/src/main/kotlin/app/hyuabot/backend/liveactivity/controller/ShuttleLiveActivityController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/liveactivity/controller/ShuttleLiveActivityController.kt
@@ -1,0 +1,37 @@
+package app.hyuabot.backend.liveactivity.controller
+
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityRegisterRequest
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityRegisterResponse
+import app.hyuabot.backend.liveactivity.service.ShuttleLiveActivityService
+import app.hyuabot.backend.utility.ResponseBuilder
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/live-activity/shuttle")
+@RestController
+class ShuttleLiveActivityController(
+    private val service: ShuttleLiveActivityService,
+) {
+    @PostMapping("")
+    fun register(
+        @RequestBody request: ShuttleLiveActivityRegisterRequest,
+    ): ResponseEntity<ShuttleLiveActivityRegisterResponse> =
+        ResponseBuilder.response(
+            HttpStatus.CREATED,
+            service.register(request),
+        )
+
+    @DeleteMapping("/{key}")
+    fun unregister(
+        @PathVariable key: String,
+    ): ResponseEntity<ResponseBuilder.Message> {
+        service.unregister(key)
+        return ResponseBuilder.response(HttpStatus.OK, "Live Activity registration removed.")
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/liveactivity/domain/ShuttleLiveActivityCheckpointRequest.kt
+++ b/src/main/kotlin/app/hyuabot/backend/liveactivity/domain/ShuttleLiveActivityCheckpointRequest.kt
@@ -1,0 +1,8 @@
+package app.hyuabot.backend.liveactivity.domain
+
+import java.time.Instant
+
+data class ShuttleLiveActivityCheckpointRequest(
+    val name: String,
+    val time: Instant,
+)

--- a/src/main/kotlin/app/hyuabot/backend/liveactivity/domain/ShuttleLiveActivityRegisterRequest.kt
+++ b/src/main/kotlin/app/hyuabot/backend/liveactivity/domain/ShuttleLiveActivityRegisterRequest.kt
@@ -1,0 +1,22 @@
+package app.hyuabot.backend.liveactivity.domain
+
+import java.time.Instant
+
+data class ShuttleLiveActivityRegisterRequest(
+    val key: String,
+    val pushToken: String,
+    val apnsEnvironment: String,
+    val alarmKind: String,
+    val titleText: String,
+    val statusText: String,
+    val dynamicIslandStatusText: String,
+    val currentStopName: String,
+    val nextStopName: String,
+    val checkpointWaitingFormat: String,
+    val checkpointApproachingFormat: String,
+    val checkpointDepartedFormat: String,
+    val progressSegments: List<Int>,
+    val createdAt: Instant,
+    val expiresAt: Instant,
+    val checkpoints: List<ShuttleLiveActivityCheckpointRequest>,
+)

--- a/src/main/kotlin/app/hyuabot/backend/liveactivity/domain/ShuttleLiveActivityRegisterResponse.kt
+++ b/src/main/kotlin/app/hyuabot/backend/liveactivity/domain/ShuttleLiveActivityRegisterResponse.kt
@@ -1,0 +1,6 @@
+package app.hyuabot.backend.liveactivity.domain
+
+data class ShuttleLiveActivityRegisterResponse(
+    val key: String,
+    val scheduledPushCount: Int,
+)

--- a/src/main/kotlin/app/hyuabot/backend/liveactivity/domain/ShuttleLiveActivityState.kt
+++ b/src/main/kotlin/app/hyuabot/backend/liveactivity/domain/ShuttleLiveActivityState.kt
@@ -1,0 +1,70 @@
+package app.hyuabot.backend.liveactivity.domain
+
+import java.time.Instant
+
+data class ShuttleLiveActivityState(
+    val titleText: String,
+    val statusText: String,
+    val dynamicIslandStatusText: String,
+    val currentStopName: String,
+    val nextStopName: String,
+    val checkpointStopNames: List<String>,
+    val checkpointTimes: List<Double>,
+    val checkpointWaitingFormat: String,
+    val checkpointApproachingFormat: String,
+    val checkpointDepartedFormat: String,
+    val progress: Int,
+    val progressSegments: List<Int>,
+)
+
+fun ShuttleLiveActivityRegisterRequest.toState(now: Instant): ShuttleLiveActivityState {
+    val times = checkpoints.map { it.time }
+    val progress =
+        if (times.size >= 2) {
+            checkpointProgress(times, now)
+        } else {
+            fallbackProgress(createdAt, expiresAt, now)
+        }
+    return ShuttleLiveActivityState(
+        titleText = titleText,
+        statusText = statusText,
+        dynamicIslandStatusText = dynamicIslandStatusText,
+        currentStopName = currentStopName,
+        nextStopName = nextStopName,
+        checkpointStopNames = checkpoints.map { it.name },
+        checkpointTimes = times.map { it.toAppleReferenceSeconds() },
+        checkpointWaitingFormat = checkpointWaitingFormat,
+        checkpointApproachingFormat = checkpointApproachingFormat,
+        checkpointDepartedFormat = checkpointDepartedFormat,
+        progress = progress,
+        progressSegments = progressSegments.ifEmpty { listOf(100) },
+    )
+}
+
+private fun checkpointProgress(
+    times: List<Instant>,
+    now: Instant,
+): Int {
+    val start = times.first()
+    val end = times.last()
+    val total = end.epochMillis - start.epochMillis
+    if (total <= 0) return 0
+    val elapsed = (now.epochMillis - start.epochMillis).coerceIn(0, total)
+    return ((elapsed * 100) / total).toInt().coerceIn(0, 100)
+}
+
+private fun fallbackProgress(
+    start: Instant,
+    end: Instant,
+    now: Instant,
+): Int {
+    val total = end.epochMillis - start.epochMillis
+    if (total <= 0) return 100
+    val elapsed = (now.epochMillis - start.epochMillis).coerceIn(0, total)
+    return ((elapsed * 100) / total).toInt().coerceIn(0, 100)
+}
+
+private val Instant.epochMillis: Long
+    get() = toEpochMilli()
+
+private fun Instant.toAppleReferenceSeconds(): Double = epochSecond - 978_307_200.0 + nano / 1_000_000_000.0

--- a/src/main/kotlin/app/hyuabot/backend/liveactivity/service/ApnsLiveActivityService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/liveactivity/service/ApnsLiveActivityService.kt
@@ -94,10 +94,12 @@ class ApnsLiveActivityService(
                 .build()
 
         val response = client.send(request, HttpResponse.BodyHandlers.ofString())
-        if (response.statusCode() !in 200..299) {
+        if (!isSuccessfulStatus(response.statusCode())) {
             logger.warn("APNs Live Activity push failed: status={} body={}", response.statusCode(), response.body())
         }
     }
+
+    private fun isSuccessfulStatus(statusCode: Int): Boolean = statusCode in 200..299
 
     private fun isConfigured(): Boolean = enabled && teamId.isNotBlank() && keyId.isNotBlank() && privateKeyPem.isNotBlank()
 

--- a/src/main/kotlin/app/hyuabot/backend/liveactivity/service/ApnsLiveActivityService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/liveactivity/service/ApnsLiveActivityService.kt
@@ -1,0 +1,163 @@
+package app.hyuabot.backend.liveactivity.service
+
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityState
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import tools.jackson.databind.ObjectMapper
+import java.math.BigInteger
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.security.KeyFactory
+import java.security.PrivateKey
+import java.security.Signature
+import java.security.spec.PKCS8EncodedKeySpec
+import java.time.Instant
+import java.util.Base64
+
+@Service
+class ApnsLiveActivityService(
+    private val objectMapper: ObjectMapper,
+    @param:Value("\${apns.live-activity.enabled:false}") private val enabled: Boolean,
+    @param:Value("\${apns.live-activity.team-id:}") private val teamId: String,
+    @param:Value("\${apns.live-activity.key-id:}") private val keyId: String,
+    @param:Value("\${apns.live-activity.bundle-id:net.jaram.hyuabot}") private val bundleId: String,
+    @param:Value("\${apns.live-activity.private-key:}") private val privateKeyPem: String,
+    @param:Value("\${apns.live-activity.base-url:}") private val configuredBaseUrl: String,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val client = HttpClient.newBuilder().version(HttpClient.Version.HTTP_2).build()
+
+    fun sendUpdate(
+        token: String,
+        apnsEnvironment: String,
+        state: ShuttleLiveActivityState,
+        staleDate: Instant,
+    ) {
+        if (!isConfigured()) {
+            logger.warn("APNs Live Activity push skipped because APNs is not configured.")
+            return
+        }
+
+        val payload =
+            mapOf(
+                "aps" to
+                    mapOf(
+                        "timestamp" to Instant.now().epochSecond,
+                        "event" to "update",
+                        "stale-date" to staleDate.epochSecond,
+                        "content-state" to state,
+                    ),
+            )
+        send(token, apnsEnvironment, payload)
+    }
+
+    fun sendEnd(
+        token: String,
+        apnsEnvironment: String,
+        state: ShuttleLiveActivityState,
+    ) {
+        if (!isConfigured()) {
+            logger.warn("APNs Live Activity end skipped because APNs is not configured.")
+            return
+        }
+
+        val payload =
+            mapOf(
+                "aps" to
+                    mapOf(
+                        "timestamp" to Instant.now().epochSecond,
+                        "event" to "end",
+                        "dismissal-date" to Instant.now().epochSecond,
+                        "content-state" to state,
+                    ),
+            )
+        send(token, apnsEnvironment, payload)
+    }
+
+    private fun send(
+        token: String,
+        apnsEnvironment: String,
+        payload: Map<String, Any>,
+    ) {
+        val request =
+            HttpRequest
+                .newBuilder(URI.create("${baseUrl(apnsEnvironment)}/3/device/$token"))
+                .header("authorization", "bearer ${providerToken()}")
+                .header("apns-topic", "$bundleId.push-type.liveactivity")
+                .header("apns-push-type", "liveactivity")
+                .header("apns-priority", "10")
+                .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
+                .build()
+
+        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+        if (response.statusCode() !in 200..299) {
+            logger.warn("APNs Live Activity push failed: status={} body={}", response.statusCode(), response.body())
+        }
+    }
+
+    private fun isConfigured(): Boolean = enabled && teamId.isNotBlank() && keyId.isNotBlank() && privateKeyPem.isNotBlank()
+
+    private fun baseUrl(apnsEnvironment: String): String =
+        configuredBaseUrl.ifBlank {
+            when (apnsEnvironment.lowercase()) {
+                "development", "sandbox" -> "https://api.sandbox.push.apple.com"
+                else -> "https://api.push.apple.com"
+            }
+        }
+
+    private fun providerToken(): String {
+        val header = base64Url(objectMapper.writeValueAsBytes(mapOf("alg" to "ES256", "kid" to keyId)))
+        val claims = base64Url(objectMapper.writeValueAsBytes(mapOf("iss" to teamId, "iat" to Instant.now().epochSecond)))
+        val signingInput = "$header.$claims"
+        val signature = Signature.getInstance("SHA256withECDSA")
+        signature.initSign(privateKey())
+        signature.update(signingInput.toByteArray(StandardCharsets.UTF_8))
+        return "$signingInput.${base64Url(derToJose(signature.sign()))}"
+    }
+
+    private fun privateKey(): PrivateKey {
+        val cleaned =
+            privateKeyPem
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replace("\\n", "")
+                .replace("\n", "")
+                .trim()
+        val keyBytes = Base64.getDecoder().decode(cleaned)
+        return KeyFactory.getInstance("EC").generatePrivate(PKCS8EncodedKeySpec(keyBytes))
+    }
+
+    private fun base64Url(bytes: ByteArray): String = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+
+    private fun derToJose(der: ByteArray): ByteArray {
+        var index = 0
+        require(der[index++].toInt() == 0x30)
+        index = skipDerLength(der, index)
+        require(der[index++].toInt() == 0x02)
+        val rLength = der[index++].toInt() and 0xff
+        val r = der.copyOfRange(index, index + rLength)
+        index += rLength
+        require(der[index++].toInt() == 0x02)
+        val sLength = der[index++].toInt() and 0xff
+        val s = der.copyOfRange(index, index + sLength)
+        return fixedLength(r) + fixedLength(s)
+    }
+
+    private fun skipDerLength(
+        der: ByteArray,
+        index: Int,
+    ): Int {
+        val length = der[index].toInt() and 0xff
+        if (length < 0x80) return index + 1
+        return index + 1 + (length and 0x7f)
+    }
+
+    private fun fixedLength(value: ByteArray): ByteArray {
+        val normalized = BigInteger(1, value).toByteArray().dropWhile { it == 0.toByte() }.toByteArray()
+        return ByteArray(32 - normalized.size.coerceAtMost(32)) + normalized.takeLast(32).toByteArray()
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/liveactivity/service/ShuttleLiveActivityService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/liveactivity/service/ShuttleLiveActivityService.kt
@@ -1,0 +1,75 @@
+package app.hyuabot.backend.liveactivity.service
+
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityRegisterRequest
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityRegisterResponse
+import app.hyuabot.backend.liveactivity.domain.toState
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ScheduledFuture
+
+@Service
+class ShuttleLiveActivityService(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val taskScheduler: TaskScheduler,
+    private val apnsLiveActivityService: ApnsLiveActivityService,
+) {
+    private val scheduledTasks = mutableMapOf<String, MutableList<ScheduledFuture<*>>>()
+
+    fun register(request: ShuttleLiveActivityRegisterRequest): ShuttleLiveActivityRegisterResponse {
+        unregister(request.key)
+        val expiresAt = request.expiresAt
+        val ttl = Duration.between(Instant.now(), expiresAt.plus(Duration.ofMinutes(10))).coerceAtLeast(Duration.ofMinutes(1))
+        redisTemplate.opsForValue().set(redisKey(request.key), request.pushToken, ttl)
+
+        val pushDates = pushDates(request)
+        scheduledTasks[request.key] =
+            pushDates
+                .map { date ->
+                    taskScheduler.schedule(
+                        {
+                            apnsLiveActivityService.sendUpdate(
+                                token = request.pushToken,
+                                apnsEnvironment = request.apnsEnvironment,
+                                state = request.toState(Instant.now()),
+                                staleDate = expiresAt,
+                            )
+                        },
+                        date,
+                    )
+                }.toMutableList()
+
+        apnsLiveActivityService.sendUpdate(request.pushToken, request.apnsEnvironment, request.toState(Instant.now()), expiresAt)
+        return ShuttleLiveActivityRegisterResponse(request.key, pushDates.size)
+    }
+
+    fun unregister(key: String) {
+        scheduledTasks.remove(key)?.forEach { it.cancel(false) }
+        redisTemplate.delete(redisKey(key))
+    }
+
+    fun end(request: ShuttleLiveActivityRegisterRequest) {
+        unregister(request.key)
+        apnsLiveActivityService.sendEnd(request.pushToken, request.apnsEnvironment, request.toState(Instant.now()))
+    }
+
+    private fun pushDates(request: ShuttleLiveActivityRegisterRequest): List<Instant> {
+        val now = Instant.now()
+        val checkpointDates =
+            request.checkpoints
+                .flatMap { listOf(it.time.minusSeconds(60), it.time, it.time.plusSeconds(1)) }
+        val periodicDates =
+            generateSequence(now.plusSeconds(15)) { it.plusSeconds(15) }
+                .takeWhile { it <= request.expiresAt.plusSeconds(60) }
+                .toList()
+        return (checkpointDates + periodicDates + request.expiresAt)
+            .filter { it > now }
+            .distinct()
+            .sorted()
+            .take(96)
+    }
+
+    private fun redisKey(key: String) = "live-activity:shuttle:$key"
+}

--- a/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
@@ -41,6 +41,7 @@ class SecurityConfig(
                     .requestMatchers(
                         "/api/v1/user",
                         "/api/v1/user/token",
+                        "/api/v1/live-activity/**",
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/graphql/**",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,10 @@ springdoc.default-consumes-media-type=application/json
 springdoc.default-produces-media-type=application/json
 springdoc.swagger-ui.tags-sorter=alpha
 springdoc.swagger-ui.path=/swagger-ui/index.html
+# APNs Live Activity
+apns.live-activity.enabled=${APNS_LIVE_ACTIVITY_ENABLED:false}
+apns.live-activity.team-id=${APNS_TEAM_ID:}
+apns.live-activity.key-id=${APNS_KEY_ID:}
+apns.live-activity.bundle-id=${APNS_BUNDLE_ID:net.jaram.hyuabot}
+apns.live-activity.private-key=${APNS_PRIVATE_KEY:}
+apns.live-activity.base-url=${APNS_BASE_URL:}

--- a/src/test/kotlin/app/hyuabot/backend/config/LiveActivitySchedulerConfigTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/config/LiveActivitySchedulerConfigTest.kt
@@ -1,0 +1,17 @@
+package app.hyuabot.backend.config
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+import kotlin.test.assertIs
+
+class LiveActivitySchedulerConfigTest {
+    @Test
+    @DisplayName("Creates Live Activity task scheduler")
+    fun liveActivityTaskScheduler() {
+        val scheduler = LiveActivitySchedulerConfig().liveActivityTaskScheduler()
+
+        assertIs<ThreadPoolTaskScheduler>(scheduler)
+        scheduler.shutdown()
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/liveactivity/ApnsLiveActivityServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/liveactivity/ApnsLiveActivityServiceTest.kt
@@ -1,0 +1,168 @@
+package app.hyuabot.backend.liveactivity
+
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityState
+import app.hyuabot.backend.liveactivity.service.ApnsLiveActivityService
+import com.sun.net.httpserver.HttpServer
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.json.JsonMapper
+import java.net.InetSocketAddress
+import java.security.KeyPairGenerator
+import java.time.Instant
+import java.util.Base64
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ApnsLiveActivityServiceTest {
+    @Test
+    @DisplayName("Disabled APNs sender skips network calls")
+    fun disabledSender() {
+        val service =
+            ApnsLiveActivityService(
+                objectMapper = JsonMapper.builder().build(),
+                enabled = false,
+                teamId = "",
+                keyId = "",
+                bundleId = "net.jaram.hyuabot",
+                privateKeyPem = "",
+                configuredBaseUrl = "http://127.0.0.1:1",
+            )
+
+        service.sendUpdate("token", "development", state(), Instant.parse("2026-06-21T00:10:00Z"))
+        service.sendEnd("token", "development", state())
+    }
+
+    @Test
+    @DisplayName("Configured APNs sender posts Live Activity update and end payloads")
+    fun configuredSender() {
+        val received = mutableListOf<ReceivedRequest>()
+        val server =
+            HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+                createContext("/3/device/token") { exchange ->
+                    received.add(
+                        ReceivedRequest(
+                            topic = exchange.requestHeaders.getFirst("apns-topic"),
+                            pushType = exchange.requestHeaders.getFirst("apns-push-type"),
+                            priority = exchange.requestHeaders.getFirst("apns-priority"),
+                            authorization = exchange.requestHeaders.getFirst("authorization"),
+                            body = exchange.requestBody.bufferedReader().readText(),
+                        ),
+                    )
+                    exchange.sendResponseHeaders(200, 0)
+                    exchange.responseBody.close()
+                }
+                start()
+            }
+        try {
+            val service = configuredService("http://127.0.0.1:${server.address.port}")
+
+            service.sendUpdate("token", "development", state(), Instant.parse("2026-06-21T00:10:00Z"))
+            service.sendEnd("token", "production", state())
+
+            assertEquals(2, received.size)
+            assertTrue(received.all { it.topic == "net.jaram.hyuabot.push-type.liveactivity" })
+            assertTrue(received.all { it.pushType == "liveactivity" })
+            assertTrue(received.all { it.priority == "10" })
+            assertTrue(received.all { it.authorization.startsWith("bearer ") })
+            assertTrue(received[0].body.contains("\"event\":\"update\""))
+            assertTrue(received[0].body.contains("\"stale-date\":1782000600"))
+            assertTrue(received[1].body.contains("\"event\":\"end\""))
+            assertTrue(received[1].body.contains("\"dismissal-date\""))
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    @DisplayName("APNs sender handles failed responses")
+    fun failedResponse() {
+        val server =
+            HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+                createContext("/3/device/token") { exchange ->
+                    val bytes = "failed".toByteArray()
+                    exchange.sendResponseHeaders(500, bytes.size.toLong())
+                    exchange.responseBody.write(bytes)
+                    exchange.responseBody.close()
+                }
+                start()
+            }
+        try {
+            configuredService("http://127.0.0.1:${server.address.port}")
+                .sendUpdate("token", "development", state(), Instant.parse("2026-06-21T00:10:00Z"))
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    @DisplayName("DER long length parser skips extended length bytes")
+    fun derLongLengthParser() {
+        val service = configuredService("http://127.0.0.1:1")
+        val method =
+            ApnsLiveActivityService::class.java.getDeclaredMethod(
+                "skipDerLength",
+                ByteArray::class.java,
+                Int::class.javaPrimitiveType,
+            )
+        method.isAccessible = true
+
+        assertEquals(3, method.invoke(service, byteArrayOf(0, 0x81.toByte(), 0), 1))
+    }
+
+    @Test
+    @DisplayName("APNs endpoint is selected from token environment")
+    fun endpointFromEnvironment() {
+        val service = configuredService("")
+        val method =
+            ApnsLiveActivityService::class.java.getDeclaredMethod(
+                "baseUrl",
+                String::class.java,
+            )
+        method.isAccessible = true
+
+        assertEquals("https://api.sandbox.push.apple.com", method.invoke(service, "development"))
+        assertEquals("https://api.sandbox.push.apple.com", method.invoke(service, "sandbox"))
+        assertEquals("https://api.push.apple.com", method.invoke(service, "production"))
+        assertEquals("https://api.push.apple.com", method.invoke(service, "unknown"))
+    }
+
+    private fun configuredService(baseUrl: String): ApnsLiveActivityService =
+        ApnsLiveActivityService(
+            objectMapper = JsonMapper.builder().build(),
+            enabled = true,
+            teamId = "TEAMID",
+            keyId = "KEYID",
+            bundleId = "net.jaram.hyuabot",
+            privateKeyPem = privateKeyPem(),
+            configuredBaseUrl = baseUrl,
+        )
+
+    private fun privateKeyPem(): String {
+        val keyPair = KeyPairGenerator.getInstance("EC").apply { initialize(256) }.generateKeyPair()
+        return Base64.getEncoder().encodeToString(keyPair.private.encoded)
+    }
+
+    private fun state() =
+        ShuttleLiveActivityState(
+            titleText = "title",
+            statusText = "status",
+            dynamicIslandStatusText = "island",
+            currentStopName = "current",
+            nextStopName = "next",
+            checkpointStopNames = listOf("current", "next"),
+            checkpointTimes = listOf(1.0, 2.0),
+            checkpointWaitingFormat = "%s waiting",
+            checkpointApproachingFormat = "%s approaching",
+            checkpointDepartedFormat = "%s departed",
+            progress = 50,
+            progressSegments = listOf(100),
+        )
+
+    private data class ReceivedRequest(
+        val topic: String,
+        val pushType: String,
+        val priority: String,
+        val authorization: String,
+        val body: String,
+    )
+}

--- a/src/test/kotlin/app/hyuabot/backend/liveactivity/ApnsLiveActivityServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/liveactivity/ApnsLiveActivityServiceTest.kt
@@ -6,30 +6,39 @@ import com.sun.net.httpserver.HttpServer
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import tools.jackson.databind.json.JsonMapper
+import java.lang.reflect.InvocationTargetException
 import java.net.InetSocketAddress
 import java.security.KeyPairGenerator
 import java.time.Instant
 import java.util.Base64
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class ApnsLiveActivityServiceTest {
     @Test
     @DisplayName("Disabled APNs sender skips network calls")
     fun disabledSender() {
-        val service =
-            ApnsLiveActivityService(
-                objectMapper = JsonMapper.builder().build(),
-                enabled = false,
-                teamId = "",
-                keyId = "",
-                bundleId = "net.jaram.hyuabot",
-                privateKeyPem = "",
-                configuredBaseUrl = "http://127.0.0.1:1",
-            )
+        val service = service(enabled = false, teamId = "", keyId = "", privateKeyPem = "")
 
         service.sendUpdate("token", "development", state(), Instant.parse("2026-06-21T00:10:00Z"))
         service.sendEnd("token", "development", state())
+    }
+
+    @Test
+    @DisplayName("APNs sender skips network calls when required credentials are blank")
+    fun blankCredentialSender() {
+        val services =
+            listOf(
+                service(teamId = ""),
+                service(keyId = ""),
+                service(privateKeyPem = ""),
+            )
+
+        services.forEach {
+            it.sendUpdate("token", "development", state(), Instant.parse("2026-06-21T00:10:00Z"))
+            it.sendEnd("token", "development", state())
+        }
     }
 
     @Test
@@ -110,6 +119,45 @@ class ApnsLiveActivityServiceTest {
     }
 
     @Test
+    @DisplayName("APNs status code success range is bounded")
+    fun statusCodeSuccessRange() {
+        val service = configuredService("http://127.0.0.1:1")
+        val method =
+            ApnsLiveActivityService::class.java.getDeclaredMethod(
+                "isSuccessfulStatus",
+                Int::class.javaPrimitiveType,
+            )
+        method.isAccessible = true
+
+        assertEquals(false, method.invoke(service, 199))
+        assertEquals(true, method.invoke(service, 200))
+        assertEquals(true, method.invoke(service, 299))
+        assertEquals(false, method.invoke(service, 300))
+    }
+
+    @Test
+    @DisplayName("DER parser rejects invalid sequence and integer markers")
+    fun invalidDerParser() {
+        val service = configuredService("http://127.0.0.1:1")
+        val method =
+            ApnsLiveActivityService::class.java.getDeclaredMethod(
+                "derToJose",
+                ByteArray::class.java,
+            )
+        method.isAccessible = true
+
+        listOf(
+            byteArrayOf(0x31, 0),
+            byteArrayOf(0x30, 0x06, 0x03),
+            byteArrayOf(0x30, 0x06, 0x02, 0x01, 0x01, 0x03),
+        ).forEach {
+            assertFailsWith<InvocationTargetException> {
+                method.invoke(service, it)
+            }
+        }
+    }
+
+    @Test
     @DisplayName("APNs endpoint is selected from token environment")
     fun endpointFromEnvironment() {
         val service = configuredService("")
@@ -126,15 +174,23 @@ class ApnsLiveActivityServiceTest {
         assertEquals("https://api.push.apple.com", method.invoke(service, "unknown"))
     }
 
-    private fun configuredService(baseUrl: String): ApnsLiveActivityService =
+    private fun configuredService(baseUrl: String): ApnsLiveActivityService = service(configuredBaseUrl = baseUrl)
+
+    private fun service(
+        enabled: Boolean = true,
+        teamId: String = "TEAMID",
+        keyId: String = "KEYID",
+        privateKeyPem: String = privateKeyPem(),
+        configuredBaseUrl: String = "http://127.0.0.1:1",
+    ): ApnsLiveActivityService =
         ApnsLiveActivityService(
             objectMapper = JsonMapper.builder().build(),
-            enabled = true,
-            teamId = "TEAMID",
-            keyId = "KEYID",
+            enabled = enabled,
+            teamId = teamId,
+            keyId = keyId,
             bundleId = "net.jaram.hyuabot",
-            privateKeyPem = privateKeyPem(),
-            configuredBaseUrl = baseUrl,
+            privateKeyPem = privateKeyPem,
+            configuredBaseUrl = configuredBaseUrl,
         )
 
     private fun privateKeyPem(): String {

--- a/src/test/kotlin/app/hyuabot/backend/liveactivity/ShuttleLiveActivityControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/liveactivity/ShuttleLiveActivityControllerTest.kt
@@ -1,0 +1,85 @@
+package app.hyuabot.backend.liveactivity
+
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityCheckpointRequest
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityRegisterRequest
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityRegisterResponse
+import app.hyuabot.backend.liveactivity.service.ShuttleLiveActivityService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import tools.jackson.databind.ObjectMapper
+import java.time.Instant
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ShuttleLiveActivityControllerTest {
+    @MockitoBean
+    private lateinit var service: ShuttleLiveActivityService
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    @DisplayName("Register Live Activity push token")
+    fun register() {
+        val request = registerRequest()
+        doReturn(ShuttleLiveActivityRegisterResponse("key", 3)).whenever(service).register(request)
+
+        mockMvc
+            .perform(
+                post("/api/v1/live-activity/shuttle")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.key").value("key"))
+            .andExpect(jsonPath("$.scheduledPushCount").value(3))
+    }
+
+    @Test
+    @DisplayName("Unregister Live Activity push token")
+    fun unregister() {
+        mockMvc
+            .perform(delete("/api/v1/live-activity/shuttle/key"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("Live Activity registration removed."))
+
+        verify(service).unregister("key")
+    }
+
+    private fun registerRequest() =
+        ShuttleLiveActivityRegisterRequest(
+            key = "key",
+            pushToken = "token",
+            apnsEnvironment = "development",
+            alarmKind = "boarding",
+            titleText = "title",
+            statusText = "status",
+            dynamicIslandStatusText = "island",
+            currentStopName = "current",
+            nextStopName = "next",
+            checkpointWaitingFormat = "%s waiting",
+            checkpointApproachingFormat = "%s approaching",
+            checkpointDepartedFormat = "%s departed",
+            progressSegments = listOf(100),
+            createdAt = Instant.parse("2026-06-21T00:00:00Z"),
+            expiresAt = Instant.parse("2026-06-21T00:10:00Z"),
+            checkpoints = listOf(ShuttleLiveActivityCheckpointRequest("current", Instant.parse("2026-06-21T00:00:00Z"))),
+        )
+}

--- a/src/test/kotlin/app/hyuabot/backend/liveactivity/ShuttleLiveActivityServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/liveactivity/ShuttleLiveActivityServiceTest.kt
@@ -1,0 +1,120 @@
+package app.hyuabot.backend.liveactivity
+
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityCheckpointRequest
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityRegisterRequest
+import app.hyuabot.backend.liveactivity.service.ApnsLiveActivityService
+import app.hyuabot.backend.liveactivity.service.ShuttleLiveActivityService
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import org.springframework.scheduling.TaskScheduler
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ScheduledFuture
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class ShuttleLiveActivityServiceTest {
+    @Test
+    @DisplayName("Register stores token, schedules pushes, and sends initial update")
+    fun register() {
+        val valueOperations = mock<ValueOperations<String, String>>()
+        val redisTemplate = mock<RedisTemplate<String, String>>()
+        val scheduler = mock<TaskScheduler>()
+        val apns = mock<ApnsLiveActivityService>()
+        val future = mock<ScheduledFuture<*>>()
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
+        whenever(scheduler.schedule(any<Runnable>(), any<Instant>())).thenReturn(future)
+        val service = ShuttleLiveActivityService(redisTemplate, scheduler, apns)
+        val request = registerRequest()
+
+        val response = service.register(request)
+        val scheduledRunnable = argumentCaptor<Runnable>()
+        verify(scheduler, atLeastOnce()).schedule(scheduledRunnable.capture(), any<Instant>())
+        scheduledRunnable.firstValue.run()
+
+        assertEquals("key", response.key)
+        assertEquals(10, response.scheduledPushCount)
+        verify(valueOperations).set(
+            eq("live-activity:shuttle:key"),
+            eq("token"),
+            any<Duration>(),
+        )
+        verify(apns, org.mockito.kotlin.times(2)).sendUpdate(eq("token"), eq("development"), any(), eq(request.expiresAt))
+    }
+
+    @Test
+    @DisplayName("Unregister cancels scheduled pushes and removes Redis key")
+    fun unregister() {
+        val redisTemplate = mock<RedisTemplate<String, String>>()
+        val scheduler = mock<TaskScheduler>()
+        val apns = mock<ApnsLiveActivityService>()
+        val future =
+            mock<ScheduledFuture<*>> {
+                on { cancel(false) } doReturn true
+            }
+        whenever(scheduler.schedule(any<Runnable>(), any<Instant>())).thenReturn(future)
+        whenever(redisTemplate.opsForValue()).thenReturn(mock())
+        val service = ShuttleLiveActivityService(redisTemplate, scheduler, apns)
+
+        service.register(registerRequest())
+        service.unregister("key")
+
+        verify(future, atLeastOnce()).cancel(false)
+        verify(redisTemplate, atLeastOnce()).delete("live-activity:shuttle:key")
+    }
+
+    @Test
+    @DisplayName("End unregisters and sends final APNs event")
+    fun end() {
+        val redisTemplate = mock<RedisTemplate<String, String>>()
+        val apns = mock<ApnsLiveActivityService>()
+        val service =
+            ShuttleLiveActivityService(
+                redisTemplate = redisTemplate,
+                taskScheduler = mock(),
+                apnsLiveActivityService = apns,
+            )
+        val request = registerRequest()
+
+        service.end(request)
+
+        verify(redisTemplate).delete("live-activity:shuttle:key")
+        verify(apns).sendEnd(eq("token"), eq("development"), any())
+    }
+
+    private fun registerRequest() =
+        ShuttleLiveActivityRegisterRequest(
+            key = "key",
+            pushToken = "token",
+            apnsEnvironment = "development",
+            alarmKind = "boarding",
+            titleText = "title",
+            statusText = "status",
+            dynamicIslandStatusText = "island",
+            currentStopName = "current",
+            nextStopName = "next",
+            checkpointWaitingFormat = "%s waiting",
+            checkpointApproachingFormat = "%s approaching",
+            checkpointDepartedFormat = "%s departed",
+            progressSegments = listOf(50, 50),
+            createdAt = Instant.now().minusSeconds(60),
+            expiresAt = Instant.now().plusSeconds(30),
+            checkpoints =
+                listOf(
+                    ShuttleLiveActivityCheckpointRequest("current", Instant.now().plusSeconds(10)),
+                    ShuttleLiveActivityCheckpointRequest("next", Instant.now().plusSeconds(20)),
+                ),
+        )
+}

--- a/src/test/kotlin/app/hyuabot/backend/liveactivity/ShuttleLiveActivityStateTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/liveactivity/ShuttleLiveActivityStateTest.kt
@@ -1,0 +1,93 @@
+package app.hyuabot.backend.liveactivity
+
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityCheckpointRequest
+import app.hyuabot.backend.liveactivity.domain.ShuttleLiveActivityRegisterRequest
+import app.hyuabot.backend.liveactivity.domain.toState
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class ShuttleLiveActivityStateTest {
+    @Test
+    @DisplayName("Checkpoint state uses checkpoint progress and Apple reference date seconds")
+    fun checkpointState() {
+        val request =
+            registerRequest(
+                checkpoints =
+                    listOf(
+                        ShuttleLiveActivityCheckpointRequest("Start", Instant.parse("2026-06-21T00:00:00Z")),
+                        ShuttleLiveActivityCheckpointRequest("End", Instant.parse("2026-06-21T00:10:00Z")),
+                    ),
+                progressSegments = listOf(100),
+            )
+
+        val state = request.toState(Instant.parse("2026-06-21T00:05:00Z"))
+
+        assertEquals(50, state.progress)
+        assertEquals(listOf("Start", "End"), state.checkpointStopNames)
+        assertEquals(803_692_800.0, state.checkpointTimes.first())
+        assertEquals(listOf(100), state.progressSegments)
+    }
+
+    @Test
+    @DisplayName("Single checkpoint state uses created and expiration dates for fallback progress")
+    fun fallbackState() {
+        val request =
+            registerRequest(
+                checkpoints = listOf(ShuttleLiveActivityCheckpointRequest("Only", Instant.parse("2026-06-21T00:00:00Z"))),
+                progressSegments = emptyList(),
+            )
+
+        val state = request.toState(Instant.parse("2026-06-21T00:05:00Z"))
+
+        assertEquals(50, state.progress)
+        assertEquals(listOf(100), state.progressSegments)
+    }
+
+    @Test
+    @DisplayName("Invalid durations clamp to completion or zero")
+    fun invalidDurations() {
+        val fallback =
+            registerRequest(
+                createdAt = Instant.parse("2026-06-21T00:10:00Z"),
+                expiresAt = Instant.parse("2026-06-21T00:00:00Z"),
+                checkpoints = emptyList(),
+            ).toState(Instant.parse("2026-06-21T00:05:00Z"))
+        val checkpoint =
+            registerRequest(
+                checkpoints =
+                    listOf(
+                        ShuttleLiveActivityCheckpointRequest("Start", Instant.parse("2026-06-21T00:00:00Z")),
+                        ShuttleLiveActivityCheckpointRequest("End", Instant.parse("2026-06-21T00:00:00Z")),
+                    ),
+            ).toState(Instant.parse("2026-06-21T00:05:00Z"))
+
+        assertEquals(100, fallback.progress)
+        assertEquals(0, checkpoint.progress)
+    }
+
+    private fun registerRequest(
+        createdAt: Instant = Instant.parse("2026-06-21T00:00:00Z"),
+        expiresAt: Instant = Instant.parse("2026-06-21T00:10:00Z"),
+        checkpoints: List<ShuttleLiveActivityCheckpointRequest>,
+        progressSegments: List<Int> = listOf(100),
+    ) = ShuttleLiveActivityRegisterRequest(
+        key = "key",
+        pushToken = "token",
+        apnsEnvironment = "development",
+        alarmKind = "boarding",
+        titleText = "title",
+        statusText = "status",
+        dynamicIslandStatusText = "island",
+        currentStopName = "current",
+        nextStopName = "next",
+        checkpointWaitingFormat = "%s waiting",
+        checkpointApproachingFormat = "%s approaching",
+        checkpointDepartedFormat = "%s departed",
+        progressSegments = progressSegments,
+        createdAt = createdAt,
+        expiresAt = expiresAt,
+        checkpoints = checkpoints,
+    )
+}

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
@@ -841,6 +841,144 @@ class SubwayDataFetcherTest {
     }
 
     @Test
+    @DisplayName("전철 도착 정보 조회 - 실시간 없이 시간표만 있으면 그대로 반환")
+    fun testSubwayArrivalKeepsTimetableWhenRealtimeIsEmpty() {
+        whenever(publicHolidayService.findPublicHoliday(any())).thenReturn(null)
+        whenever(subwayService.getStationViews(listOf(station.id))).thenReturn(listOf(createStationView()))
+        whenever(
+            subwayService.getArrival(
+                eq(station.id),
+                directions = eq(listOf("up", "0")),
+                weekday = eq("weekdays"),
+                limit = isNull(),
+                currentTime = any(),
+            ),
+        ).thenReturn(
+            listOf(
+                SubwayArrivalGroup(
+                    direction = "up",
+                    entries =
+                        listOf(
+                            SubwayArrival(
+                                minutes = 6,
+                                terminal = SubwayOriginTerminal(stationID = terminalStation.id, name = terminalStation.name),
+                                isRealtime = false,
+                            ),
+                            SubwayArrival(
+                                minutes = 16,
+                                terminal = SubwayOriginTerminal(stationID = terminalStation.id, name = terminalStation.name),
+                                isRealtime = false,
+                            ),
+                        ),
+                ),
+            ),
+        )
+
+        val result =
+            dgsQueryExecutor.executeAndExtractJsonPath<List<Map<String, Any>>>(
+                """
+                {
+                    subway(input: {
+                        keys: [{
+                            stationID: "K449",
+                            direction: ["up"],
+                            weekdays: ["weekdays"],
+                            limit: 10
+                        }],
+                    }) {
+                        arrival {
+                            entries {
+                                minutes
+                                isRealtime
+                            }
+                        }
+                    }
+                }
+                """.trimIndent(),
+                "data.subway",
+            )
+
+        val arrival = result[0]["arrival"] as List<*>
+        val group = arrival[0] as Map<*, *>
+        val entries = group["entries"] as List<*>
+        val first = entries[0] as Map<*, *>
+        val second = entries[1] as Map<*, *>
+        assertEquals(2, entries.size)
+        assertEquals(6, first["minutes"])
+        assertEquals(false, first["isRealtime"])
+        assertEquals(16, second["minutes"])
+        assertEquals(false, second["isRealtime"])
+    }
+
+    @Test
+    @DisplayName("전철 도착 정보 필터 - 실시간이 없으면 원본 목록 반환")
+    fun testFilterKeepsTimetableWhenRealtimeIsEmpty() {
+        val fetcher = SubwayDataFetcher(subwayService, publicHolidayService)
+        val method =
+            SubwayDataFetcher::class.java.getDeclaredMethod(
+                "filterTimetableAfterRealtime",
+                List::class.java,
+            )
+        method.isAccessible = true
+        val entries =
+            listOf(
+                SubwayArrival(
+                    minutes = 6,
+                    terminal = SubwayOriginTerminal(stationID = terminalStation.id, name = terminalStation.name),
+                    isRealtime = false,
+                ),
+                SubwayArrival(
+                    minutes = 16,
+                    terminal = SubwayOriginTerminal(stationID = terminalStation.id, name = terminalStation.name),
+                    isRealtime = false,
+                ),
+            )
+
+        assertEquals(entries, method.invoke(fetcher, entries))
+    }
+
+    @Test
+    @DisplayName("전철 도착 정보 필터 - 첫 실시간 값이 최대여도 시간표 간격 적용")
+    fun testFilterUsesFirstRealtimeWhenItIsMaximum() {
+        val fetcher = SubwayDataFetcher(subwayService, publicHolidayService)
+        val method =
+            SubwayDataFetcher::class.java.getDeclaredMethod(
+                "filterTimetableAfterRealtime",
+                List::class.java,
+            )
+        method.isAccessible = true
+        val entries =
+            listOf(
+                SubwayArrival(
+                    minutes = 16,
+                    terminal = SubwayOriginTerminal(stationID = terminalStation.id, name = terminalStation.name),
+                    isRealtime = true,
+                    location = "정왕",
+                ),
+                SubwayArrival(
+                    minutes = 7,
+                    terminal = SubwayOriginTerminal(stationID = terminalStation.id, name = terminalStation.name),
+                    isRealtime = true,
+                    location = "초지",
+                ),
+                SubwayArrival(
+                    minutes = 20,
+                    terminal = SubwayOriginTerminal(stationID = terminalStation.id, name = terminalStation.name),
+                    isRealtime = false,
+                ),
+                SubwayArrival(
+                    minutes = 21,
+                    terminal = SubwayOriginTerminal(stationID = terminalStation.id, name = terminalStation.name),
+                    isRealtime = false,
+                ),
+            )
+
+        val result = method.invoke(fetcher, entries) as List<*>
+
+        assertEquals(listOf(entries[0], entries[1], entries[3]), result)
+    }
+
+    @Test
     @DisplayName("전철 도착 정보 조회 (여러 요일 필터링)")
     fun testSubwayMultipleWeekdayFilter() {
         whenever(subwayService.getStationViews(listOf(station.id))).thenReturn(listOf(createStationView()))


### PR DESCRIPTION
## Summary
- Add unauthenticated shuttle Live Activity token registration and deletion endpoints.
- Store Live Activity push tokens with Redis TTL and schedule checkpoint-based APNs updates.
- Add APNs Live Activity provider-token signing and update/end payload delivery.
- Select the APNs development or production endpoint per registered token environment.
- Add focused coverage for state calculation, APNs payloads, environment routing, scheduling, and controller behavior.

## Root Cause
Live Activity state updates were driven by the iOS app process. When the app moved to the background or was suspended, checkpoint state and progress could stop updating until the app was opened again. ActivityKit needs remote Live Activity pushes for reliable lock screen updates while the app is not active.

## Validation
- `./gradlew ktlintCheck test jacocoTestReport jacocoTestCoverageVerification`
- JaCoCo line coverage: 8033/8033 included lines at 100%.
