### PR TITLE
Add Watch usage analytics

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/config/WatchAnalyticsConfig.kt
+++ b/src/main/kotlin/app/hyuabot/backend/config/WatchAnalyticsConfig.kt
@@ -1,0 +1,11 @@
+package app.hyuabot.backend.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+class WatchAnalyticsConfig {
+    @Bean
+    fun watchAnalyticsClock(): Clock = Clock.systemUTC()
+}

--- a/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
@@ -42,6 +42,7 @@ class SecurityConfig(
                         "/api/v1/user",
                         "/api/v1/user/token",
                         "/api/v1/live-activity/**",
+                        "/api/v1/analytics/watch/events",
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/graphql/**",

--- a/src/main/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsController.kt
@@ -1,0 +1,29 @@
+package app.hyuabot.backend.watchanalytics
+
+import app.hyuabot.backend.utility.ResponseBuilder
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/analytics/watch")
+class WatchAnalyticsController(
+    private val watchAnalyticsService: WatchAnalyticsService,
+) {
+    @PostMapping("/events")
+    fun recordEvent(
+        @RequestBody request: WatchAnalyticsEventRequest,
+    ): ResponseEntity<*> =
+        try {
+            watchAnalyticsService.record(request)
+            ResponseEntity.accepted().build<Void>()
+        } catch (_: IllegalArgumentException) {
+            ResponseBuilder.response(
+                HttpStatus.BAD_REQUEST,
+                ResponseBuilder.Message("INVALID_WATCH_ANALYTICS_EVENT"),
+            )
+        }
+}

--- a/src/main/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsEventRequest.kt
+++ b/src/main/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsEventRequest.kt
@@ -1,0 +1,10 @@
+package app.hyuabot.backend.watchanalytics
+
+data class WatchAnalyticsEventRequest(
+    val event: String,
+    val platform: String,
+    val installationId: String,
+    val appVersion: String,
+    val entryPoint: String,
+    val stopId: String? = null,
+)

--- a/src/main/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsService.kt
@@ -1,0 +1,137 @@
+package app.hyuabot.backend.watchanalytics
+
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import java.time.Clock
+import java.time.Duration
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+class WatchAnalyticsService(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val meterRegistry: MeterRegistry,
+    private val watchAnalyticsClock: Clock,
+) {
+    init {
+        Platform.entries.forEach { platform -> registerActiveInstallationGauge(platform.value) }
+        registerActiveInstallationGauge(ALL_PLATFORMS)
+    }
+
+    fun record(request: WatchAnalyticsEventRequest) {
+        val event = Event.from(request.event)
+        val platform = Platform.from(request.platform)
+        val entryPoint = EntryPoint.from(request.entryPoint)
+        val installationId = UUID.fromString(request.installationId).toString()
+        require(APP_VERSION_REGEX.matches(request.appVersion))
+
+        val stopId = request.stopId?.let { Stop.from(it).value }
+        require((event == Event.STOP_SELECTED) == (stopId != null))
+
+        meterRegistry
+            .counter(
+                "hyuabot.watch.events",
+                "event",
+                event.value,
+                "platform",
+                platform.value,
+                "entry_point",
+                entryPoint.value,
+                "stop_id",
+                stopId ?: NONE,
+            ).increment()
+
+        val key = activeInstallationKey(platform.value, LocalDate.now(watchAnalyticsClock))
+        redisTemplate.opsForHyperLogLog().add(key, "${platform.value}:$installationId")
+        redisTemplate.expire(key, ACTIVE_KEY_TTL)
+    }
+
+    internal fun activeInstallationKeys(
+        platform: String,
+        today: LocalDate = LocalDate.now(watchAnalyticsClock),
+    ): List<String> {
+        val platforms = if (platform == ALL_PLATFORMS) Platform.entries.map { it.value } else listOf(platform)
+        return platforms.flatMap { platformValue ->
+            (0 until ACTIVE_WINDOW_DAYS).map { dayOffset ->
+                activeInstallationKey(platformValue, today.minusDays(dayOffset.toLong()))
+            }
+        }
+    }
+
+    private fun registerActiveInstallationGauge(platform: String) {
+        Gauge
+            .builder("hyuabot.watch.active.installations") {
+                redisTemplate.opsForHyperLogLog().size(*activeInstallationKeys(platform).toTypedArray()).toDouble()
+            }.description("Estimated distinct Watch installations active during the rolling window")
+            .tag("platform", platform)
+            .tag("window", "${ACTIVE_WINDOW_DAYS}d")
+            .register(meterRegistry)
+    }
+
+    private fun activeInstallationKey(
+        platform: String,
+        date: LocalDate,
+    ) = "analytics:watch:active:$platform:$date"
+
+    private enum class Event(
+        val value: String,
+    ) {
+        APP_OPEN("watch_app_open"),
+        STOP_SELECTED("watch_stop_selected"),
+        ;
+
+        companion object {
+            fun from(value: String) = entries.firstOrNull { it.value == value } ?: throw IllegalArgumentException()
+        }
+    }
+
+    private enum class Platform(
+        val value: String,
+    ) {
+        WATCH_OS("watchos"),
+        WEAR_OS("wear_os"),
+        ;
+
+        companion object {
+            fun from(value: String) = entries.firstOrNull { it.value == value } ?: throw IllegalArgumentException()
+        }
+    }
+
+    private enum class EntryPoint(
+        val value: String,
+    ) {
+        APP("app"),
+        TILE("tile"),
+        COMPLICATION("complication"),
+        ;
+
+        companion object {
+            fun from(value: String) = entries.firstOrNull { it.value == value } ?: throw IllegalArgumentException()
+        }
+    }
+
+    private enum class Stop(
+        val value: String,
+    ) {
+        DORMITORY("dormitory"),
+        SHUTTLECOCK("shuttlecock"),
+        STATION("station"),
+        TERMINAL("terminal"),
+        JUNGANG("jungang"),
+        ;
+
+        companion object {
+            fun from(value: String) = entries.firstOrNull { it.value == value } ?: throw IllegalArgumentException()
+        }
+    }
+
+    companion object {
+        private const val ACTIVE_WINDOW_DAYS = 28
+        private const val ALL_PLATFORMS = "all"
+        private const val NONE = "none"
+        private val ACTIVE_KEY_TTL = Duration.ofDays(35)
+        private val APP_VERSION_REGEX = Regex("[0-9A-Za-z][0-9A-Za-z.+_-]{0,31}")
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsControllerTest.kt
@@ -1,0 +1,39 @@
+package app.hyuabot.backend.watchanalytics
+
+import app.hyuabot.backend.utility.ResponseBuilder
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import kotlin.test.assertEquals
+
+class WatchAnalyticsControllerTest {
+    private val service = mock<WatchAnalyticsService>()
+    private val controller = WatchAnalyticsController(service)
+    private val request =
+        WatchAnalyticsEventRequest(
+            event = "watch_app_open",
+            platform = "watchos",
+            installationId = "123e4567-e89b-12d3-a456-426614174000",
+            appVersion = "26.7.13",
+            entryPoint = "app",
+        )
+
+    @Test
+    fun `accepts a valid event`() {
+        val response = controller.recordEvent(request)
+
+        assertEquals(202, response.statusCode.value())
+        verify(service).record(request)
+    }
+
+    @Test
+    fun `returns bad request for an invalid event`() {
+        doThrow(IllegalArgumentException()).`when`(service).record(request)
+
+        val response = controller.recordEvent(request)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("INVALID_WATCH_ANALYTICS_EVENT", (response.body as ResponseBuilder.Message).message)
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsServiceTest.kt
@@ -97,6 +97,12 @@ class WatchAnalyticsServiceTest {
             service.record(validRequest(event = "other"))
         }
         assertThrows<IllegalArgumentException> {
+            service.record(validRequest(entryPoint = "widget"))
+        }
+        assertThrows<IllegalArgumentException> {
+            service.record(validRequest(event = "watch_stop_selected", stopId = "other"))
+        }
+        assertThrows<IllegalArgumentException> {
             service.record(validRequest(appVersion = "invalid version"))
         }
     }
@@ -112,6 +118,21 @@ class WatchAnalyticsServiceTest {
         assertEquals("analytics:watch:active:watchos:2026-07-13", watchOsKeys.first())
         assertEquals("analytics:watch:active:watchos:2026-06-16", watchOsKeys.last())
         assertEquals(56, allKeys.size)
+    }
+
+    @Test
+    fun `reports rolling active installations through the platform gauge`() {
+        val gauge =
+            meterRegistry
+                .get("hyuabot.watch.active.installations")
+                .tag("platform", "watchos")
+                .tag("window", "28d")
+                .gauge()
+
+        assertEquals(0.0, gauge.value())
+        verify(hyperLogLogOperations).size(
+            *service.activeInstallationKeys("watchos", LocalDate.of(2026, 7, 13)).toTypedArray(),
+        )
     }
 
     private fun validRequest(

--- a/src/test/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsServiceTest.kt
@@ -1,0 +1,131 @@
+package app.hyuabot.backend.watchanalytics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.HyperLogLogOperations
+import org.springframework.data.redis.core.RedisTemplate
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import kotlin.test.assertEquals
+
+class WatchAnalyticsServiceTest {
+    private val redisTemplate = mock<RedisTemplate<String, String>>()
+    private val hyperLogLogOperations = mock<HyperLogLogOperations<String, String>>()
+    private val meterRegistry = SimpleMeterRegistry()
+    private val clock = Clock.fixed(Instant.parse("2026-07-13T03:00:00Z"), ZoneOffset.UTC)
+    private val service =
+        WatchAnalyticsService(redisTemplate, meterRegistry, clock).also {
+            whenever(redisTemplate.opsForHyperLogLog()).thenReturn(hyperLogLogOperations)
+        }
+
+    @Test
+    fun `records an app open and active installation`() {
+        service.record(validRequest(event = "watch_app_open"))
+
+        assertEquals(
+            1.0,
+            meterRegistry
+                .counter(
+                    "hyuabot.watch.events",
+                    "event",
+                    "watch_app_open",
+                    "platform",
+                    "wear_os",
+                    "entry_point",
+                    "app",
+                    "stop_id",
+                    "none",
+                ).count(),
+        )
+        verify(hyperLogLogOperations).add(
+            "analytics:watch:active:wear_os:2026-07-13",
+            "wear_os:123e4567-e89b-12d3-a456-426614174000",
+        )
+        verify(redisTemplate).expire(
+            "analytics:watch:active:wear_os:2026-07-13",
+            Duration.ofDays(35),
+        )
+    }
+
+    @Test
+    fun `records a selected stop`() {
+        service.record(
+            validRequest(
+                event = "watch_stop_selected",
+                entryPoint = "tile",
+                stopId = "station",
+            ),
+        )
+
+        assertEquals(
+            1.0,
+            meterRegistry
+                .counter(
+                    "hyuabot.watch.events",
+                    "event",
+                    "watch_stop_selected",
+                    "platform",
+                    "wear_os",
+                    "entry_point",
+                    "tile",
+                    "stop_id",
+                    "station",
+                ).count(),
+        )
+    }
+
+    @Test
+    fun `rejects stop selection without a stop`() {
+        assertThrows<IllegalArgumentException> {
+            service.record(validRequest(event = "watch_stop_selected"))
+        }
+    }
+
+    @Test
+    fun `rejects unsupported dimensions`() {
+        assertThrows<IllegalArgumentException> {
+            service.record(validRequest(platform = "android"))
+        }
+        assertThrows<IllegalArgumentException> {
+            service.record(validRequest(event = "other"))
+        }
+        assertThrows<IllegalArgumentException> {
+            service.record(validRequest(appVersion = "invalid version"))
+        }
+    }
+
+    @Test
+    fun `builds rolling keys for one platform and all platforms`() {
+        val today = LocalDate.of(2026, 7, 13)
+
+        val watchOsKeys = service.activeInstallationKeys("watchos", today)
+        val allKeys = service.activeInstallationKeys("all", today)
+
+        assertEquals(28, watchOsKeys.size)
+        assertEquals("analytics:watch:active:watchos:2026-07-13", watchOsKeys.first())
+        assertEquals("analytics:watch:active:watchos:2026-06-16", watchOsKeys.last())
+        assertEquals(56, allKeys.size)
+    }
+
+    private fun validRequest(
+        event: String = "watch_app_open",
+        platform: String = "wear_os",
+        appVersion: String = "5.1.9",
+        entryPoint: String = "app",
+        stopId: String? = null,
+    ) = WatchAnalyticsEventRequest(
+        event = event,
+        platform = platform,
+        installationId = "123e4567-e89b-12d3-a456-426614174000",
+        appVersion = appVersion,
+        entryPoint = entryPoint,
+        stopId = stopId,
+    )
+}


### PR DESCRIPTION
## Summary
- Add an unauthenticated endpoint for Watch app-open and shuttle-stop-selection analytics events.
- Validate event, platform, entry-point, stop, installation, and app-version dimensions before recording them.
- Record bounded Prometheus counters and estimate rolling 28-day active installations with daily Redis HyperLogLog keys.
- Add controller and service coverage for valid events, rejected dimensions, metrics, retention, and rolling-window keys.

## Impact
Watch usage can now be measured separately for watchOS and Wear OS without collecting account or personal data. The metrics expose event totals and approximate active installation counts while keeping storage bounded with a 35-day TTL.

## Validation
- `./gradlew ktlintCheck test --tests 'app.hyuabot.backend.watchanalytics.*'`
