### PR TITLE
Fix service timezone consistency

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/bus/service/BusRealtimeService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/bus/service/BusRealtimeService.kt
@@ -7,13 +7,13 @@ import app.hyuabot.backend.database.repository.BusDepartureLogRepository
 import app.hyuabot.backend.database.repository.BusRealtimeRepository
 import app.hyuabot.backend.database.repository.BusTimetableRepository
 import app.hyuabot.backend.holiday.service.PublicHolidayService
+import app.hyuabot.backend.utility.LocalDateTimeBuilder
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.time.ZoneId
 import kotlin.math.abs
 
 @Service
@@ -64,7 +64,7 @@ class BusRealtimeService(
         }
     }
 
-    internal fun currentTime(): LocalDateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+    internal fun currentTime(): LocalDateTime = LocalDateTime.now(LocalDateTimeBuilder.serviceTimezone)
 
     fun getBusRealtimeList(): List<BusRealtime> = realtimeRepository.findAll()
 

--- a/src/main/kotlin/app/hyuabot/backend/notice/controller/NoticeDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/notice/controller/NoticeDataFetcher.kt
@@ -23,7 +23,7 @@ class NoticeDataFetcher(
                 category = input?.category,
                 language = input?.language,
                 since = input?.timestamp,
-                currentTime = ZonedDateTime.now(),
+                currentTime = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone),
             ).map {
                 NoticeCategory(
                     seq = it.id!!,

--- a/src/main/kotlin/app/hyuabot/backend/readingRoom/ReadingRoomService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/readingRoom/ReadingRoomService.kt
@@ -6,6 +6,7 @@ import app.hyuabot.backend.readingRoom.domain.CreateReadingRoomRequest
 import app.hyuabot.backend.readingRoom.domain.UpdateReadingRoomRequest
 import app.hyuabot.backend.readingRoom.exception.DuplicateReadingRoomException
 import app.hyuabot.backend.readingRoom.exception.ReadingRoomNotFoundException
+import app.hyuabot.backend.utility.LocalDateTimeBuilder
 import org.springframework.stereotype.Service
 import java.time.ZonedDateTime
 
@@ -38,7 +39,7 @@ class ReadingRoomService(
                 active = payload.total,
                 occupied = 0,
                 available = payload.total,
-                updatedAt = ZonedDateTime.now(),
+                updatedAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone),
                 campus = null,
             ),
         )

--- a/src/main/kotlin/app/hyuabot/backend/security/JWTTokenProvider.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/JWTTokenProvider.kt
@@ -3,6 +3,7 @@ package app.hyuabot.backend.security
 import app.hyuabot.backend.database.entity.RefreshToken
 import app.hyuabot.backend.database.entity.User
 import app.hyuabot.backend.database.repository.RefreshTokenRepository
+import app.hyuabot.backend.utility.LocalDateTimeBuilder
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Decoders
@@ -38,7 +39,7 @@ class JWTTokenProvider(
                 "access_token:$accessToken",
                 "logout",
                 Duration.between(
-                    ZonedDateTime.now(),
+                    ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone),
                     it.expiredAt,
                 ),
             )
