### PR TITLE
feat: Add admin permission management

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/admin/AdminUserController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/admin/AdminUserController.kt
@@ -1,0 +1,44 @@
+package app.hyuabot.backend.admin
+
+import app.hyuabot.backend.admin.domain.AdminUserListResponse
+import app.hyuabot.backend.admin.domain.UpdateAdminUserRequest
+import app.hyuabot.backend.admin.exception.AdminUserNotFoundException
+import app.hyuabot.backend.admin.exception.LastSuperAdminException
+import app.hyuabot.backend.utility.ResponseBuilder
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin/users")
+class AdminUserController(
+    private val adminUserService: AdminUserService,
+) {
+    @GetMapping
+    fun getUsers(): ResponseEntity<AdminUserListResponse> =
+        ResponseBuilder.response(
+            HttpStatus.OK,
+            AdminUserListResponse(adminUserService.getUsers()),
+        )
+
+    @PutMapping("/{userID}")
+    fun updateUser(
+        @PathVariable userID: String,
+        @RequestBody request: UpdateAdminUserRequest,
+    ): ResponseEntity<*> =
+        try {
+            ResponseBuilder.response(
+                HttpStatus.OK,
+                adminUserService.updateUser(userID, request),
+            )
+        } catch (_: AdminUserNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, "ADMIN_USER_NOT_FOUND")
+        } catch (_: LastSuperAdminException) {
+            ResponseBuilder.response(HttpStatus.CONFLICT, "LAST_SUPER_ADMIN_REQUIRED")
+        }
+}

