### PR TITLE
feat: Add administrator account deletion

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/admin/AdminUserController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/admin/AdminUserController.kt
@@ -6,6 +6,7 @@ import app.hyuabot.backend.admin.domain.UpdateAdminUserRequest
 import app.hyuabot.backend.admin.exception.AdminUserNotFoundException
 import app.hyuabot.backend.admin.exception.LastSuperAdminException
 import app.hyuabot.backend.admin.exception.PendingUserActivationException
+import app.hyuabot.backend.admin.exception.SelfDeletionException
 import app.hyuabot.backend.auth.exception.DuplicateEmailException
 import app.hyuabot.backend.auth.exception.DuplicateUserIDException
 import app.hyuabot.backend.auth.exception.InvalidInvitationException
@@ -15,6 +16,7 @@ import app.hyuabot.backend.utility.ResponseBuilder
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -83,6 +85,21 @@ class AdminUserController(
             ResponseBuilder.response(HttpStatus.CONFLICT, "LAST_SUPER_ADMIN_REQUIRED")
         } catch (_: PendingUserActivationException) {
             ResponseBuilder.response(HttpStatus.CONFLICT, "USER_SETUP_REQUIRED")
+        }
+
+    @DeleteMapping("/{userID}")
+    fun deleteUser(
+        @PathVariable userID: String,
+    ): ResponseEntity<ResponseBuilder.Message> =
+        try {
+            adminUserService.deleteUser(userID, currentUserID())
+            ResponseBuilder.response(HttpStatus.OK, "ADMIN_USER_DELETED")
+        } catch (_: AdminUserNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, "ADMIN_USER_NOT_FOUND")
+        } catch (_: LastSuperAdminException) {
+            ResponseBuilder.response(HttpStatus.CONFLICT, "LAST_SUPER_ADMIN_REQUIRED")
+        } catch (_: SelfDeletionException) {
+            ResponseBuilder.response(HttpStatus.CONFLICT, "SELF_DELETION_NOT_ALLOWED")
         }
 
     private fun currentUserID(): String = (SecurityContextHolder.getContext().authentication?.principal as JWTUser).username

--- a/src/main/kotlin/app/hyuabot/backend/admin/AdminUserService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/admin/AdminUserService.kt
@@ -7,24 +7,28 @@ import app.hyuabot.backend.admin.domain.UpdateAdminUserRequest
 import app.hyuabot.backend.admin.exception.AdminUserNotFoundException
 import app.hyuabot.backend.admin.exception.LastSuperAdminException
 import app.hyuabot.backend.admin.exception.PendingUserActivationException
+import app.hyuabot.backend.admin.exception.SelfDeletionException
 import app.hyuabot.backend.auth.UserInvitationService
 import app.hyuabot.backend.auth.exception.DuplicateEmailException
 import app.hyuabot.backend.auth.exception.DuplicateUserIDException
 import app.hyuabot.backend.auth.exception.InvalidUserInputException
 import app.hyuabot.backend.database.entity.User
 import app.hyuabot.backend.database.repository.AdminUserInvitationRepository
