### PR TITLE
fix: Shuttle period lookup at transition boundaries

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/database/repository/ShuttlePeriodRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/ShuttlePeriodRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.time.ZonedDateTime
 
 interface ShuttlePeriodRepository : JpaRepository<ShuttlePeriod, Int> {
-    fun findByStartBeforeAndEndAfter(
+    fun findFirstByStartBeforeAndEndAfterOrderByStartDesc(
         start: ZonedDateTime,
         end: ZonedDateTime,
     ): ShuttlePeriod?

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/service/ShuttlePeriodService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/service/ShuttlePeriodService.kt
@@ -104,8 +104,8 @@ class ShuttlePeriodService(
     }
 
     fun findShuttlePeriod(dateTime: LocalDate): ShuttlePeriod? =
-        shuttlePeriodRepository.findByStartBeforeAndEndAfter(
-            ZonedDateTime.of(dateTime, LocalTime.MIN, LocalDateTimeBuilder.serviceTimezone),
+        shuttlePeriodRepository.findFirstByStartBeforeAndEndAfterOrderByStartDesc(
+            ZonedDateTime.of(dateTime, LocalTime.MAX, LocalDateTimeBuilder.serviceTimezone),
             ZonedDateTime.of(dateTime, LocalTime.MIN, LocalDateTimeBuilder.serviceTimezone),
         )
 }

--- a/src/test/kotlin/app/hyuabot/backend/database/repository/ShuttleRepositoryTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/database/repository/ShuttleRepositoryTest.kt
@@ -237,7 +237,7 @@ class ShuttleRepositoryTest {
     @DisplayName("현재 시간 기준으로 학기/계절학기/방학 기간 조회")
     fun testCurrentPeriods() {
         val currentTime = ZonedDateTime.parse("2025-03-15T12:00:00+09:00")
-        val currentPeriods = periodRepository.findByStartBeforeAndEndAfter(currentTime, currentTime)
+        val currentPeriods = periodRepository.findFirstByStartBeforeAndEndAfterOrderByStartDesc(currentTime, currentTime)
         assert(currentPeriods != null)
         currentPeriods?.let {
             assert(it.seq != null)

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttlePeriodServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttlePeriodServiceTest.kt
@@ -293,8 +293,8 @@ class ShuttlePeriodServiceTest {
     fun findShuttlePeriodTest() {
         val date = LocalDate.parse("2025-09-01")
         whenever(
-            shuttlePeriodRepository.findByStartBeforeAndEndAfter(
-                ZonedDateTime.of(date, LocalTime.MIN, LocalDateTimeBuilder.serviceTimezone),
+            shuttlePeriodRepository.findFirstByStartBeforeAndEndAfterOrderByStartDesc(
+                ZonedDateTime.of(date, LocalTime.MAX, LocalDateTimeBuilder.serviceTimezone),
                 ZonedDateTime.of(date, LocalTime.MIN, LocalDateTimeBuilder.serviceTimezone),
             ),
         ).thenReturn(
@@ -311,5 +311,30 @@ class ShuttlePeriodServiceTest {
         assertEquals("semester", result?.type)
         assertEquals(ZonedDateTime.parse("2025-09-01T00:00:00.000+09:00"), result?.start)
         assertEquals(ZonedDateTime.parse("2025-12-23T23:59:59.999+09:00"), result?.end)
+    }
+
+    @Test
+    @DisplayName("셔틀버스 운행 기간 검색 테스트 (기간이 자정에 시작하는 전환일)")
+    fun findShuttlePeriodMidnightTransitionDateTest() {
+        val date = LocalDate.parse("2026-06-24")
+        whenever(
+            shuttlePeriodRepository.findFirstByStartBeforeAndEndAfterOrderByStartDesc(
+                ZonedDateTime.of(date, LocalTime.MAX, LocalDateTimeBuilder.serviceTimezone),
+                ZonedDateTime.of(date, LocalTime.MIN, LocalDateTimeBuilder.serviceTimezone),
+            ),
+        ).thenReturn(
+            ShuttlePeriod(
+                seq = 11,
+                start = ZonedDateTime.parse("2026-06-24T00:00:00.000+09:00"),
+                end = ZonedDateTime.parse("2026-07-14T23:59:00.999+09:00"),
+                type = "vacation_session",
+                periodType = null,
+            ),
+        )
+
+        val result = shuttlePeriodService.findShuttlePeriod(date)
+
+        assertEquals(11, result?.seq)
+        assertEquals("vacation_session", result?.type)
     }
 }


### PR DESCRIPTION
## Summary
- Fix shuttle period lookup so periods starting exactly at midnight in the service timezone are included.
- Prefer the latest-starting matching shuttle period when multiple period rows can match a date.
- Add regression coverage for the 2026-06-24 vacation session transition boundary.

## Root Cause
The backend resolved an input date to 00:00 in the service timezone and queried period_start < 00:00 and period_end > 00:00. A vacation session starting exactly at 2026-06-24 00:00 KST was excluded by the strict start-bound comparison, so clients without an explicit period could receive no shuttle timetable data.

## Validation
- `./gradlew test --tests app.hyuabot.backend.shuttle.ShuttlePeriodServiceTest`
- `./gradlew test --tests app.hyuabot.backend.database.repository.ShuttleRepositoryTest`
- `./gradlew test --tests 'app.hyuabot.backend.shuttle.*'`