--- a/src/main/kotlin/app/hyuabot/backend/admin/AdminUserService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/admin/AdminUserService.kt
@@ -1,0 +1,41 @@
+package app.hyuabot.backend.admin
+
+import app.hyuabot.backend.admin.domain.AdminUserResponse
+import app.hyuabot.backend.admin.domain.UpdateAdminUserRequest
+import app.hyuabot.backend.admin.exception.AdminUserNotFoundException
+import app.hyuabot.backend.admin.exception.LastSuperAdminException
+import app.hyuabot.backend.database.repository.UserRepository
+import app.hyuabot.backend.security.AdminPermission
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+@Service
+class AdminUserService(
+    private val userRepository: UserRepository,
+) {
+    fun getUsers(): List<AdminUserResponse> = userRepository.findAllByOrderByNameAscUserIDAsc().map(AdminUserResponse::from)
+
+    @Transactional
+    fun updateUser(
+        userID: String,
+        request: UpdateAdminUserRequest,
+    ): AdminUserResponse {
+        val users = userRepository.findAllForPermissionUpdate()
+        val user = users.firstOrNull { it.userID == userID } ?: throw AdminUserNotFoundException()
+        val removesActiveSuperAdmin =
+            user.active &&
+                AdminPermission.SUPER_ADMIN in user.permissions &&
+                (!request.active || AdminPermission.SUPER_ADMIN !in request.permissions)
+        if (
+            removesActiveSuperAdmin &&
+            users.count { it.active && AdminPermission.SUPER_ADMIN in it.permissions } <= 1
+        ) {
+            throw LastSuperAdminException()
+        }
+
+        user.active = request.active
+        user.permissions.clear()
+        user.permissions.addAll(request.permissions)
+        return AdminUserResponse.from(userRepository.save(user))
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/admin/domain/AdminUserResponse.kt
+++ b/src/main/kotlin/app/hyuabot/backend/admin/domain/AdminUserResponse.kt
@@ -1,0 +1,29 @@
+package app.hyuabot.backend.admin.domain
+
+import app.hyuabot.backend.database.entity.User
+import app.hyuabot.backend.security.AdminPermission
+
+data class AdminUserResponse(
+    val username: String,
+    val nickname: String,
+    val email: String,
+    val phone: String,
+    val active: Boolean,
+    val permissions: List<AdminPermission>,
+) {
+    companion object {
+        fun from(user: User): AdminUserResponse =
+            AdminUserResponse(
+                username = user.userID,
+                nickname = user.name,
+                email = user.email,
+                phone = user.phone,
+                active = user.active,
+                permissions = user.permissions.sortedBy { it.ordinal },
+            )
+    }
+}
+
+data class AdminUserListResponse(
+    val result: List<AdminUserResponse>,
+)

--- a/src/main/kotlin/app/hyuabot/backend/admin/domain/UpdateAdminUserRequest.kt
+++ b/src/main/kotlin/app/hyuabot/backend/admin/domain/UpdateAdminUserRequest.kt
@@ -1,0 +1,8 @@
+package app.hyuabot.backend.admin.domain
+
+import app.hyuabot.backend.security.AdminPermission
+
+data class UpdateAdminUserRequest(
+    val active: Boolean,
+    val permissions: Set<AdminPermission>,
+)

--- a/src/main/kotlin/app/hyuabot/backend/admin/exception/AdminUserNotFoundException.kt
+++ b/src/main/kotlin/app/hyuabot/backend/admin/exception/AdminUserNotFoundException.kt
@@ -1,0 +1,3 @@
+package app.hyuabot.backend.admin.exception
+
+class AdminUserNotFoundException : RuntimeException("ADMIN_USER_NOT_FOUND")

--- a/src/main/kotlin/app/hyuabot/backend/admin/exception/LastSuperAdminException.kt
+++ b/src/main/kotlin/app/hyuabot/backend/admin/exception/LastSuperAdminException.kt
@@ -1,0 +1,3 @@
+package app.hyuabot.backend.admin.exception
+
+class LastSuperAdminException : RuntimeException("LAST_SUPER_ADMIN_REQUIRED")

--- a/src/main/kotlin/app/hyuabot/backend/auth/AuthController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/auth/AuthController.kt
@@ -6,6 +6,7 @@ import app.hyuabot.backend.auth.domain.UserResponse
 import app.hyuabot.backend.auth.exception.DuplicateEmailException
 import app.hyuabot.backend.auth.exception.DuplicateUserIDException
 import app.hyuabot.backend.security.JWTUser
+import app.hyuabot.backend.security.effectivePermissions
 import app.hyuabot.backend.utility.ResponseBuilder
 import io.jsonwebtoken.ExpiredJwtException
 import io.swagger.v3.oas.annotations.Operation
@@ -289,6 +290,8 @@ class AuthController {
             )
         } catch (_: ExpiredJwtException) {
             return ResponseBuilder.response(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED")
+        } catch (_: BadCredentialsException) {
+            return ResponseBuilder.response(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED")
         } catch (e: Exception) {
             logger.error("Token refresh failed: ${e.message}", e)
             return ResponseBuilder.response(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR")
@@ -445,6 +448,7 @@ class AuthController {
                         email = user.email,
                         phone = user.phone,
                         active = user.active,
+                        permissions = user.permissions.effectivePermissions().sortedBy { it.ordinal },
                     ),
                 )
             }

--- a/src/main/kotlin/app/hyuabot/backend/auth/AuthService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/auth/AuthService.kt
@@ -8,8 +8,10 @@ import app.hyuabot.backend.database.entity.User
 import app.hyuabot.backend.database.repository.RefreshTokenRepository
 import app.hyuabot.backend.database.repository.UserRepository
 import app.hyuabot.backend.security.JWTTokenProvider
+import app.hyuabot.backend.security.JWTUser
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.transaction.Transactional
+import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -63,7 +65,11 @@ class AuthService(
 
     fun refreshToken(refreshToken: String): String {
         val authentication = tokenProvider.getAuthentication(refreshToken)
-        return tokenProvider.createRefreshToken(authentication)
+        val userID = (authentication.principal as JWTUser).username
+        if (refreshTokenRepository.findByUserID(userID)?.refreshToken != refreshToken) {
+            throw BadCredentialsException("INVALID_REFRESH_TOKEN")
+        }
+        return tokenProvider.createAccessToken(authentication)
     }
 
     fun getUserInfo(userID: String): User =

--- a/src/main/kotlin/app/hyuabot/backend/auth/domain/UserResponse.kt
+++ b/src/main/kotlin/app/hyuabot/backend/auth/domain/UserResponse.kt
@@ -1,5 +1,6 @@
 package app.hyuabot.backend.auth.domain
 
+import app.hyuabot.backend.security.AdminPermission
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class UserResponse(
@@ -13,4 +14,6 @@ data class UserResponse(
     val phone: String,
     @get:Schema(description = "사용자 활성화 상태", example = "true")
     val active: Boolean,
+    @get:Schema(description = "현재 사용자에게 적용되는 관리 권한")
+    val permissions: List<AdminPermission>,
 )

--- a/src/main/kotlin/app/hyuabot/backend/database/entity/User.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/entity/User.kt
@@ -1,8 +1,15 @@
 package app.hyuabot.backend.database.entity
 
+import app.hyuabot.backend.security.AdminPermission
+import jakarta.persistence.CollectionTable
 import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
@@ -23,6 +30,14 @@ class User(
     var phone: String,
     @Column(name = "active", nullable = false)
     var active: Boolean,
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "admin_user_permission",
+        joinColumns = [JoinColumn(name = "user_id")],
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "permission", length = 30, nullable = false)
+    val permissions: MutableSet<AdminPermission> = mutableSetOf(),
     @OneToMany(mappedBy = "user")
     val refreshToken: MutableList<RefreshToken> = mutableListOf(),
     @OneToMany(mappedBy = "user")

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/UserRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/UserRepository.kt
@@ -1,7 +1,10 @@
 package app.hyuabot.backend.database.repository
 
 import app.hyuabot.backend.database.entity.User
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 
 interface UserRepository : JpaRepository<User, String> {
     fun findByUserID(userID: String): User?
@@ -9,4 +12,14 @@ interface UserRepository : JpaRepository<User, String> {
     fun findByUserIDAndActiveIsTrue(userID: String): User?
 
     fun findByEmail(email: String): User?
+
+    fun findAllByOrderByNameAscUserIDAsc(): List<User>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+        select user from user user order by user.name asc, user.userID asc
+        """,
+    )
+    fun findAllForPermissionUpdate(): List<User>
 }

--- a/src/main/kotlin/app/hyuabot/backend/security/AdminPermission.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/AdminPermission.kt
@@ -1,0 +1,21 @@
+package app.hyuabot.backend.security
+
+enum class AdminPermission {
+    SUPER_ADMIN,
+    SHUTTLE,
+    BUS,
+    SUBWAY,
+    CAFETERIA,
+    READING_ROOM,
+    CONTACT,
+    CALENDAR,
+    NOTICE,
+    ;
+
+    companion object {
+        val managementPermissions: Set<AdminPermission> = entries.filterNot { it == SUPER_ADMIN }.toSet()
+    }
+}
+
+fun Set<AdminPermission>.effectivePermissions(): Set<AdminPermission> =
+    if (contains(AdminPermission.SUPER_ADMIN)) AdminPermission.entries.toSet() else this

--- a/src/main/kotlin/app/hyuabot/backend/security/JWTTokenProvider.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/JWTTokenProvider.kt
@@ -26,6 +26,7 @@ class JWTTokenProvider(
     @param:Value("\${jwt.expiration.refresh}") private val refreshExpirationDays: Long,
     private val refreshTokenRepository: RefreshTokenRepository,
     private val redisTemplate: RedisTemplate<String, String>,
+    private val userDetailsService: JWTUserDetailsService,
 ) {
     private val key by lazy { Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret)) }
 
@@ -90,7 +91,7 @@ class JWTTokenProvider(
                     uuid = UUID.randomUUID(),
                     userID = userID,
                     refreshToken = refreshToken,
-                    expiredAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone).plusMinutes(expirationMinutes),
+                    expiredAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone).plusDays(refreshExpirationDays),
                     createdAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone),
                     updatedAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone),
                     user = null,
@@ -117,11 +118,7 @@ class JWTTokenProvider(
 
     // Claims 에서 Authentication 객체 생성
     private fun getAuthentication(claims: Claims): Authentication {
-        val principal: UserDetails =
-            JWTUser(
-                username = claims.subject,
-                password = "",
-            )
+        val principal: UserDetails = userDetailsService.loadUserByUsername(claims.subject)
         return UsernamePasswordAuthenticationToken(principal, "", principal.authorities)
     }
 }

--- a/src/main/kotlin/app/hyuabot/backend/security/JWTUser.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/JWTUser.kt
@@ -1,8 +1,14 @@
 package app.hyuabot.backend.security
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.User
 
 class JWTUser(
     username: String,
     password: String,
-) : User(username, password, listOf())
+    permissions: Set<AdminPermission> = emptySet(),
+) : User(
+        username,
+        password,
+        permissions.effectivePermissions().map { SimpleGrantedAuthority(it.name) },
+    )

--- a/src/main/kotlin/app/hyuabot/backend/security/JWTUserDetailsService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/JWTUserDetailsService.kt
@@ -18,6 +18,7 @@ class JWTUserDetailsService(
         return JWTUser(
             username = user.userID,
             password = user.password.decodeToString(),
+            permissions = user.permissions,
         )
     }
 }

--- a/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
@@ -3,10 +3,13 @@ package app.hyuabot.backend.security
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.http.HttpStatus
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.AccessDeniedHandler
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
@@ -36,7 +39,14 @@ class SecurityConfig(
                 source.registerCorsConfiguration("/**", configuration)
                 it.configurationSource(source)
             }.sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) } // 세션 관리 정책을 Stateless로 설정
-            .authorizeHttpRequests { requests ->
+            .exceptionHandling { exceptions ->
+                exceptions
+                    .authenticationEntryPoint(
+                        AuthenticationEntryPoint { _, response, _ -> response.sendError(HttpStatus.UNAUTHORIZED.value()) },
+                    ).accessDeniedHandler(
+                        AccessDeniedHandler { _, response, _ -> response.sendError(HttpStatus.FORBIDDEN.value()) },
+                    )
+            }.authorizeHttpRequests { requests ->
                 requests // 인증 API, Swagger UI, GraphQL 클라이언트 API는 인증 없이 접근 가능
                     .requestMatchers(
                         "/api/v1/user",
@@ -52,8 +62,37 @@ class SecurityConfig(
                         "/actuator/health/**",
                         "/actuator/prometheus",
                     ).permitAll()
-                    .anyRequest()
+                    .requestMatchers("/api/v1/admin/**")
+                    .hasAuthority(AdminPermission.SUPER_ADMIN.name)
+                    .requestMatchers("/api/v1/building/**")
+                    .hasAuthority(AdminPermission.SUPER_ADMIN.name)
+                    .requestMatchers("/api/v1/shuttle/**", "/api/v1/commute-shuttle/**")
+                    .hasAuthority(AdminPermission.SHUTTLE.name)
+                    .requestMatchers("/api/v1/bus/**")
+                    .hasAuthority(AdminPermission.BUS.name)
+                    .requestMatchers("/api/v1/subway/**")
+                    .hasAuthority(AdminPermission.SUBWAY.name)
+                    .requestMatchers("/api/v1/holiday/**")
+                    .hasAnyAuthority(AdminPermission.BUS.name, AdminPermission.SUBWAY.name)
+                    .requestMatchers("/api/v1/cafeteria/**")
+                    .hasAuthority(AdminPermission.CAFETERIA.name)
+                    .requestMatchers("/api/v1/reading-room/**")
+                    .hasAuthority(AdminPermission.READING_ROOM.name)
+                    .requestMatchers("/api/v1/contact/**")
+                    .hasAuthority(AdminPermission.CONTACT.name)
+                    .requestMatchers("/api/v1/calendar/**")
+                    .hasAuthority(AdminPermission.CALENDAR.name)
+                    .requestMatchers("/api/v1/notice/**")
+                    .hasAuthority(AdminPermission.NOTICE.name)
+                    .requestMatchers("/api/v1/campus/**")
+                    .hasAnyAuthority(
+                        AdminPermission.CAFETERIA.name,
+                        AdminPermission.READING_ROOM.name,
+                        AdminPermission.CONTACT.name,
+                    ).requestMatchers("/api/v1/user/profile")
                     .authenticated()
+                    .anyRequest()
+                    .denyAll()
             }.addFilterBefore(
                 JWTAuthenticationFilter(tokenProvider, redisTemplate),
                 UsernamePasswordAuthenticationFilter::class.java,

--- a/src/test/kotlin/app/hyuabot/backend/admin/AdminUserControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/admin/AdminUserControllerTest.kt
@@ -1,0 +1,113 @@
+package app.hyuabot.backend.admin
+
+import app.hyuabot.backend.admin.domain.AdminUserResponse
+import app.hyuabot.backend.admin.domain.UpdateAdminUserRequest
+import app.hyuabot.backend.admin.exception.AdminUserNotFoundException
+import app.hyuabot.backend.admin.exception.LastSuperAdminException
+import app.hyuabot.backend.security.AdminPermission
+import app.hyuabot.backend.security.WithCustomMockUser
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import tools.jackson.databind.ObjectMapper
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminUserControllerTest {
+    @MockitoBean
+    lateinit var service: AdminUserService
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    private val response =
+        AdminUserResponse(
+            username = "user",
+            nickname = "User",
+            email = "user@example.com",
+            phone = "01000000000",
+            active = true,
+            permissions = listOf(AdminPermission.SHUTTLE),
+        )
+
+    @Test
+    @WithCustomMockUser
+    fun superAdminCanListUsers() {
+        whenever(service.getUsers()).thenReturn(listOf(response))
+
+        mockMvc
+            .perform(get("/api/v1/admin/users"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.result[0].username").value("user"))
+    }
+
+    @Test
+    @WithCustomMockUser(permissions = [AdminPermission.SHUTTLE])
+    fun managementPermissionCannotListUsers() {
+        mockMvc.perform(get("/api/v1/admin/users")).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun anonymousUserCannotListUsers() {
+        mockMvc.perform(get("/api/v1/admin/users")).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @WithCustomMockUser
+    fun superAdminCanUpdateUser() {
+        val request = UpdateAdminUserRequest(true, setOf(AdminPermission.SHUTTLE))
+        whenever(service.updateUser("user", request)).thenReturn(response)
+
+        mockMvc
+            .perform(
+                put("/api/v1/admin/users/user")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.permissions[0]").value("SHUTTLE"))
+    }
+
+    @Test
+    @WithCustomMockUser
+    fun updateMissingUserReturnsNotFound() {
+        val request = UpdateAdminUserRequest(true, emptySet())
+        whenever(service.updateUser("missing", request)).thenThrow(AdminUserNotFoundException())
+
+        mockMvc
+            .perform(
+                put("/api/v1/admin/users/missing")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("ADMIN_USER_NOT_FOUND"))
+    }
+
+    @Test
+    @WithCustomMockUser
+    fun updateLastSuperAdminReturnsConflict() {
+        val request = UpdateAdminUserRequest(false, emptySet())
+        whenever(service.updateUser("user", request)).thenThrow(LastSuperAdminException())
+
+        mockMvc
+            .perform(
+                put("/api/v1/admin/users/user")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isConflict)
+            .andExpect(jsonPath("$.message").value("LAST_SUPER_ADMIN_REQUIRED"))
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/admin/AdminUserServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/admin/AdminUserServiceTest.kt
@@ -1,0 +1,143 @@
+package app.hyuabot.backend.admin
+
+import app.hyuabot.backend.admin.domain.UpdateAdminUserRequest
+import app.hyuabot.backend.admin.exception.AdminUserNotFoundException
+import app.hyuabot.backend.admin.exception.LastSuperAdminException
+import app.hyuabot.backend.database.entity.User
+import app.hyuabot.backend.database.repository.UserRepository
+import app.hyuabot.backend.security.AdminPermission
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@ExtendWith(MockitoExtension::class)
+class AdminUserServiceTest {
+    @Mock
+    lateinit var userRepository: UserRepository
+
+    @InjectMocks
+    lateinit var service: AdminUserService
+
+    private fun user(
+        id: String = "user",
+        active: Boolean = true,
+        permissions: Set<AdminPermission> = setOf(AdminPermission.SHUTTLE),
+    ) = User(
+        userID = id,
+        password = ByteArray(0),
+        name = "User",
+        email = "user@example.com",
+        phone = "01000000000",
+        active = active,
+        permissions = permissions.toMutableSet(),
+    )
+
+    @Test
+    fun getUsersMapsRepositoryResult() {
+        whenever(userRepository.findAllByOrderByNameAscUserIDAsc()).thenReturn(listOf(user()))
+
+        val result = service.getUsers()
+
+        assertEquals(listOf(AdminPermission.SHUTTLE), result.single().permissions)
+    }
+
+    @Test
+    fun updateUserChangesActivationAndPermissions() {
+        val user = user()
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(user))
+        whenever(userRepository.save(user)).thenReturn(user)
+
+        val result =
+            service.updateUser(
+                "user",
+                UpdateAdminUserRequest(false, setOf(AdminPermission.BUS)),
+            )
+
+        assertFalse(result.active)
+        assertEquals(listOf(AdminPermission.BUS), result.permissions)
+        verify(userRepository).save(user)
+    }
+
+    @Test
+    fun updateUserRejectsMissingUser() {
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(emptyList())
+
+        assertThrows<AdminUserNotFoundException> {
+            service.updateUser("missing", UpdateAdminUserRequest(true, emptySet()))
+        }
+    }
+
+    @Test
+    fun updateUserProtectsLastActiveSuperAdmin() {
+        val user = user(permissions = setOf(AdminPermission.SUPER_ADMIN))
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(user))
+
+        assertThrows<LastSuperAdminException> {
+            service.updateUser("user", UpdateAdminUserRequest(true, setOf(AdminPermission.SHUTTLE)))
+        }
+    }
+
+    @Test
+    fun updateUserAllowsChangingSuperAdminWhenAnotherRemains() {
+        val user = user(permissions = setOf(AdminPermission.SUPER_ADMIN))
+        val otherSuperAdmin = user(id = "other", permissions = setOf(AdminPermission.SUPER_ADMIN))
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(user, otherSuperAdmin))
+        whenever(userRepository.save(user)).thenReturn(user)
+
+        val result = service.updateUser("user", UpdateAdminUserRequest(true, setOf(AdminPermission.NOTICE)))
+
+        assertEquals(listOf(AdminPermission.NOTICE), result.permissions)
+    }
+
+    @Test
+    fun updateUserAllowsDeactivatingSuperAdminWhenAnotherActiveSuperAdminRemains() {
+        val user = user(permissions = setOf(AdminPermission.SUPER_ADMIN))
+        val inactiveSuperAdmin = user(id = "inactive", active = false, permissions = setOf(AdminPermission.SUPER_ADMIN))
+        val regularAdmin = user(id = "regular", permissions = setOf(AdminPermission.BUS))
+        val otherSuperAdmin = user(id = "other", permissions = setOf(AdminPermission.SUPER_ADMIN))
+        whenever(userRepository.findAllForPermissionUpdate())
+            .thenReturn(listOf(user, inactiveSuperAdmin, regularAdmin, otherSuperAdmin))
+        whenever(userRepository.save(user)).thenReturn(user)
+
+        val result = service.updateUser("user", UpdateAdminUserRequest(false, setOf(AdminPermission.BUS)))
+
+        assertFalse(result.active)
+        assertEquals(listOf(AdminPermission.BUS), result.permissions)
+    }
+
+    @Test
+    fun updateUserAllowsRetainingLastActiveSuperAdmin() {
+        val user = user(permissions = setOf(AdminPermission.SUPER_ADMIN))
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(user))
+        whenever(userRepository.save(user)).thenReturn(user)
+
+        val result =
+            service.updateUser(
+                "user",
+                UpdateAdminUserRequest(true, setOf(AdminPermission.SUPER_ADMIN, AdminPermission.NOTICE)),
+            )
+
+        assertTrue(result.active)
+        assertEquals(listOf(AdminPermission.SUPER_ADMIN, AdminPermission.NOTICE), result.permissions)
+    }
+
+    @Test
+    fun updateUserAllowsUpdatingInactiveSuperAdmin() {
+        val user = user(active = false, permissions = setOf(AdminPermission.SUPER_ADMIN))
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(user))
+        whenever(userRepository.save(user)).thenReturn(user)
+
+        val result = service.updateUser("user", UpdateAdminUserRequest(true, setOf(AdminPermission.SHUTTLE)))
+
+        assertTrue(result.active)
+        assertEquals(listOf(AdminPermission.SHUTTLE), result.permissions)
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/auth/AuthControllerTest.kt
@@ -5,6 +5,7 @@ import app.hyuabot.backend.auth.exception.DuplicateEmailException
 import app.hyuabot.backend.auth.exception.DuplicateUserIDException
 import app.hyuabot.backend.database.entity.User
 import app.hyuabot.backend.database.repository.UserRepository
+import app.hyuabot.backend.security.AdminPermission
 import app.hyuabot.backend.security.WithCustomMockUser
 import io.jsonwebtoken.ExpiredJwtException
 import jakarta.servlet.http.Cookie
@@ -276,6 +277,20 @@ class AuthControllerTest {
     }
 
     @Test
+    @DisplayName("토큰 갱신 테스트 (잘못된 토큰)")
+    fun testRefreshTokenWithInvalidToken() {
+        doThrow(BadCredentialsException("INVALID_REFRESH_TOKEN"))
+            .whenever(authService)
+            .refreshToken("invalidRefreshToken")
+        mockMvc
+            .perform(
+                put("/api/v1/user/token")
+                    .cookie(Cookie("refresh_token", "invalidRefreshToken")),
+            ).andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.message").value("UNAUTHORIZED"))
+    }
+
+    @Test
     @DisplayName("토큰 갱신 테스트 (오류)")
     fun testRefreshTokenError() {
         doThrow(RuntimeException("DB_ERROR"))
@@ -357,6 +372,7 @@ class AuthControllerTest {
                     email = "test@example.com",
                     phone = "1234567890",
                     active = true,
+                    permissions = mutableSetOf(AdminPermission.SUPER_ADMIN),
                 ),
             )
         mockMvc
@@ -368,6 +384,9 @@ class AuthControllerTest {
                 jsonPath("$.nickname").value("Test User")
                 jsonPath("$.email").value("test@example.com")
                 jsonPath("$.phone").value("1234567890")
+                jsonPath("$.active").value(true)
+                jsonPath("$.permissions[0]").value("SUPER_ADMIN")
+                jsonPath("$.permissions[8]").value("NOTICE")
             }
     }
 

--- a/src/test/kotlin/app/hyuabot/backend/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/auth/AuthServiceTest.kt
@@ -7,6 +7,7 @@ import app.hyuabot.backend.database.entity.User
 import app.hyuabot.backend.database.repository.RefreshTokenRepository
 import app.hyuabot.backend.database.repository.UserRepository
 import app.hyuabot.backend.security.JWTTokenProvider
+import app.hyuabot.backend.security.JWTUser
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import org.junit.jupiter.api.DisplayName
@@ -22,6 +23,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.core.Authentication
@@ -149,9 +151,23 @@ class AuthServiceTest {
     @DisplayName("토큰 갱신 테스트")
     fun refreshTokenTest() {
         val authentication = mock<Authentication>()
+        val savedRefreshToken = mock<app.hyuabot.backend.database.entity.RefreshToken>()
+        whenever(authentication.principal).thenReturn(JWTUser("testUser", ""))
         whenever(tokenProvider.getAuthentication("refreshToken")).thenReturn(authentication)
-        whenever(tokenProvider.createRefreshToken(authentication)).thenReturn("newRefreshToken")
-        assertEquals("newRefreshToken", authService.refreshToken("refreshToken"))
+        whenever(savedRefreshToken.refreshToken).thenReturn("refreshToken")
+        whenever(refreshTokenRepository.findByUserID("testUser")).thenReturn(savedRefreshToken)
+        whenever(tokenProvider.createAccessToken(authentication)).thenReturn("newAccessToken")
+        assertEquals("newAccessToken", authService.refreshToken("refreshToken"))
+    }
+
+    @Test
+    fun refreshTokenRejectsRevokedToken() {
+        val authentication = mock<Authentication>()
+        whenever(authentication.principal).thenReturn(JWTUser("testUser", ""))
+        whenever(tokenProvider.getAuthentication("refreshToken")).thenReturn(authentication)
+        whenever(refreshTokenRepository.findByUserID("testUser")).thenReturn(null)
+
+        assertThrows<BadCredentialsException> { authService.refreshToken("refreshToken") }
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/database/entity/UserTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/database/entity/UserTest.kt
@@ -1,5 +1,6 @@
 package app.hyuabot.backend.database.entity
 
+import app.hyuabot.backend.security.AdminPermission
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -38,5 +39,7 @@ class UserTest {
         e.email = "y"
         e.phone = "y"
         e.active = true
+        e.permissions.add(AdminPermission.NOTICE)
+        assertEquals(setOf(AdminPermission.NOTICE), e.permissions)
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/notice/NoticeControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/notice/NoticeControllerTest.kt
@@ -8,6 +8,7 @@ import app.hyuabot.backend.notice.domain.NoticeRequest
 import app.hyuabot.backend.notice.exception.DuplicateCategoryException
 import app.hyuabot.backend.notice.exception.NoticeCategoryNotFoundException
 import app.hyuabot.backend.notice.exception.NoticeNotFoundException
+import app.hyuabot.backend.security.AdminPermission
 import app.hyuabot.backend.security.WithCustomMockUser
 import app.hyuabot.backend.utility.LocalDateTimeBuilder
 import org.junit.jupiter.api.DisplayName
@@ -19,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -472,7 +474,7 @@ class NoticeControllerTest {
             UsernamePasswordAuthenticationToken(
                 "notJWTUser",
                 null,
-                mutableListOf(),
+                mutableListOf(SimpleGrantedAuthority(AdminPermission.NOTICE.name)),
             )
         mockMvc
             .perform(

--- a/src/test/kotlin/app/hyuabot/backend/security/AdminPermissionTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/security/AdminPermissionTest.kt
@@ -1,0 +1,19 @@
+package app.hyuabot.backend.security
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AdminPermissionTest {
+    @Test
+    fun superAdminExpandsToEveryPermission() {
+        assertEquals(AdminPermission.entries.toSet(), setOf(AdminPermission.SUPER_ADMIN).effectivePermissions())
+    }
+
+    @Test
+    fun managementPermissionRemainsScoped() {
+        val permissions = setOf(AdminPermission.SHUTTLE)
+        assertEquals(permissions, permissions.effectivePermissions())
+        assertTrue(AdminPermission.SUPER_ADMIN !in AdminPermission.managementPermissions)
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/security/JWTTokenProviderTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/security/JWTTokenProviderTest.kt
@@ -46,6 +46,9 @@ class JWTTokenProviderTest {
     @Mock
     private lateinit var authentication: Authentication
 
+    @Mock
+    private lateinit var userDetailsService: JWTUserDetailsService
+
     @BeforeEach
     fun setup() {
         MockitoAnnotations.openMocks(this)
@@ -58,6 +61,7 @@ class JWTTokenProviderTest {
                 refreshExpirationDays = refreshExpirationDays,
                 refreshTokenRepository = refreshTokenRepository,
                 redisTemplate = redisTemplate,
+                userDetailsService = userDetailsService,
             )
         val jwtUser = JWTUser("testUser", "")
         given(authentication.principal).willReturn(jwtUser)
@@ -117,6 +121,7 @@ class JWTTokenProviderTest {
     @Test
     fun testGetAuthentication() {
         val token = jwtTokenProvider.createAccessToken(authentication)
+        given(userDetailsService.loadUserByUsername("testUser")).willReturn(JWTUser("testUser", ""))
         val auth = jwtTokenProvider.getAuthentication(token)
         assert(auth.isAuthenticated)
         assert((auth.principal as JWTUser).username == "testUser")

--- a/src/test/kotlin/app/hyuabot/backend/security/JWTUserDetailsServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/security/JWTUserDetailsServiceTest.kt
@@ -11,6 +11,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import org.springframework.security.core.userdetails.UsernameNotFoundException
+import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
 class JWTUserDetailsServiceTest {
@@ -32,6 +33,7 @@ class JWTUserDetailsServiceTest {
                 email = "test@example.com",
                 phone = "1234567890",
                 active = true,
+                permissions = mutableSetOf(AdminPermission.SHUTTLE),
             )
         whenever(userRepository.findByUserIDAndActiveIsTrue(userID)).thenReturn(user)
         val userDetails = jwtUserDetailsService.loadUserByUsername(userID)
@@ -39,6 +41,7 @@ class JWTUserDetailsServiceTest {
         assert(userDetails.password == "testPassword")
         assert(userDetails.isEnabled)
         assert(userDetails.isAccountNonExpired)
+        assertEquals(listOf("SHUTTLE"), userDetails.authorities.map { it.authority })
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/security/WithCustomMockUser.kt
+++ b/src/test/kotlin/app/hyuabot/backend/security/WithCustomMockUser.kt
@@ -6,4 +6,5 @@ import org.springframework.security.test.context.support.WithSecurityContext
 @WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory::class)
 annotation class WithCustomMockUser(
     val username: String = "testUser",
+    val permissions: Array<AdminPermission> = [AdminPermission.SUPER_ADMIN],
 )

--- a/src/test/kotlin/app/hyuabot/backend/security/WithCustomMockUserSecurityContextFactory.kt
+++ b/src/test/kotlin/app/hyuabot/backend/security/WithCustomMockUserSecurityContextFactory.kt
@@ -12,9 +12,16 @@ class WithCustomMockUserSecurityContextFactory : WithSecurityContextFactory<With
                 JWTUser(
                     username = annotation.username,
                     password = "testPassword",
+                    permissions = annotation.permissions.toSet(),
                 ),
                 null,
-                emptyList(),
+                annotation.permissions
+                    .toSet()
+                    .effectivePermissions()
+                    .map {
+                        org.springframework.security.core.authority
+                            .SimpleGrantedAuthority(it.name)
+                    },
             )
         val context = SecurityContextHolder.createEmptyContext()
         context.authentication = auth


### PR DESCRIPTION
## Summary
- Add `SUPER_ADMIN` and area-scoped management permissions for shuttle, bus, subway, cafeteria, reading room, contact, calendar, and notice administration.
- Enforce permissions centrally on every REST request and reload current account state for JWT authentication.
- Add super-admin user listing and permission update APIs with last-super-admin protection under concurrent updates.
- Return effective permissions in the authenticated user profile and correct refresh-token validation/access-token renewal.
- Add controller, service, security, token, and entity coverage.

## Impact
Administrators can be restricted to only their assigned management areas. `SUPER_ADMIN` grants access to every area and to user permission management. Permission assignments are read from the `admin_user_permission` schema supplied by the paired infrastructure change.

## Validation
- `./gradlew ktlintCheck test --tests app.hyuabot.backend.security.AdminPermissionTest --tests app.hyuabot.backend.admin.AdminUserServiceTest --tests app.hyuabot.backend.auth.AuthServiceTest --tests app.hyuabot.backend.security.JWTUserDetailsServiceTest --tests app.hyuabot.backend.security.JWTTokenProviderTest --tests app.hyuabot.backend.database.entity.UserTest`
- Full Spring controller and coverage checks run in GitHub Actions with the repository test database configuration.