### PR TITLE
Add shuttle service notices

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/database/repository/ShuttlePeriodRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/ShuttlePeriodRepository.kt
@@ -9,4 +9,9 @@ interface ShuttlePeriodRepository : JpaRepository<ShuttlePeriod, Int> {
         start: ZonedDateTime,
         end: ZonedDateTime,
     ): ShuttlePeriod?
+
+    fun findByStartBetweenOrderByStartAsc(
+        start: ZonedDateTime,
+        end: ZonedDateTime,
+    ): List<ShuttlePeriod>
 }

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleDataFetcher.kt
@@ -7,6 +7,7 @@ import app.hyuabot.backend.codegen.types.ShuttleInput
 import app.hyuabot.backend.codegen.types.ShuttleLimitInput
 import app.hyuabot.backend.codegen.types.ShuttlePeriod
 import app.hyuabot.backend.codegen.types.ShuttleRoute
+import app.hyuabot.backend.codegen.types.ShuttleServiceNotice
 import app.hyuabot.backend.codegen.types.ShuttleStop
 import app.hyuabot.backend.codegen.types.ShuttleTimetable
 import app.hyuabot.backend.codegen.types.ShuttleTimetableEntry
@@ -56,6 +57,7 @@ class ShuttleDataFetcher(
         return Shuttle(
             period = null,
             holiday = null,
+            serviceNotices = emptyList(),
             stops = emptyList(),
         )
     }
@@ -85,6 +87,47 @@ class ShuttleDataFetcher(
                 calendar = it.calendarType,
             )
         }
+    }
+
+    @DgsData(parentType = "Shuttle")
+    fun serviceNotices(
+        @InputArgument start: LocalDate,
+        @InputArgument end: LocalDate,
+    ): List<ShuttleServiceNotice> {
+        require(!start.isAfter(end)) { "Start date must be before or equal to end date" }
+        val periodNotices =
+            periodService.findShuttlePeriodsStartingBetween(start, end).map {
+                ShuttleServiceNotice(
+                    id = "period:${it.seq}:${it.start.toLocalDate()}",
+                    kind = "period",
+                    date = it.start.toLocalDate(),
+                    period =
+                        ShuttlePeriod(
+                            seq = it.seq!!,
+                            start = it.start.withZoneSameInstant(LocalDateTimeBuilder.serviceTimezone),
+                            end = it.end.withZoneSameInstant(LocalDateTimeBuilder.serviceTimezone),
+                            type = it.type,
+                        ),
+                    holiday = null,
+                )
+            }
+        val holidayNotices =
+            holidayService.findShuttleHolidayOccurrences(start, end).map {
+                ShuttleServiceNotice(
+                    id = "holiday:${it.holiday.seq}:${it.date}",
+                    kind = "holiday",
+                    date = it.date,
+                    period = null,
+                    holiday =
+                        ShuttleHoliday(
+                            seq = it.holiday.seq!!,
+                            date = it.holiday.date,
+                            type = it.holiday.type,
+                            calendar = it.holiday.calendarType,
+                        ),
+                )
+            }
+        return (periodNotices + holidayNotices).sortedWith(compareBy({ it.date }, { it.id }))
     }
 
     @DgsData(parentType = "Shuttle")

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/domain/ShuttleHolidayOccurrence.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/domain/ShuttleHolidayOccurrence.kt
@@ -1,0 +1,9 @@
+package app.hyuabot.backend.shuttle.domain
+
+import app.hyuabot.backend.database.entity.ShuttleHoliday
+import java.time.LocalDate
+
+data class ShuttleHolidayOccurrence(
+    val date: LocalDate,
+    val holiday: ShuttleHoliday,
+)

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/service/ShuttleHolidayService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/service/ShuttleHolidayService.kt
@@ -3,6 +3,7 @@ package app.hyuabot.backend.shuttle.service
 import app.hyuabot.backend.database.entity.ShuttleHoliday
 import app.hyuabot.backend.database.exception.LocalDateNotValidException
 import app.hyuabot.backend.database.repository.ShuttleHolidayRepository
+import app.hyuabot.backend.shuttle.domain.ShuttleHolidayOccurrence
 import app.hyuabot.backend.shuttle.domain.ShuttleHolidayRequest
 import app.hyuabot.backend.shuttle.exception.DuplicateShuttleHolidayException
 import app.hyuabot.backend.shuttle.exception.ShuttleHolidayNotFoundException
@@ -79,5 +80,22 @@ class ShuttleHolidayService(
             date,
             LocalDate.parse(lunarDate.lunarIsoFormat, dateFormatter),
         )
