### PR TITLE
feat: Add operations overview and safe timetable imports

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -118,5 +118,5 @@ jobs:
           paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
-          min-coverage-changed-files: 60
+          min-coverage-changed-files: 100
           update-comment: 'true'

--- a/src/main/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewController.kt
@@ -1,0 +1,22 @@
+package app.hyuabot.backend.adminoverview
+
+import app.hyuabot.backend.security.AdminPermission
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/user/overview")
+class AdminOverviewController(
+    private val service: AdminOverviewService,
+) {
+    @GetMapping
+    fun getOverview(authentication: Authentication) =
+        service.getOverview(
+            authentication.authorities
+                .mapNotNull { authority ->
+                    AdminPermission.entries.find { permission -> permission.name == authority.authority }
+                }.toSet(),
+        )
+}

--- a/src/main/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewService.kt
@@ -1,0 +1,158 @@
+package app.hyuabot.backend.adminoverview
+
+import app.hyuabot.backend.adminoverview.domain.AdminOverviewResponse
+import app.hyuabot.backend.adminoverview.domain.AdminServiceStatus
+import app.hyuabot.backend.adminoverview.domain.CronJobRun
+import app.hyuabot.backend.database.repository.AdminUserInvitationRepository
+import app.hyuabot.backend.security.AdminPermission
+import app.hyuabot.backend.shuttle.service.ShuttleHolidayService
+import app.hyuabot.backend.shuttle.service.ShuttlePeriodService
+import app.hyuabot.backend.utility.LocalDateTimeBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZonedDateTime
+
+@Service
+class AdminOverviewService(
+    private val prometheusClient: PrometheusClient,
+    private val shuttlePeriodService: ShuttlePeriodService,
+    private val shuttleHolidayService: ShuttleHolidayService,
+    private val invitationRepository: AdminUserInvitationRepository,
+    @param:Value("\${admin.overview.grafana-url:https://grafana.hyuabot.app}") private val grafanaURL: String,
+) {
+    fun getOverview(permissions: Set<AdminPermission>): AdminOverviewResponse =
+        getOverview(permissions, ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone))
+
+    internal fun getOverview(
+        permissions: Set<AdminPermission>,
+        now: ZonedDateTime,
+    ): AdminOverviewResponse {
+        val jobs = runCatching { prometheusClient.getCronJobRuns() }.getOrNull()
+        val services =
+            buildList {
+                if (AdminPermission.SHUTTLE in permissions) add(shuttleStatus(now.toLocalDate()))
+                JOBS.filter { it.permission in permissions }.forEach { definition ->
+                    add(jobStatus(definition, jobs?.get(definition.jobName), now.toInstant()))
+                }
+            }
+        val expiringInvitations =
+            if (AdminPermission.SUPER_ADMIN in permissions) {
+                invitationRepository
+                    .findAllByConsumedAtIsNullAndRevokedAtIsNull()
+                    .count { invitation -> invitation.expiresAt.isAfter(now) && !invitation.expiresAt.isAfter(now.plusHours(24)) }
+            } else {
+                null
+            }
+        return AdminOverviewResponse(
+            checkedAt = now.toString(),
+            services = services,
+            expiringInvitationCount = expiringInvitations,
+            grafanaURL = grafanaURL,
+        )
+    }
+
+    private fun shuttleStatus(date: LocalDate): AdminServiceStatus {
+        val period = shuttlePeriodService.findShuttlePeriod(date)
+        val holiday = shuttleHolidayService.findShuttleHoliday(date)
+        val status = if (period == null) "WARNING" else "NORMAL"
+        val periodLabel = period?.type?.let { PERIOD_LABELS[it] ?: it }
+        val message =
+            when {
+                period == null -> "현재 날짜에 적용되는 운행 기간이 없습니다."
+                holiday != null -> "$periodLabel · 오늘은 ${HOLIDAY_LABELS[holiday.type] ?: holiday.type}입니다."
+                else -> "$periodLabel 운행 기간입니다."
+            }
+        return AdminServiceStatus(
+            id = "shuttle",
+            title = "셔틀버스",
+            status = status,
+            message = message,
+            lastSuccessAt = null,
+            lastFailureAt = null,
+            managementPath = "/shuttle/period",
+        )
+    }
+
+    private fun jobStatus(
+        definition: JobDefinition,
+        run: CronJobRun?,
+        now: Instant,
+    ): AdminServiceStatus {
+        val success = run?.lastSuccessAt?.let(Instant::parse)
+        val failure = run?.lastFailureAt?.let(Instant::parse)
+        val outsideServiceHours = definition.serviceHoursOnly.and(now.atZone(LocalDateTimeBuilder.serviceTimezone).hour in 2..4)
+        val status =
+            when {
+                run == null -> "UNKNOWN"
+                failure != null && (success == null || failure.isAfter(success)) -> "ERROR"
+                success == null -> "WARNING"
+                !outsideServiceHours && Duration.between(success, now) > definition.staleAfter -> "WARNING"
+                else -> "NORMAL"
+            }
+        val message =
+            when (status) {
+                "ERROR" -> "최근 데이터 수집 작업이 실패했습니다."
+                "WARNING" -> "최근 데이터 갱신 시각을 확인해주세요."
+                "UNKNOWN" -> "수집 작업 상태를 확인할 수 없습니다."
+                else -> if (outsideServiceHours) "현재는 실시간 수집 운영 시간 외입니다." else "데이터 수집이 정상입니다."
+            }
+        return AdminServiceStatus(
+            id = definition.id,
+            title = definition.title,
+            status = status,
+            message = message,
+            lastSuccessAt = run?.lastSuccessAt,
+            lastFailureAt = run?.lastFailureAt,
+            managementPath = definition.managementPath,
+        )
+    }
+
+    private data class JobDefinition(
+        val id: String,
+        val title: String,
+        val permission: AdminPermission,
+        val jobName: String,
+        val staleAfter: Duration,
+        val managementPath: String,
+        val serviceHoursOnly: Boolean = false,
+    )
+
+    companion object {
+        private val PERIOD_LABELS =
+            mapOf(
+                "semester" to "학기",
+                "vacation_session" to "계절학기",
+                "vacation" to "방학",
+            )
+        private val HOLIDAY_LABELS =
+            mapOf(
+                "weekends" to "주말/공휴일",
+                "halt" to "운행 중지일",
+            )
+        private val JOBS =
+            listOf(
+                JobDefinition("bus", "노선버스", AdminPermission.BUS, "bus-realtime-cron-job", Duration.ofMinutes(10), "/bus/realtime", true),
+                JobDefinition(
+                    "subway",
+                    "전철",
+                    AdminPermission.SUBWAY,
+                    "subway-realtime-cron-job",
+                    Duration.ofMinutes(10),
+                    "/subway/realtime",
+                    true,
+                ),
+                JobDefinition("cafeteria", "학식", AdminPermission.CAFETERIA, "cafeteria-cron-job", Duration.ofHours(2), "/cafeteria/menu"),
+                JobDefinition(
+                    "reading-room",
+                    "열람실",
+                    AdminPermission.READING_ROOM,
+                    "reading-room-cron-job",
+                    Duration.ofMinutes(5),
+                    "/readingRoom/room",
+                ),
+            )
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/adminoverview/PrometheusClient.kt
+++ b/src/main/kotlin/app/hyuabot/backend/adminoverview/PrometheusClient.kt
@@ -1,0 +1,67 @@
+package app.hyuabot.backend.adminoverview
+
+import app.hyuabot.backend.adminoverview.domain.CronJobRun
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import java.time.Instant
+
+@Component
+class PrometheusClient(
+    @param:Value("\${admin.overview.prometheus-base-url:http://prometheus:9090}") baseURL: String,
+) {
+    private val restClient = RestClient.builder().baseUrl(baseURL).build()
+
+    fun getCronJobRuns(): Map<String, CronJobRun> {
+        val successes = query(LAST_SUCCESS_QUERY)
+        val failures = query(LAST_FAILURE_QUERY)
+        return (successes.keys + failures.keys).associateWith { name ->
+            CronJobRun(
+                lastSuccessAt = successes[name]?.toString(),
+                lastFailureAt = failures[name]?.toString(),
+            )
+        }
+    }
+
+    private fun query(expression: String): Map<String, Instant> {
+        val response =
+            restClient
+                .get()
+                .uri("/api/v1/query?query={query}", expression)
+                .retrieve()
+                .body(PrometheusResponse::class.java)
+                ?: throw IllegalStateException("Prometheus returned an empty response")
+        if (response.status != "success") throw IllegalStateException("Prometheus query failed")
+        return response.data.result
+            .mapNotNull { result ->
+                val name = result.metric["owner_name"] ?: return@mapNotNull null
+                val seconds =
+                    result.value
+                        .getOrNull(1)
+                        ?.toString()
+                        ?.toDoubleOrNull() ?: return@mapNotNull null
+                name to Instant.ofEpochSecond(seconds.toLong())
+            }.toMap()
+    }
+
+    private data class PrometheusResponse(
+        val status: String,
+        val data: PrometheusData,
+    )
+
+    private data class PrometheusData(
+        val result: List<PrometheusResult>,
+    )
+
+    private data class PrometheusResult(
+        val metric: Map<String, String>,
+        val value: List<Any>,
+    )
+
+    companion object {
+        private const val LAST_SUCCESS_QUERY =
+            "max by (owner_name) ((kube_job_status_completion_time{namespace=\"hyuabot\"} * on(job_name) group_left(owner_name) kube_job_owner{namespace=\"hyuabot\",owner_kind=\"CronJob\"}) * on(job_name) group_left() (kube_job_status_succeeded{namespace=\"hyuabot\"} > 0))"
+        private const val LAST_FAILURE_QUERY =
+            "max by (owner_name) ((kube_job_status_start_time{namespace=\"hyuabot\"} * on(job_name) group_left(owner_name) kube_job_owner{namespace=\"hyuabot\",owner_kind=\"CronJob\"}) * on(job_name) group_left() (kube_job_status_failed{namespace=\"hyuabot\"} > 0))"
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/adminoverview/domain/AdminOverviewModels.kt
+++ b/src/main/kotlin/app/hyuabot/backend/adminoverview/domain/AdminOverviewModels.kt
@@ -1,0 +1,23 @@
+package app.hyuabot.backend.adminoverview.domain
+
+data class AdminOverviewResponse(
+    val checkedAt: String,
+    val services: List<AdminServiceStatus>,
+    val expiringInvitationCount: Int?,
+    val grafanaURL: String,
+)
+
+data class AdminServiceStatus(
+    val id: String,
+    val title: String,
+    val status: String,
+    val message: String,
+    val lastSuccessAt: String?,
+    val lastFailureAt: String?,
+    val managementPath: String,
+)
+
+data class CronJobRun(
+    val lastSuccessAt: String?,
+    val lastFailureAt: String?,
+)

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/ShuttleTimetableRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/ShuttleTimetableRepository.kt
@@ -1,11 +1,24 @@
 package app.hyuabot.backend.database.repository
 
 import app.hyuabot.backend.database.entity.ShuttleTimetable
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalTime
 
 interface ShuttleTimetableRepository : JpaRepository<ShuttleTimetable, Int> {
     fun findByRouteName(routeName: String): List<ShuttleTimetable>
+
+    fun findByRouteNameIn(routeNames: List<String>): List<ShuttleTimetable>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT timetable FROM shuttle_timetable timetable WHERE timetable.routeName IN :routeNames")
+    fun findByRouteNameInForUpdate(routeNames: List<String>): List<ShuttleTimetable>
+
+    @Transactional
+    fun deleteAllByRouteNameIn(routeNames: List<String>)
 
     fun findByPeriodType(periodType: String): List<ShuttleTimetable>
 

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/SubwayTimetableRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/SubwayTimetableRepository.kt
@@ -1,13 +1,21 @@
 package app.hyuabot.backend.database.repository
 
 import app.hyuabot.backend.database.entity.SubwayTimetable
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalTime
 
 interface SubwayTimetableRepository : JpaRepository<SubwayTimetable, Int> {
     fun findByStationID(stationID: String): List<SubwayTimetable>
+
+    fun findByStationIDIn(stationIDs: List<String>): List<SubwayTimetable>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT timetable FROM subway_timetable timetable WHERE timetable.stationID IN :stationIDs")
+    fun findByStationIDInForUpdate(stationIDs: List<String>): List<SubwayTimetable>
 
     fun findByStationIDAndDepartureTimeAfter(
         stationID: String,

--- a/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
@@ -89,7 +89,7 @@ class SecurityConfig(
                         AdminPermission.CAFETERIA.name,
                         AdminPermission.READING_ROOM.name,
                         AdminPermission.CONTACT.name,
-                    ).requestMatchers("/api/v1/user/profile", "/api/v1/user/password")
+                    ).requestMatchers("/api/v1/user/profile", "/api/v1/user/password", "/api/v1/user/overview")
                     .authenticated()
                     .anyRequest()
                     .denyAll()

--- a/src/main/kotlin/app/hyuabot/backend/timetableimport/ShuttleTimetableImportService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/timetableimport/ShuttleTimetableImportService.kt
@@ -1,0 +1,152 @@
+package app.hyuabot.backend.timetableimport
+
+import app.hyuabot.backend.database.entity.ShuttleTimetable
+import app.hyuabot.backend.database.repository.ShuttlePeriodTypeRepository
+import app.hyuabot.backend.database.repository.ShuttleRouteRepository
+import app.hyuabot.backend.database.repository.ShuttleTimetableRepository
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportEntry
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportRequest
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportSnapshot
+import app.hyuabot.backend.timetableimport.domain.TimetableImportApplyResponse
+import app.hyuabot.backend.timetableimport.domain.TimetableImportChange
+import app.hyuabot.backend.timetableimport.domain.TimetableImportIssue
+import app.hyuabot.backend.timetableimport.domain.TimetableImportPreviewResponse
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalTime
+
+@Service
+class ShuttleTimetableImportService(
+    private val routeRepository: ShuttleRouteRepository,
+    private val periodTypeRepository: ShuttlePeriodTypeRepository,
+    private val timetableRepository: ShuttleTimetableRepository,
+    private val store: TimetableImportStore,
+) {
+    fun preview(request: ShuttleTimetableImportRequest): TimetableImportPreviewResponse {
+        val scope = request.routeNames.distinct()
+        val errors = validate(request, scope)
+        if (errors.isNotEmpty()) return emptyPreview(errors)
+
+        val current = timetableRepository.findByRouteNameIn(scope)
+        val currentKeys = current.map(::key).toSet()
+        val incomingKeys = request.entries.map(::key).toSet()
+        val createKeys = incomingKeys - currentKeys
+        val deleteKeys = currentKeys - incomingKeys
+        val unchangedCount = incomingKeys.intersect(currentKeys).size
+        val result = TimetableImportApplyResponse(createKeys.size, 0, deleteKeys.size, unchangedCount)
+        val snapshot =
+            ShuttleTimetableImportSnapshot(
+                request = request.copy(routeNames = scope),
+                fingerprint = fingerprint(current),
+                result = result,
+            )
+        val stored = store.save(TYPE, snapshot)
+        val changes =
+            buildList {
+                createKeys.take(SAMPLE_LIMIT).forEach { timetableKey ->
+                    add(TimetableImportChange("CREATE", timetableKey.replace("|", " · "), null, "새 시간표"))
+                }
+                deleteKeys.take((SAMPLE_LIMIT - size).coerceAtLeast(0)).forEach { timetableKey ->
+                    add(TimetableImportChange("DELETE", timetableKey.replace("|", " · "), "기존 시간표", null))
+                }
+            }
+        val warnings =
+            if (deleteKeys.isEmpty()) {
+                emptyList()
+            } else {
+                listOf(TimetableImportIssue(null, "DELETE_EXISTING", "기존 시간표 ${deleteKeys.size}건이 삭제됩니다."))
+            }
+        return TimetableImportPreviewResponse(
+            previewID = stored.id,
+            expiresAt = stored.expiresAt.toString(),
+            createCount = result.createCount,
+            updateCount = result.updateCount,
+            deleteCount = result.deleteCount,
+            unchangedCount = result.unchangedCount,
+            errors = emptyList(),
+            warnings = warnings,
+            sampleChanges = changes,
+        )
+    }
+
+    @CacheEvict(cacheNames = ["shuttleTimetable"], allEntries = true)
+    @Transactional
+    fun apply(previewID: String): TimetableImportApplyResponse {
+        store.acquire(TYPE, previewID)
+        try {
+            val snapshot = store.load(TYPE, previewID, ShuttleTimetableImportSnapshot::class.java)
+            val current = timetableRepository.findByRouteNameInForUpdate(snapshot.request.routeNames)
+            if (fingerprint(current) != snapshot.fingerprint) throw TimetableImportException("PREVIEW_STALE")
+            timetableRepository.deleteAllByRouteNameIn(snapshot.request.routeNames)
+            timetableRepository.flush()
+            timetableRepository.saveAll(snapshot.request.entries.map(::toEntity))
+            store.consume(TYPE, previewID)
+            return snapshot.result
+        } finally {
+            store.release(TYPE, previewID)
+        }
+    }
+
+    private fun validate(
+        request: ShuttleTimetableImportRequest,
+        scope: List<String>,
+    ): List<TimetableImportIssue> {
+        val issues = mutableListOf<TimetableImportIssue>()
+        if (scope.isEmpty()) issues += TimetableImportIssue(null, "EMPTY_SCOPE", "교체할 셔틀 노선을 선택해주세요.")
+        if (request.entries.isEmpty()) issues += TimetableImportIssue(null, "EMPTY_IMPORT", "업로드할 시간표가 없습니다.")
+        val existingRoutes = routeRepository.findAllById((scope + request.entries.map { it.routeName }).distinct()).map { it.name }.toSet()
+        val existingPeriods = periodTypeRepository.findAllById(request.entries.map { it.period }.distinct()).map { it.type }.toSet()
+        request.entries.forEachIndexed { index, entry ->
+            val row = index + 1
+            if (entry.routeName !in scope) issues += TimetableImportIssue(row, "OUT_OF_SCOPE", "교체 대상이 아닌 노선입니다: ${entry.routeName}")
+            if (entry.routeName !in
+                existingRoutes
+            ) {
+                issues += TimetableImportIssue(row, "ROUTE_NOT_FOUND", "존재하지 않는 노선입니다: ${entry.routeName}")
+            }
+            if (entry.period !in
+                existingPeriods
+            ) {
+                issues += TimetableImportIssue(row, "PERIOD_NOT_FOUND", "존재하지 않는 운행 종류입니다: ${entry.period}")
+            }
+            if (runCatching { LocalTime.parse(entry.departureTime) }.isFailure) {
+                issues += TimetableImportIssue(row, "INVALID_TIME", "출발 시각 형식이 올바르지 않습니다.")
+            }
+        }
+        request.entries
+            .groupBy { entry -> runCatching { key(entry) }.getOrNull() }
+            .filter { (timetableKey, entries) -> timetableKey != null && entries.size > 1 }
+            .forEach { (_, entries) ->
+                issues += TimetableImportIssue(null, "DUPLICATE_ENTRY", "중복된 시간표가 ${entries.size}건 있습니다: ${entries.first().description()}")
+            }
+        return issues
+    }
+
+    private fun emptyPreview(errors: List<TimetableImportIssue>) =
+        TimetableImportPreviewResponse(null, null, 0, 0, 0, 0, errors, emptyList(), emptyList())
+
+    private fun fingerprint(timetables: List<ShuttleTimetable>) = TimetableImportSupport.fingerprint(timetables.map(::key))
+
+    private fun key(timetable: ShuttleTimetable) =
+        "${timetable.routeName}|${timetable.periodType}|${timetable.weekday}|${timetable.departureTime}"
+
+    private fun key(timetable: ShuttleTimetableImportEntry) =
+        "${timetable.routeName}|${timetable.period}|${timetable.weekday}|${LocalTime.parse(timetable.departureTime)}"
+
+    private fun ShuttleTimetableImportEntry.description() = "$routeName · $period · ${if (weekday) "평일" else "주말"} · $departureTime"
+
+    private fun toEntity(payload: ShuttleTimetableImportEntry) =
+        ShuttleTimetable(
+            routeName = payload.routeName,
+            periodType = payload.period,
+            weekday = payload.weekday,
+            departureTime = LocalTime.parse(payload.departureTime),
+            route = null,
+        )
+
+    companion object {
+        private const val TYPE = "shuttle"
+        private const val SAMPLE_LIMIT = 20
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/timetableimport/SubwayTimetableImportService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/timetableimport/SubwayTimetableImportService.kt
@@ -1,0 +1,191 @@
+package app.hyuabot.backend.timetableimport
+
+import app.hyuabot.backend.database.entity.SubwayTimetable
+import app.hyuabot.backend.database.repository.SubwayStationRepository
+import app.hyuabot.backend.database.repository.SubwayTimetableRepository
+import app.hyuabot.backend.subway.domain.BulkSubwayTimetableCreateRequest
+import app.hyuabot.backend.timetableimport.domain.SubwayTimetableImportRequest
+import app.hyuabot.backend.timetableimport.domain.SubwayTimetableImportSnapshot
+import app.hyuabot.backend.timetableimport.domain.TimetableImportApplyResponse
+import app.hyuabot.backend.timetableimport.domain.TimetableImportChange
+import app.hyuabot.backend.timetableimport.domain.TimetableImportIssue
+import app.hyuabot.backend.timetableimport.domain.TimetableImportPreviewResponse
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalTime
+
+@Service
+class SubwayTimetableImportService(
+    private val stationRepository: SubwayStationRepository,
+    private val timetableRepository: SubwayTimetableRepository,
+    private val store: TimetableImportStore,
+) {
+    fun preview(request: SubwayTimetableImportRequest): TimetableImportPreviewResponse {
+        val scope = request.stationIDs.distinct()
+        val errors = validate(request, scope)
+        if (errors.isNotEmpty()) return emptyPreview(errors)
+
+        val current = timetableRepository.findByStationIDIn(scope)
+        val currentByKey = current.associateBy(::key)
+        val incomingByKey = request.entries.associateBy(::key)
+        val createKeys = incomingByKey.keys - currentByKey.keys
+        val deleteKeys = currentByKey.keys - incomingByKey.keys
+        val updateKeys =
+            (incomingByKey.keys intersect currentByKey.keys)
+                .filter { timetableKey ->
+                    val incoming = incomingByKey.getValue(timetableKey)
+                    val existing = currentByKey.getValue(timetableKey)
+                    incoming.startStationID != existing.startStationID || incoming.terminalStationID != existing.terminalStationID
+                }.toSet()
+        val unchangedCount = incomingByKey.keys.intersect(currentByKey.keys).size - updateKeys.size
+        val result =
+            TimetableImportApplyResponse(
+                createCount = createKeys.size,
+                updateCount = updateKeys.size,
+                deleteCount = deleteKeys.size,
+                unchangedCount = unchangedCount,
+            )
+        val snapshot =
+            SubwayTimetableImportSnapshot(
+                request = request.copy(stationIDs = scope),
+                fingerprint = fingerprint(current),
+                result = result,
+            )
+        val stored = store.save(TYPE, snapshot)
+        val changes =
+            buildList {
+                createKeys.take(SAMPLE_LIMIT).forEach { timetableKey ->
+                    add(change("CREATE", timetableKey, null, incomingByKey.getValue(timetableKey).description()))
+                }
+                updateKeys.take(remainingCapacity()).forEach { timetableKey ->
+                    add(
+                        change(
+                            "UPDATE",
+                            timetableKey,
+                            currentByKey.getValue(timetableKey).description(),
+                            incomingByKey.getValue(timetableKey).description(),
+                        ),
+                    )
+                }
+                deleteKeys.take(remainingCapacity()).forEach { timetableKey ->
+                    add(change("DELETE", timetableKey, currentByKey.getValue(timetableKey).description(), null))
+                }
+            }
+        val warnings =
+            if (deleteKeys.isEmpty()) {
+                emptyList()
+            } else {
+                listOf(TimetableImportIssue(null, "DELETE_EXISTING", "기존 시간표 ${deleteKeys.size}건이 삭제됩니다."))
+            }
+        return TimetableImportPreviewResponse(
+            previewID = stored.id,
+            expiresAt = stored.expiresAt.toString(),
+            createCount = result.createCount,
+            updateCount = result.updateCount,
+            deleteCount = result.deleteCount,
+            unchangedCount = result.unchangedCount,
+            errors = emptyList(),
+            warnings = warnings,
+            sampleChanges = changes,
+        )
+    }
+
+    @CacheEvict(cacheNames = ["subwayTimetable"], allEntries = true)
+    @Transactional
+    fun apply(previewID: String): TimetableImportApplyResponse {
+        store.acquire(TYPE, previewID)
+        try {
+            val snapshot = store.load(TYPE, previewID, SubwayTimetableImportSnapshot::class.java)
+            val current = timetableRepository.findByStationIDInForUpdate(snapshot.request.stationIDs)
+            if (fingerprint(current) != snapshot.fingerprint) throw TimetableImportException("PREVIEW_STALE")
+            timetableRepository.deleteAllByStationIDIn(snapshot.request.stationIDs)
+            timetableRepository.flush()
+            timetableRepository.saveAll(snapshot.request.entries.map(::toEntity))
+            store.consume(TYPE, previewID)
+            return snapshot.result
+        } finally {
+            store.release(TYPE, previewID)
+        }
+    }
+
+    private fun validate(
+        request: SubwayTimetableImportRequest,
+        scope: List<String>,
+    ): List<TimetableImportIssue> {
+        val issues = mutableListOf<TimetableImportIssue>()
+        if (scope.isEmpty()) issues += TimetableImportIssue(null, "EMPTY_SCOPE", "교체할 전철역을 선택해주세요.")
+        if (request.entries.isEmpty()) issues += TimetableImportIssue(null, "EMPTY_IMPORT", "업로드할 시간표가 없습니다.")
+
+        val allStationIDs =
+            (scope + request.entries.flatMap { listOf(it.stationID, it.startStationID, it.terminalStationID) }).distinct()
+        val existingStationIDs = stationRepository.findByIdIn(allStationIDs).map { it.id }.toSet()
+        request.entries.forEachIndexed { index, entry ->
+            val row = index + 1
+            if (entry.stationID !in scope) issues += TimetableImportIssue(row, "OUT_OF_SCOPE", "교체 대상이 아닌 역입니다: ${entry.stationID}")
+            if (runCatching { LocalTime.parse(entry.departureTime) }.isFailure) {
+                issues += TimetableImportIssue(row, "INVALID_TIME", "출발 시각 형식이 올바르지 않습니다.")
+            }
+            if (entry.weekday !in WEEKDAYS) issues += TimetableImportIssue(row, "INVALID_WEEKDAY", "요일 구분이 올바르지 않습니다.")
+            if (entry.direction !in DIRECTIONS) issues += TimetableImportIssue(row, "INVALID_DIRECTION", "행선 구분이 올바르지 않습니다.")
+            listOf(entry.stationID, entry.startStationID, entry.terminalStationID)
+                .filterNot(existingStationIDs::contains)
+                .distinct()
+                .forEach { stationID ->
+                    issues += TimetableImportIssue(row, "STATION_NOT_FOUND", "존재하지 않는 역입니다: $stationID")
+                }
+        }
+        request.entries
+            .groupBy { entry -> runCatching { key(entry) }.getOrNull() }
+            .filter { (timetableKey, entries) -> timetableKey != null && entries.size > 1 }
+            .forEach { (_, entries) ->
+                issues += TimetableImportIssue(null, "DUPLICATE_ENTRY", "중복된 시간표가 ${entries.size}건 있습니다: ${entries.first().description()}")
+            }
+        return issues
+    }
+
+    private fun emptyPreview(errors: List<TimetableImportIssue>) =
+        TimetableImportPreviewResponse(null, null, 0, 0, 0, 0, errors, emptyList(), emptyList())
+
+    private fun fingerprint(timetables: List<SubwayTimetable>) =
+        TimetableImportSupport.fingerprint(timetables.map { "${key(it)}|${it.startStationID}|${it.terminalStationID}" })
+
+    private fun key(timetable: SubwayTimetable) =
+        "${timetable.stationID}|${timetable.weekday}|${timetable.heading}|${timetable.departureTime}"
+
+    private fun key(timetable: BulkSubwayTimetableCreateRequest) =
+        "${timetable.stationID}|${timetable.weekday}|${timetable.direction}|${LocalTime.parse(timetable.departureTime)}"
+
+    private fun SubwayTimetable.description() = "$startStationID → $terminalStationID"
+
+    private fun BulkSubwayTimetableCreateRequest.description() = "$startStationID → $terminalStationID"
+
+    private fun change(
+        type: String,
+        identifier: String,
+        before: String?,
+        after: String?,
+    ) = TimetableImportChange(type, identifier.replace("|", " · "), before, after)
+
+    private fun MutableList<TimetableImportChange>.remainingCapacity() = (SAMPLE_LIMIT - size).coerceAtLeast(0)
+
+    private fun toEntity(payload: BulkSubwayTimetableCreateRequest) =
+        SubwayTimetable(
+            stationID = payload.stationID,
+            startStationID = payload.startStationID,
+            terminalStationID = payload.terminalStationID,
+            departureTime = LocalTime.parse(payload.departureTime),
+            weekday = payload.weekday,
+            heading = payload.direction,
+            station = null,
+            startStation = null,
+            terminalStation = null,
+        )
+
+    companion object {
+        private const val TYPE = "subway"
+        private const val SAMPLE_LIMIT = 20
+        private val WEEKDAYS = setOf("weekdays", "weekends")
+        private val DIRECTIONS = setOf("up", "down")
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/timetableimport/TimetableImportController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/timetableimport/TimetableImportController.kt
@@ -1,0 +1,67 @@
+package app.hyuabot.backend.timetableimport
+
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportRequest
+import app.hyuabot.backend.timetableimport.domain.SubwayTimetableImportRequest
+import app.hyuabot.backend.timetableimport.domain.TimetableImportApplyRequest
+import app.hyuabot.backend.utility.ResponseBuilder
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/subway/timetable/import")
+class SubwayTimetableImportController(
+    private val service: SubwayTimetableImportService,
+) {
+    @PostMapping("/preview")
+    fun preview(
+        @RequestBody request: SubwayTimetableImportRequest,
+    ) = service.preview(request)
+
+    @PostMapping("/apply")
+    fun apply(
+        @RequestBody request: TimetableImportApplyRequest,
+    ) = service.apply(request.previewID)
+
+    @ExceptionHandler(TimetableImportException::class)
+    fun handleImportException(exception: TimetableImportException): ResponseEntity<ResponseBuilder.Message> =
+        ResponseBuilder.response(
+            if (exception.code == "PREVIEW_STALE" || exception.code == "PREVIEW_ALREADY_APPLYING") {
+                HttpStatus.CONFLICT
+            } else {
+                HttpStatus.NOT_FOUND
+            },
+            exception.code,
+        )
+}
+
+@RestController
+@RequestMapping("/api/v1/shuttle/timetable/import")
+class ShuttleTimetableImportController(
+    private val service: ShuttleTimetableImportService,
+) {
+    @PostMapping("/preview")
+    fun preview(
+        @RequestBody request: ShuttleTimetableImportRequest,
+    ) = service.preview(request)
+
+    @PostMapping("/apply")
+    fun apply(
+        @RequestBody request: TimetableImportApplyRequest,
+    ) = service.apply(request.previewID)
+
+    @ExceptionHandler(TimetableImportException::class)
+    fun handleImportException(exception: TimetableImportException): ResponseEntity<ResponseBuilder.Message> =
+        ResponseBuilder.response(
+            if (exception.code == "PREVIEW_STALE" || exception.code == "PREVIEW_ALREADY_APPLYING") {
+                HttpStatus.CONFLICT
+            } else {
+                HttpStatus.NOT_FOUND
+            },
+            exception.code,
+        )
+}

--- a/src/main/kotlin/app/hyuabot/backend/timetableimport/TimetableImportException.kt
+++ b/src/main/kotlin/app/hyuabot/backend/timetableimport/TimetableImportException.kt
@@ -1,0 +1,5 @@
+package app.hyuabot.backend.timetableimport
+
+class TimetableImportException(
+    val code: String,
+) : IllegalStateException(code)

--- a/src/main/kotlin/app/hyuabot/backend/timetableimport/TimetableImportStore.kt
+++ b/src/main/kotlin/app/hyuabot/backend/timetableimport/TimetableImportStore.kt
@@ -1,0 +1,76 @@
+package app.hyuabot.backend.timetableimport
+
+import app.hyuabot.backend.utility.LocalDateTimeBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+import java.time.Duration
+import java.time.ZonedDateTime
+import java.util.UUID
+
+data class StoredTimetableImport(
+    val id: String,
+    val expiresAt: ZonedDateTime,
+)
+
+@Component
+class TimetableImportStore(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+    @param:Value("\${admin.timetable-import.preview-ttl-minutes:15}") private val ttlMinutes: Long,
+) {
+    fun save(
+        type: String,
+        snapshot: Any,
+    ): StoredTimetableImport {
+        val id = UUID.randomUUID().toString()
+        val ttl = Duration.ofMinutes(ttlMinutes)
+        redisTemplate.opsForValue().set(dataKey(type, id), objectMapper.writeValueAsString(snapshot), ttl)
+        return StoredTimetableImport(
+            id = id,
+            expiresAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone).plus(ttl),
+        )
+    }
+
+    fun <T> load(
+        type: String,
+        id: String,
+        valueType: Class<T>,
+    ): T {
+        val value = redisTemplate.opsForValue().get(dataKey(type, id)) ?: throw TimetableImportException("PREVIEW_NOT_FOUND")
+        return objectMapper.readValue(value, valueType)
+    }
+
+    fun acquire(
+        type: String,
+        id: String,
+    ) {
+        val acquired = redisTemplate.opsForValue().setIfAbsent(lockKey(type, id), "locked", Duration.ofMinutes(1)) == true
+        if (!acquired) throw TimetableImportException("PREVIEW_ALREADY_APPLYING")
+    }
+
+    fun consume(
+        type: String,
+        id: String,
+    ) {
+        redisTemplate.delete(dataKey(type, id))
+    }
+
+    fun release(
+        type: String,
+        id: String,
+    ) {
+        redisTemplate.delete(lockKey(type, id))
+    }
+
+    private fun dataKey(
+        type: String,
+        id: String,
+    ) = "admin:timetable-import:$type:$id"
+
+    private fun lockKey(
+        type: String,
+        id: String,
+    ) = "admin:timetable-import:$type:$id:lock"
+}

--- a/src/main/kotlin/app/hyuabot/backend/timetableimport/TimetableImportSupport.kt
+++ b/src/main/kotlin/app/hyuabot/backend/timetableimport/TimetableImportSupport.kt
@@ -1,0 +1,13 @@
+package app.hyuabot.backend.timetableimport
+
+import java.security.MessageDigest
+
+object TimetableImportSupport {
+    fun fingerprint(values: List<String>): String {
+        val canonical = values.sorted().joinToString("\n")
+        return MessageDigest
+            .getInstance("SHA-256")
+            .digest(canonical.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/timetableimport/domain/TimetableImportModels.kt
+++ b/src/main/kotlin/app/hyuabot/backend/timetableimport/domain/TimetableImportModels.kt
@@ -1,0 +1,68 @@
+package app.hyuabot.backend.timetableimport.domain
+
+import app.hyuabot.backend.subway.domain.BulkSubwayTimetableCreateRequest
+
+data class TimetableImportIssue(
+    val row: Int?,
+    val code: String,
+    val message: String,
+)
+
+data class TimetableImportChange(
+    val type: String,
+    val identifier: String,
+    val before: String?,
+    val after: String?,
+)
+
+data class TimetableImportPreviewResponse(
+    val previewID: String?,
+    val expiresAt: String?,
+    val createCount: Int,
+    val updateCount: Int,
+    val deleteCount: Int,
+    val unchangedCount: Int,
+    val errors: List<TimetableImportIssue>,
+    val warnings: List<TimetableImportIssue>,
+    val sampleChanges: List<TimetableImportChange>,
+)
+
+data class TimetableImportApplyRequest(
+    val previewID: String,
+)
+
+data class TimetableImportApplyResponse(
+    val createCount: Int,
+    val updateCount: Int,
+    val deleteCount: Int,
+    val unchangedCount: Int,
+)
+
+data class SubwayTimetableImportRequest(
+    val stationIDs: List<String>,
+    val entries: List<BulkSubwayTimetableCreateRequest>,
+)
+
+data class ShuttleTimetableImportEntry(
+    val routeName: String,
+    val period: String,
+    val weekday: Boolean,
+    val departureTime: String,
+)
+
+data class ShuttleTimetableImportRequest(
+    val routeNames: List<String>,
+    val entries: List<ShuttleTimetableImportEntry>,
+)
+
+data class SubwayTimetableImportSnapshot(
+    val request: SubwayTimetableImportRequest,
+    val fingerprint: String,
+    val result: TimetableImportApplyResponse,
+)
+
+data class ShuttleTimetableImportSnapshot(
+    val request: ShuttleTimetableImportRequest,
+    val fingerprint: String,
+    val result: TimetableImportApplyResponse,
+)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,3 +43,7 @@ apns.live-activity.key-id=${APNS_KEY_ID:}
 apns.live-activity.bundle-id=${APNS_BUNDLE_ID:net.jaram.hyuabot}
 apns.live-activity.private-key=${APNS_PRIVATE_KEY:}
 apns.live-activity.base-url=${APNS_BASE_URL:}
+# Admin overview
+admin.overview.prometheus-base-url=${PROMETHEUS_BASE_URL:http://prometheus:9090}
+admin.overview.grafana-url=${GRAFANA_PUBLIC_URL:https://grafana.hyuabot.app}
+admin.timetable-import.preview-ttl-minutes=${TIMETABLE_IMPORT_PREVIEW_TTL_MINUTES:15}

--- a/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewControllerTest.kt
@@ -1,0 +1,30 @@
+package app.hyuabot.backend.adminoverview
+
+import app.hyuabot.backend.adminoverview.domain.AdminOverviewResponse
+import app.hyuabot.backend.security.AdminPermission
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
+class AdminOverviewControllerTest {
+    @Test
+    fun `controller passes recognized authorities to the service`() {
+        val service = mock<AdminOverviewService>()
+        val authentication = mock<Authentication>()
+        val response = AdminOverviewResponse("now", emptyList(), null, "grafana")
+        whenever(authentication.authorities).thenReturn(
+            listOf(SimpleGrantedAuthority("BUS"), SimpleGrantedAuthority("UNKNOWN")),
+        )
+        whenever(service.getOverview(setOf(AdminPermission.BUS))).thenReturn(response)
+
+        assertEquals(response, AdminOverviewController(service).getOverview(authentication))
+        val captor = argumentCaptor<Set<AdminPermission>>()
+        verify(service).getOverview(captor.capture())
+        assertEquals(setOf(AdminPermission.BUS), captor.firstValue)
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewModelsTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewModelsTest.kt
@@ -1,0 +1,61 @@
+package app.hyuabot.backend.adminoverview
+
+import app.hyuabot.backend.adminoverview.domain.AdminOverviewResponse
+import app.hyuabot.backend.adminoverview.domain.AdminServiceStatus
+import app.hyuabot.backend.adminoverview.domain.CronJobRun
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class AdminOverviewModelsTest {
+    @Test
+    fun `overview models expose value semantics`() {
+        val status = AdminServiceStatus("id", "title", "NORMAL", "message", "success", "failure", "/path")
+        val overview = AdminOverviewResponse("now", listOf(status), 1, "grafana")
+        val run = CronJobRun("success", "failure")
+        val (id, title, state, message, success, failure, path) = status
+        val (checkedAt, services, invitations, grafana) = overview
+        val (runSuccess, runFailure) = run
+        assertEquals(
+            listOf("id", "title", "NORMAL", "message", "success", "failure", "/path"),
+            listOf(id, title, state, message, success, failure, path),
+        )
+        assertEquals(listOf("now", listOf(status), 1, "grafana"), listOf(checkedAt, services, invitations, grafana))
+        assertEquals(listOf("success", "failure"), listOf(runSuccess, runFailure))
+        assertEquals("title", status.title)
+        assertEquals("success", status.lastSuccessAt)
+        assertEquals("failure", status.lastFailureAt)
+        assertEquals("/path", status.managementPath)
+        assertEquals("now", overview.checkedAt)
+        assertEquals(status, status.copy())
+        assertEquals(overview, overview.copy())
+        assertEquals(run, run.copy())
+        exerciseValue(
+            status,
+            status.copy(
+                id = "other",
+                title = "other",
+                status = "ERROR",
+                message = "other",
+                lastSuccessAt = null,
+                lastFailureAt = null,
+                managementPath = "/other",
+            ),
+        )
+        exerciseValue(
+            overview,
+            overview.copy(checkedAt = "later", services = emptyList(), expiringInvitationCount = null, grafanaURL = "other"),
+        )
+        exerciseValue(run, run.copy(lastSuccessAt = null, lastFailureAt = null))
+    }
+
+    private fun exerciseValue(
+        value: Any,
+        different: Any,
+    ) {
+        assertEquals(value, value)
+        assertNotEquals(value, different)
+        value.hashCode()
+        value.toString()
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewServiceTest.kt
@@ -1,0 +1,144 @@
+package app.hyuabot.backend.adminoverview
+
+import app.hyuabot.backend.adminoverview.domain.CronJobRun
+import app.hyuabot.backend.database.entity.AdminUserInvitation
+import app.hyuabot.backend.database.entity.ShuttleHoliday
+import app.hyuabot.backend.database.entity.ShuttlePeriod
+import app.hyuabot.backend.database.repository.AdminUserInvitationRepository
+import app.hyuabot.backend.security.AdminPermission
+import app.hyuabot.backend.shuttle.service.ShuttleHolidayService
+import app.hyuabot.backend.shuttle.service.ShuttlePeriodService
+import app.hyuabot.backend.utility.LocalDateTimeBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.util.UUID
+
+class AdminOverviewServiceTest {
+    private val prometheusClient = mock<PrometheusClient>()
+    private val periodService = mock<ShuttlePeriodService>()
+    private val holidayService = mock<ShuttleHolidayService>()
+    private val invitationRepository = mock<AdminUserInvitationRepository>()
+    private val service =
+        AdminOverviewService(prometheusClient, periodService, holidayService, invitationRepository, "https://grafana.example")
+
+    @Test
+    fun `overview summarizes service health shuttle holiday and expiring invitations`() {
+        val now = Instant.now()
+        whenever(prometheusClient.getCronJobRuns()).thenReturn(
+            mapOf(
+                "bus-realtime-cron-job" to CronJobRun(now.minusSeconds(60).toString(), now.minusSeconds(120).toString()),
+                "subway-realtime-cron-job" to CronJobRun(now.minusSeconds(120).toString(), now.minusSeconds(60).toString()),
+                "cafeteria-cron-job" to CronJobRun(now.minusSeconds(3 * 3600).toString(), null),
+            ),
+        )
+        val current = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
+        whenever(periodService.findShuttlePeriod(any())).thenReturn(
+            ShuttlePeriod(1, "vacation", current.minusDays(1), current.plusDays(1), null),
+        )
+        whenever(holidayService.findShuttleHoliday(any())).thenReturn(ShuttleHoliday(1, current.toLocalDate(), "weekends", "solar"))
+        whenever(invitationRepository.findAllByConsumedAtIsNullAndRevokedAtIsNull()).thenReturn(
+            listOf(
+                invitation(current.plusHours(1)),
+                invitation(current.minusHours(1)),
+                invitation(current.plusHours(25)),
+            ),
+        )
+
+        val result = service.getOverview(AdminPermission.entries.toSet())
+
+        assertEquals("https://grafana.example", result.grafanaURL)
+        assertEquals(1, result.expiringInvitationCount)
+        assertEquals("NORMAL", result.services.first { it.id == "shuttle" }.status)
+        assertEquals("방학 · 오늘은 주말/공휴일입니다.", result.services.first { it.id == "shuttle" }.message)
+        assertEquals("NORMAL", result.services.first { it.id == "bus" }.status)
+        assertEquals("ERROR", result.services.first { it.id == "subway" }.status)
+        assertEquals("WARNING", result.services.first { it.id == "cafeteria" }.status)
+        assertEquals("UNKNOWN", result.services.first { it.id == "reading-room" }.status)
+    }
+
+    @Test
+    fun `missing periods and Prometheus failures remain actionable without super admin data`() {
+        whenever(prometheusClient.getCronJobRuns()).thenThrow(IllegalStateException("offline"))
+        whenever(periodService.findShuttlePeriod(any())).thenReturn(null)
+        whenever(holidayService.findShuttleHoliday(any())).thenReturn(null)
+
+        val result = service.getOverview(setOf(AdminPermission.SHUTTLE, AdminPermission.BUS))
+
+        assertNull(result.expiringInvitationCount)
+        assertEquals("WARNING", result.services.first { it.id == "shuttle" }.status)
+        assertEquals("UNKNOWN", result.services.first { it.id == "bus" }.status)
+    }
+
+    @Test
+    fun `regular shuttle days and jobs without successful runs are described`() {
+        val current = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
+        whenever(periodService.findShuttlePeriod(any())).thenReturn(
+            ShuttlePeriod(1, "semester", current.minusDays(1), current.plusDays(1), null),
+        )
+        whenever(holidayService.findShuttleHoliday(any())).thenReturn(null)
+        whenever(prometheusClient.getCronJobRuns()).thenReturn(
+            mapOf("reading-room-cron-job" to CronJobRun(null, null)),
+        )
+
+        val result = service.getOverview(setOf(AdminPermission.SHUTTLE, AdminPermission.READING_ROOM))
+
+        assertEquals("학기 운행 기간입니다.", result.services.first { it.id == "shuttle" }.message)
+        assertEquals("WARNING", result.services.first { it.id == "reading-room" }.status)
+    }
+
+    @Test
+    fun `unknown period and holiday codes remain readable`() {
+        val current = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
+        whenever(periodService.findShuttlePeriod(any())).thenReturn(
+            ShuttlePeriod(1, "special", current.minusDays(1), current.plusDays(1), null),
+        )
+        whenever(holidayService.findShuttleHoliday(any())).thenReturn(ShuttleHoliday(1, current.toLocalDate(), "special-day", "solar"))
+        whenever(prometheusClient.getCronJobRuns()).thenReturn(emptyMap())
+
+        val result = service.getOverview(setOf(AdminPermission.SHUTTLE))
+
+        assertEquals("special · 오늘은 special-day입니다.", result.services.single().message)
+    }
+
+    @Test
+    fun `realtime jobs are normal during overnight maintenance hours`() {
+        val overnight = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone).withHour(3).withMinute(0)
+        whenever(prometheusClient.getCronJobRuns()).thenReturn(
+            mapOf("bus-realtime-cron-job" to CronJobRun(overnight.minusHours(3).toInstant().toString(), null)),
+        )
+
+        val result = service.getOverview(setOf(AdminPermission.BUS), overnight)
+
+        assertEquals("NORMAL", result.services.single().status)
+        assertEquals("현재는 실시간 수집 운영 시간 외입니다.", result.services.single().message)
+
+        val earlyMorning = overnight.withHour(1)
+        whenever(prometheusClient.getCronJobRuns()).thenReturn(
+            mapOf("bus-realtime-cron-job" to CronJobRun(earlyMorning.minusMinutes(1).toInstant().toString(), null)),
+        )
+        assertEquals(
+            "데이터 수집이 정상입니다.",
+            service
+                .getOverview(setOf(AdminPermission.BUS), earlyMorning)
+                .services
+                .single()
+                .message,
+        )
+    }
+
+    private fun invitation(expiresAt: ZonedDateTime) =
+        AdminUserInvitation(
+            uuid = UUID.randomUUID(),
+            userID = "user",
+            tokenHash = "hash-${UUID.randomUUID()}",
+            createdBy = "admin",
+            expiresAt = expiresAt,
+            createdAt = expiresAt.minusDays(1),
+        )
+}

--- a/src/test/kotlin/app/hyuabot/backend/adminoverview/PrometheusClientTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminoverview/PrometheusClientTest.kt
@@ -1,0 +1,57 @@
+package app.hyuabot.backend.adminoverview
+
+import com.sun.net.httpserver.HttpServer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+
+class PrometheusClientTest {
+    @Test
+    fun `cron job queries parse valid series and ignore malformed series`() {
+        withServer(
+            listOf(
+                """{"status":"success","data":{"result":[{"metric":{"owner_name":"bus-realtime-cron-job"},"value":[1,"100"]},{"metric":{},"value":[1,"200"]},{"metric":{"owner_name":"invalid"},"value":[1,"not-a-number"]}]}}""",
+                """{"status":"success","data":{"result":[{"metric":{"owner_name":"subway-realtime-cron-job"},"value":[1,"200"]}]}}""",
+            ),
+        ) { baseURL ->
+            val runs = PrometheusClient(baseURL).getCronJobRuns()
+            assertEquals("1970-01-01T00:01:40Z", runs.getValue("bus-realtime-cron-job").lastSuccessAt)
+            assertEquals(null, runs.getValue("bus-realtime-cron-job").lastFailureAt)
+            assertEquals(null, runs.getValue("subway-realtime-cron-job").lastSuccessAt)
+            assertEquals("1970-01-01T00:03:20Z", runs.getValue("subway-realtime-cron-job").lastFailureAt)
+        }
+    }
+
+    @Test
+    fun `failed and empty Prometheus responses are rejected`() {
+        withServer(listOf("""{"status":"error","data":{"result":[]}}""")) { baseURL ->
+            assertThrows(IllegalStateException::class.java) { PrometheusClient(baseURL).getCronJobRuns() }
+        }
+        withServer(listOf("")) { baseURL ->
+            assertThrows(IllegalStateException::class.java) { PrometheusClient(baseURL).getCronJobRuns() }
+        }
+    }
+
+    private fun withServer(
+        responses: List<String>,
+        block: (String) -> Unit,
+    ) {
+        val server = HttpServer.create(InetSocketAddress(0), 0)
+        val requestIndex = AtomicInteger()
+        server.createContext("/api/v1/query") { exchange ->
+            val response = responses[requestIndex.getAndIncrement().coerceAtMost(responses.lastIndex)]
+            val bytes = response.toByteArray()
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        server.start()
+        try {
+            block("http://127.0.0.1:${server.address.port}")
+        } finally {
+            server.stop(0)
+        }
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/timetableimport/ShuttleTimetableImportServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/timetableimport/ShuttleTimetableImportServiceTest.kt
@@ -1,0 +1,165 @@
+package app.hyuabot.backend.timetableimport
+
+import app.hyuabot.backend.database.entity.ShuttlePeriodType
+import app.hyuabot.backend.database.entity.ShuttleRoute
+import app.hyuabot.backend.database.entity.ShuttleTimetable
+import app.hyuabot.backend.database.repository.ShuttlePeriodTypeRepository
+import app.hyuabot.backend.database.repository.ShuttleRouteRepository
+import app.hyuabot.backend.database.repository.ShuttleTimetableRepository
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportEntry
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportRequest
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportSnapshot
+import app.hyuabot.backend.timetableimport.domain.TimetableImportApplyResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalTime
+import java.time.ZonedDateTime
+
+class ShuttleTimetableImportServiceTest {
+    private val routeRepository = mock<ShuttleRouteRepository>()
+    private val periodRepository = mock<ShuttlePeriodTypeRepository>()
+    private val timetableRepository = mock<ShuttleTimetableRepository>()
+    private val store = mock<TimetableImportStore>()
+    private val service = ShuttleTimetableImportService(routeRepository, periodRepository, timetableRepository, store)
+
+    @Test
+    fun `preview reports creates deletes unchanged rows and warnings`() {
+        val current = listOf(entity("A", "semester", true, "05:00:00"), entity("A", "semester", true, "06:00:00"))
+        val request =
+            ShuttleTimetableImportRequest(
+                listOf("A", "A"),
+                listOf(entry("A", "semester", true, "05:00:00"), entry("A", "semester", false, "07:00:00")),
+            )
+        stubReferences("A", "semester")
+        whenever(timetableRepository.findByRouteNameIn(listOf("A"))).thenReturn(current)
+        whenever(store.save(any(), any())).thenReturn(StoredTimetableImport("preview", ZonedDateTime.now().plusMinutes(15)))
+
+        val result = service.preview(request)
+
+        assertEquals("preview", result.previewID)
+        assertEquals(1, result.createCount)
+        assertEquals(0, result.updateCount)
+        assertEquals(1, result.deleteCount)
+        assertEquals(1, result.unchangedCount)
+        assertEquals(2, result.sampleChanges.size)
+        assertEquals(1, result.warnings.size)
+        verify(store).save(any(), any<ShuttleTimetableImportSnapshot>())
+    }
+
+    @Test
+    fun `preview reports invalid route period time scope duplicate and empty input`() {
+        whenever(routeRepository.findAllById(any<List<String>>())).thenReturn(emptyList())
+        whenever(periodRepository.findAllById(any<List<String>>())).thenReturn(emptyList())
+        val invalidEntry = entry("missing", "unknown", true, "bad")
+        val duplicateEntry = entry("missing", "unknown", false, "05:00:00")
+        val weekdayDuplicate = entry("missing", "unknown", true, "06:00:00")
+        val result =
+            service.preview(
+                ShuttleTimetableImportRequest(
+                    emptyList(),
+                    listOf(invalidEntry, duplicateEntry, duplicateEntry, weekdayDuplicate, weekdayDuplicate),
+                ),
+            )
+
+        assertNull(result.previewID)
+        assert(
+            result.errors
+                .map {
+                    it.code
+                }.containsAll(listOf("EMPTY_SCOPE", "OUT_OF_SCOPE", "ROUTE_NOT_FOUND", "PERIOD_NOT_FOUND", "INVALID_TIME")),
+        )
+
+        whenever(routeRepository.findAllById(emptyList<String>())).thenReturn(emptyList())
+        whenever(periodRepository.findAllById(emptyList<String>())).thenReturn(emptyList())
+        assert(service.preview(ShuttleTimetableImportRequest(emptyList(), emptyList())).errors.any { it.code == "EMPTY_IMPORT" })
+    }
+
+    @Test
+    fun `preview without deletions has no warning`() {
+        stubReferences("A", "semester")
+        whenever(timetableRepository.findByRouteNameIn(listOf("A"))).thenReturn(emptyList())
+        whenever(store.save(any(), any())).thenReturn(StoredTimetableImport("preview", ZonedDateTime.now().plusMinutes(15)))
+        val result = service.preview(ShuttleTimetableImportRequest(listOf("A"), listOf(entry("A", "semester", true, "05:00:00"))))
+        assert(result.warnings.isEmpty())
+    }
+
+    @Test
+    fun `apply atomically replaces routes and consumes preview`() {
+        val request = ShuttleTimetableImportRequest(listOf("A"), listOf(entry("A", "semester", true, "05:00:00")))
+        val current = listOf(entity("A", "semester", true, "04:00:00"))
+        val snapshot = ShuttleTimetableImportSnapshot(request, fingerprint(current), TimetableImportApplyResponse(1, 0, 1, 0))
+        whenever(store.load("shuttle", "preview", ShuttleTimetableImportSnapshot::class.java)).thenReturn(snapshot)
+        whenever(timetableRepository.findByRouteNameInForUpdate(listOf("A"))).thenReturn(current)
+
+        assertEquals(snapshot.result, service.apply("preview"))
+
+        verify(timetableRepository).deleteAllByRouteNameIn(listOf("A"))
+        verify(timetableRepository).flush()
+        val captor = argumentCaptor<List<ShuttleTimetable>>()
+        verify(timetableRepository).saveAll(captor.capture())
+        assertEquals("A", captor.firstValue.single().routeName)
+        verify(store).consume("shuttle", "preview")
+        verify(store).release("shuttle", "preview")
+    }
+
+    @Test
+    fun `apply rejects stale previews and releases lock`() {
+        val snapshot =
+            ShuttleTimetableImportSnapshot(
+                ShuttleTimetableImportRequest(listOf("A"), emptyList()),
+                "old",
+                TimetableImportApplyResponse(0, 0, 0, 0),
+            )
+        whenever(store.load("shuttle", "preview", ShuttleTimetableImportSnapshot::class.java)).thenReturn(snapshot)
+        whenever(timetableRepository.findByRouteNameInForUpdate(listOf("A"))).thenReturn(emptyList())
+        assertEquals("PREVIEW_STALE", assertThrows(TimetableImportException::class.java) { service.apply("preview") }.code)
+        verify(store).release("shuttle", "preview")
+    }
+
+    private fun stubReferences(
+        route: String,
+        period: String,
+    ) {
+        whenever(routeRepository.findAllById(any<List<String>>())).thenReturn(
+            listOf(
+                ShuttleRoute(
+                    name = route,
+                    descriptionKorean = "ko",
+                    descriptionEnglish = "en",
+                    tag = "tag",
+                    startStopID = "start",
+                    endStopID = "end",
+                    timetable = mutableListOf(),
+                    stop = mutableListOf(),
+                    startStop = null,
+                    endStop = null,
+                ),
+            ),
+        )
+        whenever(periodRepository.findAllById(any<List<String>>())).thenReturn(listOf(ShuttlePeriodType(period, mutableListOf())))
+    }
+
+    private fun entry(
+        route: String,
+        period: String,
+        weekday: Boolean,
+        time: String,
+    ) = ShuttleTimetableImportEntry(route, period, weekday, time)
+
+    private fun entity(
+        route: String,
+        period: String,
+        weekday: Boolean,
+        time: String,
+    ) = ShuttleTimetable(null, period, weekday, route, LocalTime.parse(time), null)
+
+    private fun fingerprint(values: List<ShuttleTimetable>) =
+        TimetableImportSupport.fingerprint(values.map { "${it.routeName}|${it.periodType}|${it.weekday}|${it.departureTime}" })
+}

--- a/src/test/kotlin/app/hyuabot/backend/timetableimport/SubwayTimetableImportServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/timetableimport/SubwayTimetableImportServiceTest.kt
@@ -1,0 +1,171 @@
+package app.hyuabot.backend.timetableimport
+
+import app.hyuabot.backend.database.entity.SubwayRouteStation
+import app.hyuabot.backend.database.entity.SubwayTimetable
+import app.hyuabot.backend.database.repository.SubwayStationRepository
+import app.hyuabot.backend.database.repository.SubwayTimetableRepository
+import app.hyuabot.backend.subway.domain.BulkSubwayTimetableCreateRequest
+import app.hyuabot.backend.timetableimport.domain.SubwayTimetableImportRequest
+import app.hyuabot.backend.timetableimport.domain.SubwayTimetableImportSnapshot
+import app.hyuabot.backend.timetableimport.domain.TimetableImportApplyResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Duration
+import java.time.LocalTime
+import java.time.ZonedDateTime
+
+class SubwayTimetableImportServiceTest {
+    private val stationRepository = mock<SubwayStationRepository>()
+    private val timetableRepository = mock<SubwayTimetableRepository>()
+    private val store = mock<TimetableImportStore>()
+    private val service = SubwayTimetableImportService(stationRepository, timetableRepository, store)
+
+    @Test
+    fun `preview reports creates updates deletes and unchanged rows`() {
+        val current =
+            listOf(
+                entity("A", "OLD", "T1", "05:00:00"),
+                entity("A", "S2", "T2", "06:00:00"),
+                entity("A", "S3", "T3", "07:00:00"),
+            )
+        val request =
+            SubwayTimetableImportRequest(
+                stationIDs = listOf("A", "A"),
+                entries =
+                    listOf(
+                        entry("A", "NEW", "T1", "05:00:00"),
+                        entry("A", "S3", "T3", "07:00:00"),
+                        entry("A", "S4", "T4", "08:00:00"),
+                    ),
+            )
+        whenever(stationRepository.findByIdIn(any())).thenReturn(stations("A", "OLD", "NEW", "T1", "S2", "T2", "S3", "T3", "S4", "T4"))
+        whenever(timetableRepository.findByStationIDIn(listOf("A"))).thenReturn(current)
+        whenever(store.save(any(), any())).thenReturn(StoredTimetableImport("preview", ZonedDateTime.now().plusMinutes(15)))
+
+        val result = service.preview(request)
+
+        assertEquals("preview", result.previewID)
+        assertEquals(1, result.createCount)
+        assertEquals(1, result.updateCount)
+        assertEquals(1, result.deleteCount)
+        assertEquals(1, result.unchangedCount)
+        assertEquals(3, result.sampleChanges.size)
+        assertEquals(1, result.warnings.size)
+        verify(store).save(any(), any<SubwayTimetableImportSnapshot>())
+    }
+
+    @Test
+    fun `preview returns all validation problems without storing data`() {
+        val invalid =
+            SubwayTimetableImportRequest(
+                stationIDs = emptyList(),
+                entries =
+                    listOf(
+                        entry("missing", "missing-start", "missing-end", "bad", "holiday", "side"),
+                        entry("missing", "missing-start", "missing-end", "bad", "holiday", "side"),
+                        entry("missing", "missing-start", "missing-end", "05:00:00"),
+                        entry("missing", "missing-start", "missing-end", "05:00:00"),
+                    ),
+            )
+        whenever(stationRepository.findByIdIn(any())).thenReturn(emptyList())
+
+        val result = service.preview(invalid)
+
+        assertNull(result.previewID)
+        assertEquals(0, result.createCount)
+        assert(
+            result.errors
+                .map {
+                    it.code
+                }.containsAll(
+                    listOf(
+                        "EMPTY_SCOPE",
+                        "OUT_OF_SCOPE",
+                        "INVALID_TIME",
+                        "INVALID_WEEKDAY",
+                        "INVALID_DIRECTION",
+                        "STATION_NOT_FOUND",
+                    ),
+                ),
+        )
+    }
+
+    @Test
+    fun `empty imports and imports without deletions are represented safely`() {
+        whenever(stationRepository.findByIdIn(emptyList())).thenReturn(emptyList())
+        assert(service.preview(SubwayTimetableImportRequest(emptyList(), emptyList())).errors.any { it.code == "EMPTY_IMPORT" })
+
+        val request = SubwayTimetableImportRequest(listOf("A"), listOf(entry("A", "S", "T", "05:00:00")))
+        whenever(stationRepository.findByIdIn(any())).thenReturn(stations("A", "S", "T"))
+        whenever(timetableRepository.findByStationIDIn(listOf("A"))).thenReturn(emptyList())
+        whenever(store.save(any(), any())).thenReturn(StoredTimetableImport("preview", ZonedDateTime.now().plusMinutes(15)))
+        assert(service.preview(request).warnings.isEmpty())
+    }
+
+    @Test
+    fun `apply replaces the scoped timetable and consumes the preview`() {
+        val request = SubwayTimetableImportRequest(listOf("A"), listOf(entry("A", "S", "T", "05:00:00")))
+        val current = listOf(entity("A", "OLD", "T", "04:00:00"))
+        val snapshot = SubwayTimetableImportSnapshot(request, fingerprint(current), TimetableImportApplyResponse(1, 0, 1, 0))
+        whenever(store.load("subway", "preview", SubwayTimetableImportSnapshot::class.java)).thenReturn(snapshot)
+        whenever(timetableRepository.findByStationIDInForUpdate(listOf("A"))).thenReturn(current)
+
+        assertEquals(snapshot.result, service.apply("preview"))
+
+        verify(timetableRepository).deleteAllByStationIDIn(listOf("A"))
+        verify(timetableRepository).flush()
+        val captor = argumentCaptor<List<SubwayTimetable>>()
+        verify(timetableRepository).saveAll(captor.capture())
+        assertEquals(LocalTime.of(5, 0), captor.firstValue.single().departureTime)
+        verify(store).consume("subway", "preview")
+        verify(store).release("subway", "preview")
+    }
+
+    @Test
+    fun `apply rejects stale previews and always releases the lock`() {
+        val snapshot =
+            SubwayTimetableImportSnapshot(
+                SubwayTimetableImportRequest(listOf("A"), emptyList()),
+                "old",
+                TimetableImportApplyResponse(0, 0, 0, 0),
+            )
+        whenever(store.load("subway", "preview", SubwayTimetableImportSnapshot::class.java)).thenReturn(snapshot)
+        whenever(timetableRepository.findByStationIDInForUpdate(listOf("A"))).thenReturn(emptyList())
+
+        assertEquals("PREVIEW_STALE", assertThrows(TimetableImportException::class.java) { service.apply("preview") }.code)
+        verify(store).release("subway", "preview")
+    }
+
+    private fun entry(
+        station: String,
+        start: String,
+        terminal: String,
+        time: String,
+        weekday: String = "weekdays",
+        direction: String = "up",
+    ) = BulkSubwayTimetableCreateRequest(station, start, terminal, time, weekday, direction)
+
+    private fun entity(
+        station: String,
+        start: String,
+        terminal: String,
+        time: String,
+    ) = SubwayTimetable(null, station, start, terminal, LocalTime.parse(time), "weekdays", "up", null, null, null)
+
+    private fun stations(vararg ids: String) =
+        ids.map { id -> SubwayRouteStation(id, 1, id, 1, Duration.ZERO, null, null, mutableListOf(), mutableListOf()) }
+
+    private fun fingerprint(values: List<SubwayTimetable>) =
+        TimetableImportSupport.fingerprint(
+            values.map {
+                "${it.stationID}|${it.weekday}|${it.heading}|${it.departureTime}|${it.startStationID}|${it.terminalStationID}"
+            },
+        )
+}

--- a/src/test/kotlin/app/hyuabot/backend/timetableimport/TimetableImportControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/timetableimport/TimetableImportControllerTest.kt
@@ -1,0 +1,54 @@
+package app.hyuabot.backend.timetableimport
+
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportRequest
+import app.hyuabot.backend.timetableimport.domain.SubwayTimetableImportRequest
+import app.hyuabot.backend.timetableimport.domain.TimetableImportApplyRequest
+import app.hyuabot.backend.timetableimport.domain.TimetableImportApplyResponse
+import app.hyuabot.backend.timetableimport.domain.TimetableImportPreviewResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+
+class TimetableImportControllerTest {
+    private val subwayService = mock<SubwayTimetableImportService>()
+    private val shuttleService = mock<ShuttleTimetableImportService>()
+    private val subwayController = SubwayTimetableImportController(subwayService)
+    private val shuttleController = ShuttleTimetableImportController(shuttleService)
+    private val preview = TimetableImportPreviewResponse("id", "expires", 1, 2, 3, 4, emptyList(), emptyList(), emptyList())
+    private val applied = TimetableImportApplyResponse(1, 2, 3, 4)
+
+    @Test
+    fun `subway endpoints delegate and map import errors`() {
+        val request = SubwayTimetableImportRequest(emptyList(), emptyList())
+        whenever(subwayService.preview(request)).thenReturn(preview)
+        whenever(subwayService.apply("id")).thenReturn(applied)
+        assertEquals(preview, subwayController.preview(request))
+        assertEquals(applied, subwayController.apply(TimetableImportApplyRequest("id")))
+        assertEquals(HttpStatus.CONFLICT, subwayController.handleImportException(TimetableImportException("PREVIEW_STALE")).statusCode)
+        assertEquals(
+            HttpStatus.CONFLICT,
+            subwayController.handleImportException(TimetableImportException("PREVIEW_ALREADY_APPLYING")).statusCode,
+        )
+        assertEquals(HttpStatus.NOT_FOUND, subwayController.handleImportException(TimetableImportException("PREVIEW_NOT_FOUND")).statusCode)
+    }
+
+    @Test
+    fun `shuttle endpoints delegate and map import errors`() {
+        val request = ShuttleTimetableImportRequest(emptyList(), emptyList())
+        whenever(shuttleService.preview(request)).thenReturn(preview)
+        whenever(shuttleService.apply("id")).thenReturn(applied)
+        assertEquals(preview, shuttleController.preview(request))
+        assertEquals(applied, shuttleController.apply(TimetableImportApplyRequest("id")))
+        assertEquals(HttpStatus.CONFLICT, shuttleController.handleImportException(TimetableImportException("PREVIEW_STALE")).statusCode)
+        assertEquals(
+            HttpStatus.CONFLICT,
+            shuttleController.handleImportException(TimetableImportException("PREVIEW_ALREADY_APPLYING")).statusCode,
+        )
+        assertEquals(
+            HttpStatus.NOT_FOUND,
+            shuttleController.handleImportException(TimetableImportException("PREVIEW_NOT_FOUND")).statusCode,
+        )
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/timetableimport/TimetableImportModelsTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/timetableimport/TimetableImportModelsTest.kt
@@ -1,0 +1,116 @@
+package app.hyuabot.backend.timetableimport
+
+import app.hyuabot.backend.subway.domain.BulkSubwayTimetableCreateRequest
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportEntry
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportRequest
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportSnapshot
+import app.hyuabot.backend.timetableimport.domain.SubwayTimetableImportRequest
+import app.hyuabot.backend.timetableimport.domain.SubwayTimetableImportSnapshot
+import app.hyuabot.backend.timetableimport.domain.TimetableImportApplyRequest
+import app.hyuabot.backend.timetableimport.domain.TimetableImportApplyResponse
+import app.hyuabot.backend.timetableimport.domain.TimetableImportChange
+import app.hyuabot.backend.timetableimport.domain.TimetableImportIssue
+import app.hyuabot.backend.timetableimport.domain.TimetableImportPreviewResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class TimetableImportModelsTest {
+    @Test
+    fun `import response models expose value semantics`() {
+        val issue = TimetableImportIssue(1, "CODE", "message")
+        val change = TimetableImportChange("CREATE", "item", null, "after")
+        val preview = TimetableImportPreviewResponse("id", "expires", 1, 2, 3, 4, listOf(issue), emptyList(), listOf(change))
+        val applyRequest = TimetableImportApplyRequest("id")
+        val result = TimetableImportApplyResponse(1, 2, 3, 4)
+
+        val (row, code, message) = issue
+        val (type, identifier, before, after) = change
+        val (previewID, expiresAt, createCount, updateCount, deleteCount, unchangedCount, errors, warnings, changes) = preview
+        assertEquals(listOf(1, "CODE", "message"), listOf(row, code, message))
+        assertEquals(listOf("CREATE", "item", null, "after"), listOf(type, identifier, before, after))
+        assertEquals(
+            listOf("id", "expires", 1, 2, 3, 4, listOf(issue), emptyList<Any>(), listOf(change)),
+            listOf(previewID, expiresAt, createCount, updateCount, deleteCount, unchangedCount, errors, warnings, changes),
+        )
+        assertEquals(1, issue.row)
+        assertEquals("message", issue.message)
+        assertEquals("CREATE", change.type)
+        assertEquals("item", change.identifier)
+        assertEquals(null, change.before)
+        assertEquals("after", change.after)
+        assertEquals("expires", preview.expiresAt)
+        assertEquals("id", applyRequest.component1())
+        assertEquals(listOf(1, 2, 3, 4), listOf(result.component1(), result.component2(), result.component3(), result.component4()))
+        assertEquals(issue, issue.copy())
+        assertEquals(change, change.copy())
+        assertEquals(preview, preview.copy())
+        assertEquals(applyRequest, applyRequest.copy())
+        assertEquals(result, result.copy())
+        exerciseValue(issue, issue.copy(row = 2, code = "OTHER", message = "other"))
+        exerciseValue(change, change.copy(type = "DELETE", identifier = "other", before = "before", after = null))
+        exerciseValue(
+            preview,
+            preview.copy(
+                previewID = "other",
+                expiresAt = null,
+                createCount = 0,
+                updateCount = 0,
+                deleteCount = 0,
+                unchangedCount = 0,
+                errors = emptyList(),
+                warnings = listOf(issue),
+                sampleChanges = emptyList(),
+            ),
+        )
+        exerciseValue(applyRequest, applyRequest.copy(previewID = "other"))
+        exerciseValue(result, result.copy(createCount = 0, updateCount = 0, deleteCount = 0, unchangedCount = 0))
+    }
+
+    @Test
+    fun `import request and snapshot models expose value semantics`() {
+        val subwayEntry = BulkSubwayTimetableCreateRequest("station", "start", "terminal", "05:00:00", "weekdays", "up")
+        val subwayRequest = SubwayTimetableImportRequest(listOf("station"), listOf(subwayEntry))
+        val shuttleEntry = ShuttleTimetableImportEntry("route", "semester", true, "05:00:00")
+        val shuttleRequest = ShuttleTimetableImportRequest(listOf("route"), listOf(shuttleEntry))
+        val result = TimetableImportApplyResponse(1, 0, 0, 0)
+        val subwaySnapshot = SubwayTimetableImportSnapshot(subwayRequest, "hash", result)
+        val shuttleSnapshot = ShuttleTimetableImportSnapshot(shuttleRequest, "hash", result)
+
+        val (stationIDs, subwayEntries) = subwayRequest
+        val (route, period, weekday, time) = shuttleEntry
+        val (routeNames, shuttleEntries) = shuttleRequest
+        val (savedSubwayRequest, subwayHash, subwayResult) = subwaySnapshot
+        val (savedShuttleRequest, shuttleHash, shuttleResult) = shuttleSnapshot
+        assertEquals(listOf("station"), stationIDs)
+        assertEquals(listOf(subwayEntry), subwayEntries)
+        assertEquals(listOf("route", "semester", true, "05:00:00"), listOf(route, period, weekday, time))
+        assertEquals(listOf("route"), routeNames)
+        assertEquals(listOf(shuttleEntry), shuttleEntries)
+        assertEquals(listOf(subwayRequest, "hash", result), listOf(savedSubwayRequest, subwayHash, subwayResult))
+        assertEquals(listOf(shuttleRequest, "hash", result), listOf(savedShuttleRequest, shuttleHash, shuttleResult))
+        assertEquals(subwayRequest, subwayRequest.copy())
+        assertEquals(shuttleEntry, shuttleEntry.copy())
+        assertEquals(shuttleRequest, shuttleRequest.copy())
+        assertEquals(subwaySnapshot, subwaySnapshot.copy())
+        assertEquals(shuttleSnapshot, shuttleSnapshot.copy())
+        exerciseValue(subwayRequest, subwayRequest.copy(stationIDs = emptyList(), entries = emptyList()))
+        exerciseValue(
+            shuttleEntry,
+            shuttleEntry.copy(routeName = "other", period = "vacation", weekday = false, departureTime = "06:00:00"),
+        )
+        exerciseValue(shuttleRequest, shuttleRequest.copy(routeNames = emptyList(), entries = emptyList()))
+        exerciseValue(subwaySnapshot, subwaySnapshot.copy(request = subwayRequest, fingerprint = "other", result = result))
+        exerciseValue(shuttleSnapshot, shuttleSnapshot.copy(request = shuttleRequest, fingerprint = "other", result = result))
+    }
+
+    private fun exerciseValue(
+        value: Any,
+        different: Any,
+    ) {
+        assertEquals(value, value)
+        assertNotEquals(value, different)
+        value.hashCode()
+        value.toString()
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/timetableimport/TimetableImportStoreTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/timetableimport/TimetableImportStoreTest.kt
@@ -1,0 +1,80 @@
+package app.hyuabot.backend.timetableimport
+
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportRequest
+import app.hyuabot.backend.timetableimport.domain.ShuttleTimetableImportSnapshot
+import app.hyuabot.backend.timetableimport.domain.TimetableImportApplyResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import tools.jackson.databind.ObjectMapper
+import java.time.Duration
+
+class TimetableImportStoreTest {
+    private val redisTemplate = mock<RedisTemplate<String, String>>()
+    private val valueOperations = mock<ValueOperations<String, String>>()
+    private val objectMapper = mock<ObjectMapper>()
+    private val store = TimetableImportStore(redisTemplate, objectMapper, 15)
+    private val snapshot =
+        ShuttleTimetableImportSnapshot(
+            ShuttleTimetableImportRequest(emptyList(), emptyList()),
+            "fingerprint",
+            TimetableImportApplyResponse(1, 0, 2, 3),
+        )
+
+    init {
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
+    }
+
+    @Test
+    fun `save writes a TTL preview and load restores it`() {
+        whenever(objectMapper.writeValueAsString(snapshot)).thenReturn("snapshot-json")
+        val stored = store.save("shuttle", snapshot)
+        verify(valueOperations).set(
+            "admin:timetable-import:shuttle:${stored.id}",
+            "snapshot-json",
+            Duration.ofMinutes(15),
+        )
+
+        whenever(valueOperations.get("admin:timetable-import:shuttle:${stored.id}")).thenReturn("snapshot-json")
+        whenever(objectMapper.readValue("snapshot-json", ShuttleTimetableImportSnapshot::class.java)).thenReturn(snapshot)
+        assertEquals(snapshot, store.load("shuttle", stored.id, ShuttleTimetableImportSnapshot::class.java))
+    }
+
+    @Test
+    fun `missing and busy previews are rejected while locks can be released`() {
+        whenever(valueOperations.get(any())).thenReturn(null)
+        assertEquals(
+            "PREVIEW_NOT_FOUND",
+            assertThrows(TimetableImportException::class.java) {
+                store.load("subway", "missing", ShuttleTimetableImportSnapshot::class.java)
+            }.code,
+        )
+
+        whenever(valueOperations.setIfAbsent(any(), any(), any<Duration>())).thenReturn(false)
+        assertEquals(
+            "PREVIEW_ALREADY_APPLYING",
+            assertThrows(TimetableImportException::class.java) { store.acquire("subway", "busy") }.code,
+        )
+
+        whenever(valueOperations.setIfAbsent(any(), any(), any<Duration>())).thenReturn(true)
+        store.acquire("subway", "available")
+        store.consume("subway", "available")
+        store.release("subway", "available")
+        verify(redisTemplate).delete("admin:timetable-import:subway:available")
+        verify(redisTemplate).delete("admin:timetable-import:subway:available:lock")
+    }
+
+    @Test
+    fun `fingerprints are stable regardless of input ordering`() {
+        assertEquals(
+            TimetableImportSupport.fingerprint(listOf("a", "b")),
+            TimetableImportSupport.fingerprint(listOf("b", "a")),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add a permission-scoped operations overview for shuttle schedules, data collection jobs, and expiring administrator invitations.
- Read CronJob health from Prometheus and expose direct management and Grafana destinations.
- Add preview-and-apply imports for subway and shuttle timetables with validation, deletion warnings, Redis-backed expiration, stale-preview detection, and database locking.
- Replace partial timetable updates with a single transactional delete-and-create operation.
- Raise changed-file coverage enforcement to 100% and cover the new overview and import flows.

## Impact
Administrators can identify operational issues from their landing page and review timetable changes before applying them. Concurrent or expired imports are rejected without leaving a partially replaced timetable.

No database schema or secret change is required. The paired infrastructure change supplies public Prometheus, Grafana, and preview-expiration settings.

## Validation
- `./gradlew ktlintCheck test --tests 'app.hyuabot.backend.timetableimport.*' --tests 'app.hyuabot.backend.adminoverview.*' jacocoTestReport`
- New `adminoverview` package: 764/764 instructions covered (100%).
- New `timetableimport` package: 1,731/1,731 instructions covered (100%).