+import app.hyuabot.backend.database.repository.RefreshTokenRepository
 import app.hyuabot.backend.database.repository.UserRepository
 import app.hyuabot.backend.security.AdminPermission
 import app.hyuabot.backend.utility.LocalDateTimeBuilder
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import java.time.ZonedDateTime
+import java.util.UUID
 
 @Service
 class AdminUserService(
     private val userRepository: UserRepository,
     private val invitationRepository: AdminUserInvitationRepository,
     private val invitationService: UserInvitationService,
+    private val refreshTokenRepository: RefreshTokenRepository,
 ) {
     fun getUsers(): List<AdminUserResponse> {
         val invitations =
@@ -71,7 +75,7 @@ class AdminUserService(
         userID: String,
         createdBy: String,
     ): AdminUserInvitationResponse {
-        val user = userRepository.findByUserID(userID) ?: throw AdminUserNotFoundException()
+        val user = userRepository.findByUserID(userID)?.takeIf { it.deletedAt == null } ?: throw AdminUserNotFoundException()
         val invitation = invitationService.issue(userID, createdBy)
         return AdminUserInvitationResponse(
             user = AdminUserResponse.from(user, invitation.expiresAt),
@@ -86,7 +90,7 @@ class AdminUserService(
         request: UpdateAdminUserRequest,
     ): AdminUserResponse {
         val users = userRepository.findAllForPermissionUpdate()
-        val user = users.firstOrNull { it.userID == userID } ?: throw AdminUserNotFoundException()
+        val user = users.firstOrNull { it.userID == userID && it.deletedAt == null } ?: throw AdminUserNotFoundException()
         val removesActiveSuperAdmin =
             user.active &&
                 AdminPermission.SUPER_ADMIN in user.permissions &&
@@ -105,6 +109,36 @@ class AdminUserService(
         user.permissions.clear()
         user.permissions.addAll(request.permissions)
         return AdminUserResponse.from(userRepository.save(user))
+    }
+
+    @Transactional
+    fun deleteUser(
+        userID: String,
+        deletedBy: String,
+    ) {
+        val users = userRepository.findAllForPermissionUpdate()
+        val user = users.firstOrNull { it.userID == userID && it.deletedAt == null } ?: throw AdminUserNotFoundException()
+        if (userID == deletedBy) throw SelfDeletionException()
+        if (
+            user.active &&
+            AdminPermission.SUPER_ADMIN in user.permissions &&
+            users.count { it.deletedAt == null && it.active && AdminPermission.SUPER_ADMIN in it.permissions } <= 1
+        ) {
+            throw LastSuperAdminException()
+        }
+
+        val now = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
+        invitationRepository.findAllActiveRelatedForUpdate(userID).forEach { it.revokedAt = now }
+        refreshTokenRepository.findByUserID(userID)?.let(refreshTokenRepository::delete)
+        user.active = false
+        user.password = null
+        user.authVersion += 1
+        user.name = "삭제된 관리자"
+        user.email = "deleted-${UUID.randomUUID().toString().take(16)}@deleted.invalid"
+        user.phone = ""
+        user.permissions.clear()
+        user.deletedAt = now
+        userRepository.save(user)
     }
 
     private fun validate(request: CreateAdminUserRequest) {

--- a/src/main/kotlin/app/hyuabot/backend/admin/domain/AdminUserResponse.kt
+++ b/src/main/kotlin/app/hyuabot/backend/admin/domain/AdminUserResponse.kt
@@ -5,6 +5,7 @@ import app.hyuabot.backend.security.AdminPermission
 import java.time.ZonedDateTime
 
 enum class AdminUserStatus {
+    DELETED,
     PENDING_SETUP,
     INVITATION_EXPIRED,
     ACTIVE,
@@ -35,6 +36,7 @@ data class AdminUserResponse(
                 active = user.active,
                 status =
                     when {
+                        user.deletedAt != null -> AdminUserStatus.DELETED
                         user.password == null && invitationExpiresAt?.isAfter(now) == true ->
                             AdminUserStatus.PENDING_SETUP
                         user.password == null -> AdminUserStatus.INVITATION_EXPIRED

--- a/src/main/kotlin/app/hyuabot/backend/admin/exception/SelfDeletionException.kt
+++ b/src/main/kotlin/app/hyuabot/backend/admin/exception/SelfDeletionException.kt
@@ -1,0 +1,3 @@
+package app.hyuabot.backend.admin.exception
+
+class SelfDeletionException : RuntimeException("SELF_DELETION_NOT_ALLOWED")

--- a/src/main/kotlin/app/hyuabot/backend/auth/UserInvitationService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/auth/UserInvitationService.kt
@@ -35,7 +35,7 @@ class UserInvitationService(
         userID: String,
         createdBy: String,
     ): IssuedInvitation {
-        val user = userRepository.findByUserID(userID) ?: throw AdminUserNotFoundException()
+        val user = userRepository.findByUserID(userID)?.takeIf { it.deletedAt == null } ?: throw AdminUserNotFoundException()
         if (user.password != null) {
             throw InvalidInvitationException()
         }
@@ -81,7 +81,7 @@ class UserInvitationService(
         if (!invitation.expiresAt.isAfter(now)) {
             throw InvalidInvitationException()
         }
-        val user = userRepository.findByUserID(invitation.userID) ?: throw InvalidInvitationException()
+        val user = userRepository.findByUserID(invitation.userID)?.takeIf { it.deletedAt == null } ?: throw InvalidInvitationException()
         if (user.password != null) {
             throw InvalidInvitationException()
         }
@@ -115,7 +115,13 @@ class UserInvitationService(
 
         fun validatePassword(password: String) {
             val byteLength = password.toByteArray().size
-            if (password.length < 15 || byteLength > 72) {
+            if (
+                password.length < 8 ||
+                byteLength > 72 ||
+                !password.contains(Regex("[A-Za-z]")) ||
+                !password.contains(Regex("[0-9]")) ||
+                !password.contains(Regex("[\\p{P}\\p{S}]"))
+            ) {
                 throw InvalidUserInputException("INVALID_PASSWORD")
             }
         }

--- a/src/main/kotlin/app/hyuabot/backend/database/entity/User.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/entity/User.kt
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
+import java.time.ZonedDateTime
 
 @Entity(name = "user")
 @Table(name = "admin_user")
@@ -32,6 +33,8 @@ class User(
     var active: Boolean,
     @Column(name = "auth_version", nullable = false)
     var authVersion: Int = 0,
+    @Column(name = "deleted_at", columnDefinition = "timestamptz")
+    var deletedAt: ZonedDateTime? = null,
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(
         name = "admin_user_permission",

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/AdminUserInvitationRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/AdminUserInvitationRepository.kt
@@ -17,6 +17,19 @@ interface AdminUserInvitationRepository : JpaRepository<AdminUserInvitation, UUI
     @Query(
         """
         select invitation from admin_user_invitation invitation
+        where (invitation.userID = :userID or invitation.createdBy = :userID)
+          and invitation.consumedAt is null
+          and invitation.revokedAt is null
+        """,
+    )
+    fun findAllActiveRelatedForUpdate(
+        @Param("userID") userID: String,
+    ): List<AdminUserInvitation>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+        select invitation from admin_user_invitation invitation
         where invitation.tokenHash = :tokenHash
           and invitation.consumedAt is null
           and invitation.revokedAt is null

--- a/src/test/kotlin/app/hyuabot/backend/admin/AdminUserControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/admin/AdminUserControllerTest.kt
@@ -7,6 +7,7 @@ import app.hyuabot.backend.admin.domain.UpdateAdminUserRequest
 import app.hyuabot.backend.admin.exception.AdminUserNotFoundException
 import app.hyuabot.backend.admin.exception.LastSuperAdminException
 import app.hyuabot.backend.admin.exception.PendingUserActivationException
+import app.hyuabot.backend.admin.exception.SelfDeletionException
 import app.hyuabot.backend.auth.exception.DuplicateEmailException
 import app.hyuabot.backend.auth.exception.DuplicateUserIDException
 import app.hyuabot.backend.auth.exception.InvalidInvitationException
@@ -25,6 +26,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
@@ -200,6 +202,37 @@ class AdminUserControllerTest {
                     .content(objectMapper.writeValueAsString(request)),
             ).andExpect(status().isConflict)
             .andExpect(jsonPath("$.message").value("USER_SETUP_REQUIRED"))
+    }
+
+    @Test
+    @WithCustomMockUser
+    fun superAdminCanDeleteUser() {
+        mockMvc
+            .perform(delete("/api/v1/admin/users/user"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("ADMIN_USER_DELETED"))
+    }
+
+    @Test
+    @WithCustomMockUser
+    fun deleteUserMapsNotFoundAndSafetyConflicts() {
+        doThrow(AdminUserNotFoundException()).whenever(service).deleteUser("missing", "testUser")
+        mockMvc
+            .perform(delete("/api/v1/admin/users/missing"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("ADMIN_USER_NOT_FOUND"))
+
+        doThrow(LastSuperAdminException()).whenever(service).deleteUser("last-admin", "testUser")
+        mockMvc
+            .perform(delete("/api/v1/admin/users/last-admin"))
+            .andExpect(status().isConflict)
+            .andExpect(jsonPath("$.message").value("LAST_SUPER_ADMIN_REQUIRED"))
+
+        doThrow(SelfDeletionException()).whenever(service).deleteUser("testUser", "testUser")
+        mockMvc
+            .perform(delete("/api/v1/admin/users/testUser"))
+            .andExpect(status().isConflict)
+            .andExpect(jsonPath("$.message").value("SELF_DELETION_NOT_ALLOWED"))
     }
 
     private fun performCreate(request: CreateAdminUserRequest) =

--- a/src/test/kotlin/app/hyuabot/backend/admin/AdminUserServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/admin/AdminUserServiceTest.kt
@@ -1,19 +1,23 @@
 package app.hyuabot.backend.admin
 
+import app.hyuabot.backend.admin.domain.AdminUserResponse
 import app.hyuabot.backend.admin.domain.AdminUserStatus
 import app.hyuabot.backend.admin.domain.CreateAdminUserRequest
 import app.hyuabot.backend.admin.domain.UpdateAdminUserRequest
 import app.hyuabot.backend.admin.exception.AdminUserNotFoundException
 import app.hyuabot.backend.admin.exception.LastSuperAdminException
 import app.hyuabot.backend.admin.exception.PendingUserActivationException
+import app.hyuabot.backend.admin.exception.SelfDeletionException
 import app.hyuabot.backend.auth.IssuedInvitation
 import app.hyuabot.backend.auth.UserInvitationService
 import app.hyuabot.backend.auth.exception.DuplicateEmailException
 import app.hyuabot.backend.auth.exception.DuplicateUserIDException
 import app.hyuabot.backend.auth.exception.InvalidUserInputException
 import app.hyuabot.backend.database.entity.AdminUserInvitation
+import app.hyuabot.backend.database.entity.RefreshToken
 import app.hyuabot.backend.database.entity.User
 import app.hyuabot.backend.database.repository.AdminUserInvitationRepository
+import app.hyuabot.backend.database.repository.RefreshTokenRepository
 import app.hyuabot.backend.database.repository.UserRepository
 import app.hyuabot.backend.security.AdminPermission
 import org.junit.jupiter.api.Test
@@ -23,6 +27,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -40,6 +45,9 @@ class AdminUserServiceTest {
 
     @Mock
     lateinit var invitationService: UserInvitationService
+
+    @Mock
+    lateinit var refreshTokenRepository: RefreshTokenRepository
 
     @InjectMocks
     lateinit var service: AdminUserService
@@ -143,6 +151,9 @@ class AdminUserServiceTest {
 
         whenever(userRepository.findByUserID("missing")).thenReturn(null)
         assertThrows<AdminUserNotFoundException> { service.reissueInvitation("missing", "creator") }
+
+        whenever(userRepository.findByUserID("deleted")).thenReturn(user(id = "deleted").apply { deletedAt = ZonedDateTime.now() })
+        assertThrows<AdminUserNotFoundException> { service.reissueInvitation("deleted", "creator") }
     }
 
     @Test
@@ -168,6 +179,12 @@ class AdminUserServiceTest {
 
         assertThrows<AdminUserNotFoundException> {
             service.updateUser("missing", UpdateAdminUserRequest(true, emptySet()))
+        }
+
+        whenever(userRepository.findAllForPermissionUpdate())
+            .thenReturn(listOf(user(id = "deleted").apply { deletedAt = ZonedDateTime.now() }))
+        assertThrows<AdminUserNotFoundException> {
+            service.updateUser("deleted", UpdateAdminUserRequest(true, emptySet()))
         }
     }
 
@@ -245,5 +262,87 @@ class AdminUserServiceTest {
         assertThrows<PendingUserActivationException> {
             service.updateUser("user", UpdateAdminUserRequest(true, emptySet()))
         }
+    }
+
+    @Test
+    fun deleteUserAnonymizesAccountAndRevokesAccess() {
+        val target = user()
+        val admin = user(id = "admin", permissions = setOf(AdminPermission.SUPER_ADMIN))
+        val invitation =
+            AdminUserInvitation(
+                UUID.randomUUID(),
+                target.userID,
+                "hash",
+                target.userID,
+                ZonedDateTime.now().plusHours(1),
+                createdAt = ZonedDateTime.now(),
+            )
+        val refreshToken = org.mockito.kotlin.mock<RefreshToken>()
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(target, admin))
+        whenever(invitationRepository.findAllActiveRelatedForUpdate("user")).thenReturn(listOf(invitation))
+        whenever(refreshTokenRepository.findByUserID("user")).thenReturn(refreshToken)
+
+        service.deleteUser("user", "admin")
+
+        assertFalse(target.active)
+        assertEquals(null, target.password)
+        assertEquals(1, target.authVersion)
+        assertEquals("삭제된 관리자", target.name)
+        assertTrue(target.email.matches(Regex("deleted-[0-9a-f-]{16}@deleted\\.invalid")))
+        assertEquals("", target.phone)
+        assertTrue(target.permissions.isEmpty())
+        assertEquals(target.deletedAt, invitation.revokedAt)
+        verify(refreshTokenRepository).delete(refreshToken)
+        verify(userRepository).save(target)
+    }
+
+    @Test
+    fun deleteUserSucceedsWithoutInvitationOrRefreshToken() {
+        val target = user(active = false)
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(target))
+        whenever(invitationRepository.findAllActiveRelatedForUpdate("user")).thenReturn(emptyList())
+        whenever(refreshTokenRepository.findByUserID("user")).thenReturn(null)
+
+        service.deleteUser("user", "admin")
+
+        assertEquals(AdminUserStatus.DELETED, AdminUserResponse.from(target).status)
+        verifyNoInteractions(invitationService)
+    }
+
+    @Test
+    fun deleteUserRejectsMissingDeletedSelfAndLastSuperAdmin() {
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(emptyList())
+        assertThrows<AdminUserNotFoundException> { service.deleteUser("missing", "admin") }
+
+        val deleted = user(id = "deleted").apply { deletedAt = ZonedDateTime.now() }
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(deleted))
+        assertThrows<AdminUserNotFoundException> { service.deleteUser("deleted", "admin") }
+
+        val self = user(id = "admin", permissions = setOf(AdminPermission.SUPER_ADMIN))
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(self))
+        assertThrows<SelfDeletionException> { service.deleteUser("admin", "admin") }
+
+        val lastSuperAdmin = user(permissions = setOf(AdminPermission.SUPER_ADMIN))
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(lastSuperAdmin))
+        assertThrows<LastSuperAdminException> { service.deleteUser("user", "admin") }
+    }
+
+    @Test
+    fun deleteUserAllowsRemovingSuperAdminWhenAnotherRemains() {
+        val target = user(permissions = setOf(AdminPermission.SUPER_ADMIN))
+        val other = user(id = "other", permissions = setOf(AdminPermission.SUPER_ADMIN))
+        val deletedSuperAdmin =
+            user(id = "deleted", permissions = setOf(AdminPermission.SUPER_ADMIN)).apply {
+                deletedAt = ZonedDateTime.now()
+            }
+        val inactiveSuperAdmin = user(id = "inactive", active = false, permissions = setOf(AdminPermission.SUPER_ADMIN))
+        val regularAdmin = user(id = "regular")
+        whenever(userRepository.findAllForPermissionUpdate())
+            .thenReturn(listOf(target, deletedSuperAdmin, inactiveSuperAdmin, regularAdmin, other))
+        whenever(invitationRepository.findAllActiveRelatedForUpdate("user")).thenReturn(emptyList())
+
+        service.deleteUser("user", "admin")
+
+        assertEquals(AdminUserStatus.DELETED, AdminUserResponse.from(target).status)
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/admin/domain/AdminUserResponseTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/admin/domain/AdminUserResponseTest.kt
@@ -23,6 +23,10 @@ class AdminUserResponseTest {
     @Test
     fun mapsEveryAccountStatus() {
         assertEquals(
+            AdminUserStatus.DELETED,
+            AdminUserResponse.from(user().apply { deletedAt = now }, now = now).status,
+        )
+        assertEquals(
             AdminUserStatus.PENDING_SETUP,
             AdminUserResponse.from(user(password = null), now.plusMinutes(1), now).status,
         )

--- a/src/test/kotlin/app/hyuabot/backend/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/auth/AuthControllerTest.kt
@@ -127,7 +127,7 @@ class AuthControllerTest {
             .perform(
                 post("/api/v1/user/account-setup/complete")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("{\"token\":\"token\",\"password\":\"a-secure-password\"}"),
+                    .content("{\"token\":\"token\",\"password\":\"Password1!\"}"),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("ACCOUNT_SETUP_COMPLETE"))
     }
@@ -147,12 +147,12 @@ class AuthControllerTest {
 
         doThrow(InvalidInvitationException())
             .whenever(invitationService)
-            .complete("expired", "a-secure-password")
+            .complete("expired", "Password1!")
         mockMvc
             .perform(
                 post("/api/v1/user/account-setup/complete")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("{\"token\":\"expired\",\"password\":\"a-secure-password\"}"),
+                    .content("{\"token\":\"expired\",\"password\":\"Password1!\"}"),
             ).andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.message").value("INVALID_OR_EXPIRED_INVITATION"))
     }
@@ -443,7 +443,7 @@ class AuthControllerTest {
     @Test
     @WithCustomMockUser(username = "test_user")
     fun authenticatedUserCanChangePasswordAndErrorsAreMapped() {
-        val request = ChangePasswordRequest("current", "a-new-secure-password")
+        val request = ChangePasswordRequest("current", "Password1!")
         mockMvc
             .perform(
                 put("/api/v1/user/password")

--- a/src/test/kotlin/app/hyuabot/backend/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/auth/AuthServiceTest.kt
@@ -173,10 +173,10 @@ class AuthServiceTest {
         val refreshToken = mock<RefreshToken>()
         whenever(userRepository.findByUserIDAndActiveIsTrue("testUser")).thenReturn(user)
         whenever(passwordEncoder.matches("current", "encoded-password")).thenReturn(true)
-        whenever(passwordEncoder.encode("a-new-secure-password")).thenReturn("new-encoded")
+        whenever(passwordEncoder.encode("Password1!")).thenReturn("new-encoded")
         whenever(refreshTokenRepository.findByUserID("testUser")).thenReturn(refreshToken)
 
-        authService.changePassword("testUser", ChangePasswordRequest("current", "a-new-secure-password"))
+        authService.changePassword("testUser", ChangePasswordRequest("current", "Password1!"))
 
         assertEquals("new-encoded", user.password?.decodeToString())
         assertEquals(1, user.authVersion)
@@ -189,10 +189,10 @@ class AuthServiceTest {
         val user = user()
         whenever(userRepository.findByUserIDAndActiveIsTrue("testUser")).thenReturn(user)
         whenever(passwordEncoder.matches("current", "encoded-password")).thenReturn(true)
-        whenever(passwordEncoder.encode("a-new-secure-password")).thenReturn("new-encoded")
+        whenever(passwordEncoder.encode("Password1!")).thenReturn("new-encoded")
         whenever(refreshTokenRepository.findByUserID("testUser")).thenReturn(null)
 
-        authService.changePassword("testUser", ChangePasswordRequest("current", "a-new-secure-password"))
+        authService.changePassword("testUser", ChangePasswordRequest("current", "Password1!"))
 
         assertEquals("new-encoded", user.password?.decodeToString())
         assertEquals(1, user.authVersion)
@@ -204,12 +204,12 @@ class AuthServiceTest {
         whenever(userRepository.findByUserIDAndActiveIsTrue("testUser")).thenReturn(user)
         whenever(passwordEncoder.matches("wrong", "encoded-password")).thenReturn(false)
         assertThrows<BadCredentialsException> {
-            authService.changePassword("testUser", ChangePasswordRequest("wrong", "a-new-secure-password"))
+            authService.changePassword("testUser", ChangePasswordRequest("wrong", "Password1!"))
         }
 
         whenever(userRepository.findByUserIDAndActiveIsTrue("testUser")).thenReturn(user(password = null))
         assertThrows<BadCredentialsException> {
-            authService.changePassword("testUser", ChangePasswordRequest("current", "a-new-secure-password"))
+            authService.changePassword("testUser", ChangePasswordRequest("current", "Password1!"))
         }
 
         assertThrows<InvalidUserInputException> {
@@ -222,10 +222,10 @@ class AuthServiceTest {
         val user = user()
         whenever(userRepository.findByUserIDAndActiveIsTrue("testUser")).thenReturn(user)
         whenever(passwordEncoder.matches("current", "encoded-password")).thenReturn(true)
-        whenever(passwordEncoder.encode("a-new-secure-password")).thenReturn(null)
+        whenever(passwordEncoder.encode("Password1!")).thenReturn(null)
 
         assertThrows<InvalidUserInputException> {
-            authService.changePassword("testUser", ChangePasswordRequest("current", "a-new-secure-password"))
+            authService.changePassword("testUser", ChangePasswordRequest("current", "Password1!"))
         }
         assertTrue(user.authVersion == 0)
     }

--- a/src/test/kotlin/app/hyuabot/backend/auth/UserInvitationServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/auth/UserInvitationServiceTest.kt
@@ -81,6 +81,9 @@ class UserInvitationServiceTest {
 
         whenever(userRepository.findByUserID("new-user")).thenReturn(user("encoded".toByteArray()))
         assertThrows<InvalidInvitationException> { service.issue("new-user", "jil8885") }
+
+        whenever(userRepository.findByUserID("new-user")).thenReturn(user().apply { deletedAt = ZonedDateTime.now() })
+        assertThrows<AdminUserNotFoundException> { service.issue("new-user", "jil8885") }
     }
 
     @Test
@@ -108,9 +111,9 @@ class UserInvitationServiceTest {
         val user = user()
         whenever(invitationRepository.findActiveForUpdate(service.hash("token"))).thenReturn(invitation)
         whenever(userRepository.findByUserID("new-user")).thenReturn(user)
-        whenever(passwordEncoder.encode("a-secure-password")).thenReturn("encoded")
+        whenever(passwordEncoder.encode("Password1!")).thenReturn("encoded")
 
-        service.complete("token", "a-secure-password")
+        service.complete("token", "Password1!")
 
         assertTrue(user.active)
         assertEquals("encoded", user.password?.decodeToString())
@@ -121,32 +124,39 @@ class UserInvitationServiceTest {
 
     @Test
     fun completeRejectsInvalidInvitationStates() {
-        assertThrows<InvalidInvitationException> { service.complete("missing", "a-secure-password") }
+        assertThrows<InvalidInvitationException> { service.complete("missing", "Password1!") }
 
         val expired = invitation(expiresAt = ZonedDateTime.now().minusMinutes(1))
         whenever(invitationRepository.findActiveForUpdate(service.hash("expired"))).thenReturn(expired)
-        assertThrows<InvalidInvitationException> { service.complete("expired", "a-secure-password") }
+        assertThrows<InvalidInvitationException> { service.complete("expired", "Password1!") }
 
         val valid = invitation()
         whenever(invitationRepository.findActiveForUpdate(service.hash("unknown-user"))).thenReturn(valid)
         whenever(userRepository.findByUserID("new-user")).thenReturn(null)
-        assertThrows<InvalidInvitationException> { service.complete("unknown-user", "a-secure-password") }
+        assertThrows<InvalidInvitationException> { service.complete("unknown-user", "Password1!") }
 
         whenever(invitationRepository.findActiveForUpdate(service.hash("configured"))).thenReturn(valid)
         whenever(userRepository.findByUserID("new-user")).thenReturn(user("encoded".toByteArray()))
-        assertThrows<InvalidInvitationException> { service.complete("configured", "a-secure-password") }
+        assertThrows<InvalidInvitationException> { service.complete("configured", "Password1!") }
+
+        whenever(invitationRepository.findActiveForUpdate(service.hash("deleted"))).thenReturn(valid)
+        whenever(userRepository.findByUserID("new-user")).thenReturn(user().apply { deletedAt = ZonedDateTime.now() })
+        assertThrows<InvalidInvitationException> { service.complete("deleted", "Password1!") }
     }
 
     @Test
     fun completeRejectsInvalidPasswordAndEncoderFailure() {
-        assertThrows<InvalidUserInputException> { service.complete("token", "too-short") }
-        assertThrows<InvalidUserInputException> { service.complete("token", "가".repeat(25)) }
+        assertThrows<InvalidUserInputException> { service.complete("token", "Ab1!") }
+        assertThrows<InvalidUserInputException> { service.complete("token", "Password!") }
+        assertThrows<InvalidUserInputException> { service.complete("token", "Password1") }
+        assertThrows<InvalidUserInputException> { service.complete("token", "1234567!") }
+        assertThrows<InvalidUserInputException> { service.complete("token", "Ab1!" + "가".repeat(23)) }
 
         val invitation = invitation()
         whenever(invitationRepository.findActiveForUpdate(service.hash("token"))).thenReturn(invitation)
         whenever(userRepository.findByUserID("new-user")).thenReturn(user())
         whenever(passwordEncoder.encode(any())).thenReturn(null)
-        assertThrows<InvalidUserInputException> { service.complete("token", "a-secure-password") }
+        assertThrows<InvalidUserInputException> { service.complete("token", "Password1!") }
         assertNull(invitation.consumedAt)
     }
 

--- a/src/test/kotlin/app/hyuabot/backend/database/entity/UserTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/database/entity/UserTest.kt
@@ -2,6 +2,7 @@ package app.hyuabot.backend.database.entity
 
 import app.hyuabot.backend.security.AdminPermission
 import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -39,6 +40,7 @@ class UserTest {
         e.email = "y"
         e.phone = "y"
         e.active = true
+        e.deletedAt = ZonedDateTime.now()
         e.permissions.add(AdminPermission.NOTICE)
         assertEquals(setOf(AdminPermission.NOTICE), e.permissions)
     }


### PR DESCRIPTION
## Summary
- Enforce administrator passwords with at least eight characters including an English letter, number, and special character.
- Add super-administrator account deletion with self-deletion and last-super-administrator safeguards.
- Logically delete accounts, remove credentials and personal information, clear permissions, and revoke refresh tokens and active invitations.
- Preserve the administrator identifier so notices and other existing records retain their author relationship.
- Add controller, service, invitation, response, and entity coverage for deletion and password validation.

## Impact
Deleted administrators cannot sign in, be reactivated, or reuse the same identifier. Existing authored data remains linked to an anonymized administrator record.

The paired database schema must be applied before deployment so `admin_user.deleted_at` exists.

## Validation
- `./gradlew clean ktlintCheck test jacocoTestReport jacocoTestCoverageVerification`
- 1,371 tests passed with no failures.
- Every changed executable source file has 100% instruction coverage.