+    }
+
+    fun findShuttleHolidayOccurrences(
+        start: LocalDate,
+        end: LocalDate,
+    ): List<ShuttleHolidayOccurrence> {
+        require(!start.isAfter(end)) { "Start date must be before or equal to end date" }
+        return generateSequence(start) { date -> date.plusDays(1) }
+            .takeWhile { date -> !date.isAfter(end) }
+            .mapNotNull { date ->
+                findShuttleHoliday(date)?.let { holiday ->
+                    ShuttleHolidayOccurrence(
+                        date = date,
+                        holiday = holiday,
+                    )
+                }
+            }.toList()
     }
 }

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/service/ShuttlePeriodService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/service/ShuttlePeriodService.kt
@@ -108,4 +108,15 @@ class ShuttlePeriodService(
             ZonedDateTime.of(dateTime, LocalTime.MAX, LocalDateTimeBuilder.serviceTimezone),
             ZonedDateTime.of(dateTime, LocalTime.MIN, LocalDateTimeBuilder.serviceTimezone),
         )
+
+    fun findShuttlePeriodsStartingBetween(
+        start: LocalDate,
+        end: LocalDate,
+    ): List<ShuttlePeriod> {
+        require(!start.isAfter(end)) { "Start date must be before or equal to end date" }
+        return shuttlePeriodRepository.findByStartBetweenOrderByStartAsc(
+            ZonedDateTime.of(start, LocalTime.MIN, LocalDateTimeBuilder.serviceTimezone),
+            ZonedDateTime.of(end, LocalTime.MAX, LocalDateTimeBuilder.serviceTimezone),
+        )
+    }
 }

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -384,7 +384,16 @@ input ShuttleLimitInput {
 type Shuttle {
     period: ShuttlePeriod
     holiday: ShuttleHoliday
+    serviceNotices(start: Date!, end: Date!): [ShuttleServiceNotice!]!
     stops: [ShuttleStop!]!
+}
+
+type ShuttleServiceNotice {
+    id: String!
+    kind: String!
+    date: Date!
+    period: ShuttlePeriod
+    holiday: ShuttleHoliday
 }
 
 type ShuttlePeriod {

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleDataFetcherTest.kt
@@ -7,6 +7,7 @@ import app.hyuabot.backend.database.entity.ShuttleStop
 import app.hyuabot.backend.shuttle.controller.ShuttleDataFetcher
 import app.hyuabot.backend.shuttle.controller.ShuttleTimetableDataLoader
 import app.hyuabot.backend.shuttle.domain.ShuttleArrivalItem
+import app.hyuabot.backend.shuttle.domain.ShuttleHolidayOccurrence
 import app.hyuabot.backend.shuttle.domain.ShuttleTimetableKey
 import app.hyuabot.backend.shuttle.domain.ShuttleTimetableResult
 import app.hyuabot.backend.shuttle.domain.ShuttleTimetableViewItem
@@ -313,6 +314,89 @@ class ShuttleDataFetcherTest {
                 }
             }
         }