@@ -79,8 +80,8 @@ class JWTTokenProvider(
         if (previousRefreshToken != null) {
             previousRefreshToken.apply {
                 this.refreshToken = refreshToken
-                this.expiredAt = ZonedDateTime.now().plusDays(refreshExpirationDays)
-                this.updatedAt = ZonedDateTime.now()
+                this.expiredAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone).plusDays(refreshExpirationDays)
+                this.updatedAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
             }
             refreshTokenRepository.save(previousRefreshToken)
         } else {
@@ -89,9 +90,9 @@ class JWTTokenProvider(
                     uuid = UUID.randomUUID(),
                     userID = userID,
                     refreshToken = refreshToken,
-                    expiredAt = ZonedDateTime.now().plusMinutes(expirationMinutes),
-                    createdAt = ZonedDateTime.now(),
-                    updatedAt = ZonedDateTime.now(),
+                    expiredAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone).plusMinutes(expirationMinutes),
+                    createdAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone),
+                    updatedAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone),
                     user = null,
                 ),
             )

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleDataFetcher.kt
@@ -97,10 +97,11 @@ class ShuttleDataFetcher(
         require(!start.isAfter(end)) { "Start date must be before or equal to end date" }
         val periodNotices =
             periodService.findShuttlePeriodsStartingBetween(start, end).map {
+                val serviceDate = it.start.withZoneSameInstant(LocalDateTimeBuilder.serviceTimezone).toLocalDate()
                 ShuttleServiceNotice(
-                    id = "period:${it.seq}:${it.start.toLocalDate()}",
+                    id = "period:${it.seq}:$serviceDate",
                     kind = "period",
-                    date = it.start.toLocalDate(),
+                    date = serviceDate,
                     period =
                         ShuttlePeriod(
                             seq = it.seq!!,

--- a/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
@@ -113,7 +113,7 @@ class SubwayDataFetcher(
                 "arrival query expects exactly one weekday, but got: $weekdays for station ${station.stationID}",
             )
         }
-        val today = LocalDate.now()
+        val today = LocalDate.now(LocalDateTimeBuilder.serviceTimezone)
         val weekday = if (publicHolidayService.findPublicHoliday(today) != null) "weekends" else weekdays.first()
         val limitMap = dfe.graphQlContext.get<Map<String, Int>>("limitMap")
         val limit = limitMap[station.stationID]

--- a/src/main/kotlin/app/hyuabot/backend/subway/service/SubwayService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/service/SubwayService.kt
@@ -38,7 +38,6 @@ import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalTime
-import java.time.ZoneId
 import kotlin.collections.emptyList
 import app.hyuabot.backend.codegen.types.SubwayRoute as SubwayRouteDto
 import app.hyuabot.backend.codegen.types.SubwayStation as SubwayStationDto
@@ -451,7 +450,7 @@ class SubwayService(
         directions: List<String>,
         weekday: String,
         limit: Int? = null,
-        currentTime: LocalTime = LocalTime.now(ZoneId.of("Asia/Seoul")),
+        currentTime: LocalTime = LocalTime.now(LocalDateTimeBuilder.serviceTimezone),
     ): List<SubwayArrivalGroup> {
         if (directions.isEmpty()) return emptyList()
         val realtimeGroups =

--- a/src/main/kotlin/app/hyuabot/backend/utility/ScalarRegistration.kt
+++ b/src/main/kotlin/app/hyuabot/backend/utility/ScalarRegistration.kt
@@ -12,7 +12,6 @@ import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
 import graphql.schema.GraphQLScalarType
 import graphql.schema.idl.RuntimeWiring
-import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -33,7 +32,7 @@ class ScalarRegistration {
             .description("DateTime Scalar (KST)")
             .coercing(
                 object : Coercing<ZonedDateTime, String> {
-                    private val zone = ZoneId.of("Asia/Seoul")
+                    private val zone = LocalDateTimeBuilder.serviceTimezone
                     private val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 
                     override fun serialize(

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleDataFetcherTest.kt
@@ -326,7 +326,7 @@ class ShuttleDataFetcherTest {
                 createPeriod(
                     seq = 2,
                     type = "vacation",
-                    start = ZonedDateTime.parse("2026-03-26T00:00:00.000+09:00"),
+                    start = ZonedDateTime.parse("2026-03-25T15:00:00.000Z"),
                     end = ZonedDateTime.parse("2026-04-30T23:59:59.999+09:00"),
                 ),
             ),


### PR DESCRIPTION
## Summary
- Convert shuttle period timestamps to the service timezone before deriving service notice dates and identifiers.
- Use the service timezone for subway holiday date resolution, notice filtering, reading room timestamps, and token timestamps.
- Reuse the shared service timezone in bus and subway realtime services and the GraphQL DateTime scalar.
- Add regression coverage for a KST midnight transition represented as the preceding UTC date.

## Root Cause
The backend defines `Asia/Seoul` as its service timezone, but several date and timestamp paths still relied on the JVM default timezone or derived a local date before converting a database timestamp. In UTC environments, this could make a KST midnight shuttle transition appear on the previous date and could evaluate subway holiday schedules against the previous calendar day during the KST midnight boundary.

## Impact
Service calendar decisions and generated timestamps now consistently use KST regardless of the host JVM timezone. Shuttle service notice dates match their period start, and subway holiday timetable selection uses the Korean calendar date.

## Validation
- `./gradlew ktlintCheck test --tests app.hyuabot.backend.subway.SubwayDataFetcherTest --tests app.hyuabot.backend.notice.NoticeDataFetcherTest --tests app.hyuabot.backend.readingRoom.ReadingRoomServiceTest --tests app.hyuabot.backend.security.JWTTokenProviderTest --tests app.hyuabot.backend.bus.BusServiceTest --tests app.hyuabot.backend.subway.SubwayServiceTest`
- `./gradlew test jacocoTestReport jacocoTestCoverageVerification`