+    }
+
+    @Test
+    @DisplayName("셔틀버스 운행 변경 알림 후보 조회")
+    fun testShuttleServiceNotices() {
+        val start = today
+        val end = today.plusDays(7)
+        whenever(periodService.findShuttlePeriodsStartingBetween(start, end)).thenReturn(
+            listOf(
+                createPeriod(
+                    seq = 2,
+                    type = "vacation",
+                    start = ZonedDateTime.parse("2026-03-26T00:00:00.000+09:00"),
+                    end = ZonedDateTime.parse("2026-04-30T23:59:59.999+09:00"),
+                ),
+            ),
+        )
+        whenever(holidayService.findShuttleHolidayOccurrences(start, end)).thenReturn(
+            listOf(
+                ShuttleHolidayOccurrence(
+                    date = today.plusDays(1),
+                    holiday =
+                        createHoliday(
+                            seq = 3,
+                            date = LocalDate.parse("2026-03-26"),
+                            type = "halt",
+                        ),
+                ),
+            ),
+        )
+
+        val result =
+            dgsQueryExecutor.executeAndExtractJsonPath<List<Map<String, Any>>>(
+                """
+                {
+                    shuttle(input: { date: "${dateFormatter.format(today)}" }) {
+                        serviceNotices(start: "${dateFormatter.format(start)}", end: "${dateFormatter.format(end)}") {
+                            id
+                            kind
+                            date
+                            period { seq, type, start, end }
+                            holiday { seq, date, type, calendar }
+                        }
+                    }
+                }
+                """.trimIndent(),
+                "data.shuttle.serviceNotices",
+            )
+
+        assertEquals(2, result.size)
+        assertEquals("holiday:3:2026-03-26", result[0]["id"])
+        assertEquals("holiday", result[0]["kind"])
+        assertEquals("2026-03-26", result[0]["date"])
+        val holiday = result[0]["holiday"] as Map<*, *>
+        assertEquals(3, holiday["seq"])
+        assertEquals("halt", holiday["type"])
+        assertEquals("solar", holiday["calendar"])
+
+        assertEquals("period:2:2026-03-26", result[1]["id"])
+        assertEquals("period", result[1]["kind"])
+        assertEquals("2026-03-26", result[1]["date"])
+        val period = result[1]["period"] as Map<*, *>
+        assertEquals(2, period["seq"])
+        assertEquals("vacation", period["type"])
+    }
+
+    @Test
+    @DisplayName("셔틀버스 운행 변경 알림 후보 조회 - 잘못된 범위")
+    fun testShuttleServiceNoticesInvalidRange() {
+        val result =
+            dgsQueryExecutor.execute(
+                """
+                {
+                    shuttle(input: { date: "${dateFormatter.format(today)}" }) {
+                        serviceNotices(start: "2026-04-01", end: "2026-03-01") {
+                            id
+                        }
+                    }
+                }
+                """.trimIndent(),
+            )
+
+        assert(result.errors.isNotEmpty())
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleHolidayServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleHolidayServiceTest.kt
@@ -320,4 +320,51 @@ class ShuttleHolidayServiceTest {
         assertEquals("solar", result?.calendarType)
         assertEquals("New Year's Day", result?.type)
     }
+
+    @Test
+    @DisplayName("셔틀 공휴일 발생일 범위 검색")
+    fun testFindShuttleHolidayOccurrences() {
+        val start = LocalDate.of(2026, 3, 1)
+        val end = LocalDate.of(2026, 3, 3)
+        val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        listOf(start, start.plusDays(1), start.plusDays(2)).forEach { date ->
+            val lunarDate = KoreanLunarCalendar.getInstance()
+            lunarDate.setSolarDate(date.year, date.monthValue, date.dayOfMonth)
+            whenever(
+                repository.findBySolarDateOrLunarDate(
+                    date,
+                    LocalDate.parse(lunarDate.lunarIsoFormat, dateFormat),
+                ),
+            ).thenReturn(
+                if (date == start.plusDays(1)) {
+                    ShuttleHoliday(
+                        seq = 2,
+                        date = date,
+                        calendarType = "solar",
+                        type = "halt",
+                    )
+                } else {
+                    null
+                },
+            )
+        }
+
+        val result = service.findShuttleHolidayOccurrences(start, end)
+
+        assertEquals(1, result.size)
+        assertEquals(start.plusDays(1), result[0].date)
+        assertEquals(2, result[0].holiday.seq)
+        assertEquals("halt", result[0].holiday.type)
+    }
+
+    @Test
+    @DisplayName("셔틀 공휴일 발생일 범위 검색 - 잘못된 범위")
+    fun testFindShuttleHolidayOccurrencesInvalidRange() {
+        assertThrows<IllegalArgumentException> {
+            service.findShuttleHolidayOccurrences(
+                LocalDate.of(2026, 3, 3),
+                LocalDate.of(2026, 3, 1),
+            )
+        }
+    }
 }

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttlePeriodServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttlePeriodServiceTest.kt
@@ -337,4 +337,43 @@ class ShuttlePeriodServiceTest {
         assertEquals(11, result?.seq)
         assertEquals("vacation_session", result?.type)
     }
+
+    @Test
+    @DisplayName("셔틀버스 운행 기간 시작일 범위 검색 테스트")
+    fun findShuttlePeriodsStartingBetweenTest() {
+        val start = LocalDate.parse("2026-03-01")
+        val end = LocalDate.parse("2026-03-31")
+        val expected =
+            listOf(
+                ShuttlePeriod(
+                    seq = 2,
+                    start = ZonedDateTime.parse("2026-03-02T00:00:00.000+09:00"),
+                    end = ZonedDateTime.parse("2026-06-23T23:59:59.999+09:00"),
+                    type = "semester",
+                    periodType = null,
+                ),
+            )
+
+        whenever(
+            shuttlePeriodRepository.findByStartBetweenOrderByStartAsc(
+                ZonedDateTime.of(start, LocalTime.MIN, LocalDateTimeBuilder.serviceTimezone),
+                ZonedDateTime.of(end, LocalTime.MAX, LocalDateTimeBuilder.serviceTimezone),
+            ),
+        ).thenReturn(expected)
+
+        val result = shuttlePeriodService.findShuttlePeriodsStartingBetween(start, end)
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    @DisplayName("셔틀버스 운행 기간 시작일 범위 검색 테스트 (잘못된 범위)")
+    fun findShuttlePeriodsStartingBetweenInvalidRangeTest() {
+        assertThrows<IllegalArgumentException> {
+            shuttlePeriodService.findShuttlePeriodsStartingBetween(
+                LocalDate.parse("2026-04-01"),
+                LocalDate.parse("2026-03-01"),
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add shuttle service notice GraphQL data for upcoming period changes and holiday operations
- Add range lookup support for shuttle periods and holiday occurrences
- Cover the new GraphQL and service behavior with tests

## Test
- ./gradlew ktlintCheck test jacocoTestReport jacocoTestCoverageVerification
- JaCoCo: 100% instructions, branches, lines, methods, and classes