### PR TITLE
feat: Add administrator Web Push subscriptions

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/adminpush/AdminPushController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/adminpush/AdminPushController.kt
@@ -1,0 +1,65 @@
+package app.hyuabot.backend.adminpush
+
+import app.hyuabot.backend.adminpush.domain.AdminPushSubscriptionDeleteRequest
+import app.hyuabot.backend.adminpush.domain.AdminPushSubscriptionRequest
+import app.hyuabot.backend.adminpush.domain.AdminPushSubscriptionStatusResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.client.RestClientException
+
+@RestController
+@RequestMapping("/api/v1/user/push")
+class AdminPushController(
+    private val notifierClient: NotifierClient,
+) {
+    @GetMapping("/public-key")
+    fun getPublicKey(): ResponseEntity<*> = notifierResponse { ResponseEntity.ok(notifierClient.getPublicKey()) }
+
+    @GetMapping("/status")
+    fun getStatus(
+        authentication: Authentication,
+        @RequestParam endpoint: String,
+    ): ResponseEntity<*> =
+        notifierResponse {
+            ResponseEntity.ok(notifierClient.getStatus(authentication.name, endpoint))
+        }
+
+    @PostMapping("/subscription")
+    fun subscribe(
+        authentication: Authentication,
+        @RequestHeader("User-Agent", required = false) userAgent: String?,
+        @RequestBody request: AdminPushSubscriptionRequest,
+    ): ResponseEntity<*> =
+        notifierResponse {
+            notifierClient.subscribe(authentication.name, userAgent, request)
+            ResponseEntity.noContent().build<Any>()
+        }
+
+    @DeleteMapping("/subscription")
+    fun unsubscribe(
+        authentication: Authentication,
+        @RequestBody request: AdminPushSubscriptionDeleteRequest,
+    ): ResponseEntity<*> =
+        notifierResponse {
+            notifierClient.unsubscribe(authentication.name, request.endpoint)
+            ResponseEntity.noContent().build<Any>()
+        }
+
+    private fun notifierResponse(block: () -> ResponseEntity<*>): ResponseEntity<*> =
+        try {
+            block()
+        } catch (_: RestClientException) {
+            ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(
+                AdminPushSubscriptionStatusResponse(enabled = false),
+            )
+        }
+}

--- a/src/main/kotlin/app/hyuabot/backend/adminpush/NotifierClient.kt
+++ b/src/main/kotlin/app/hyuabot/backend/adminpush/NotifierClient.kt
@@ -1,0 +1,76 @@
+package app.hyuabot.backend.adminpush
+
+import app.hyuabot.backend.adminpush.domain.AdminPushPublicKeyResponse
+import app.hyuabot.backend.adminpush.domain.AdminPushSubscriptionRequest
+import app.hyuabot.backend.adminpush.domain.AdminPushSubscriptionStatusResponse
+import app.hyuabot.backend.adminpush.domain.NotifierSubscriptionDeleteRequest
+import app.hyuabot.backend.adminpush.domain.NotifierSubscriptionRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+
+@Component
+class NotifierClient(
+    @param:Value("\${admin.push.notifier-base-url:http://127.0.0.1:8081}") baseURL: String,
+    @param:Value("\${admin.push.notifier-service-token:}") serviceToken: String,
+) {
+    private val restClient =
+        RestClient
+            .builder()
+            .baseUrl(baseURL)
+            .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer $serviceToken")
+            .build()
+
+    fun getPublicKey(): AdminPushPublicKeyResponse =
+        requireNotNull(
+            restClient
+                .get()
+                .uri("/api/v1/push/public-key")
+                .retrieve()
+                .body(AdminPushPublicKeyResponse::class.java),
+        ) { "Notifier returned an empty public key response" }
+
+    fun getStatus(
+        userID: String,
+        endpoint: String,
+    ): AdminPushSubscriptionStatusResponse =
+        requireNotNull(
+            restClient
+                .get()
+                .uri { builder ->
+                    builder
+                        .path("/api/v1/push/subscriptions/status")
+                        .queryParam("userId", userID)
+                        .queryParam("endpoint", endpoint)
+                        .build()
+                }.retrieve()
+                .body(AdminPushSubscriptionStatusResponse::class.java),
+        ) { "Notifier returned an empty subscription status response" }
+
+    fun subscribe(
+        userID: String,
+        userAgent: String?,
+        request: AdminPushSubscriptionRequest,
+    ) {
+        restClient
+            .post()
+            .uri("/api/v1/push/subscriptions")
+            .body(NotifierSubscriptionRequest(userID, request.endpoint, request.keys, userAgent))
+            .retrieve()
+            .toBodilessEntity()
+    }
+
+    fun unsubscribe(
+        userID: String,
+        endpoint: String,
+    ) {
+        restClient
+            .method(HttpMethod.DELETE)
+            .uri("/api/v1/push/subscriptions")
+            .body(NotifierSubscriptionDeleteRequest(userID, endpoint))
+            .retrieve()
+            .toBodilessEntity()
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/adminpush/domain/AdminPushSubscriptionRequest.kt
+++ b/src/main/kotlin/app/hyuabot/backend/adminpush/domain/AdminPushSubscriptionRequest.kt
@@ -1,0 +1,35 @@
+package app.hyuabot.backend.adminpush.domain
+
+data class AdminPushSubscriptionRequest(
+    val endpoint: String,
+    val keys: AdminPushSubscriptionKeys,
+)
+
+data class AdminPushSubscriptionKeys(
+    val p256dh: String,
+    val auth: String,
+)
+
+data class AdminPushSubscriptionDeleteRequest(
+    val endpoint: String,
+)
+
+data class AdminPushPublicKeyResponse(
+    val publicKey: String,
+)
+
+data class AdminPushSubscriptionStatusResponse(
+    val enabled: Boolean,
+)
+
+internal data class NotifierSubscriptionRequest(
+    val userId: String,
+    val endpoint: String,
+    val keys: AdminPushSubscriptionKeys,
+    val userAgent: String?,
+)
+
+internal data class NotifierSubscriptionDeleteRequest(
+    val userId: String,
+    val endpoint: String,
+)

--- a/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
@@ -89,7 +89,9 @@ class SecurityConfig(
                         AdminPermission.CAFETERIA.name,
                         AdminPermission.READING_ROOM.name,
                         AdminPermission.CONTACT.name,
-                    ).requestMatchers("/api/v1/user/profile", "/api/v1/user/password", "/api/v1/user/overview")
+                    ).requestMatchers("/api/v1/user/push/**")
+                    .hasAuthority(AdminPermission.SUPER_ADMIN.name)
+                    .requestMatchers("/api/v1/user/profile", "/api/v1/user/password", "/api/v1/user/overview")
                     .authenticated()
                     .anyRequest()
                     .denyAll()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,3 +47,6 @@ apns.live-activity.base-url=${APNS_BASE_URL:}
 admin.overview.prometheus-base-url=${PROMETHEUS_BASE_URL:http://prometheus:9090}
 admin.overview.grafana-url=${GRAFANA_PUBLIC_URL:https://grafana.hyuabot.app}
 admin.timetable-import.preview-ttl-minutes=${TIMETABLE_IMPORT_PREVIEW_TTL_MINUTES:15}
+# Admin Web Push
+admin.push.notifier-base-url=${NOTIFIER_BASE_URL:http://127.0.0.1:8081}
+admin.push.notifier-service-token=${NOTIFIER_SERVICE_TOKEN:}

--- a/src/test/kotlin/app/hyuabot/backend/adminpush/AdminPushControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminpush/AdminPushControllerTest.kt
@@ -1,0 +1,95 @@
+package app.hyuabot.backend.adminpush
+
+import app.hyuabot.backend.adminpush.domain.AdminPushPublicKeyResponse
+import app.hyuabot.backend.adminpush.domain.AdminPushSubscriptionStatusResponse
+import app.hyuabot.backend.security.AdminPermission
+import app.hyuabot.backend.security.WithCustomMockUser
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.web.client.RestClientException
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminPushControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    lateinit var notifierClient: NotifierClient
+
+    @Test
+    @WithCustomMockUser(username = "jil8885")
+    fun `super admin manages this device subscription`() {
+        whenever(notifierClient.getPublicKey()).thenReturn(AdminPushPublicKeyResponse("public-key"))
+        whenever(notifierClient.getStatus("jil8885", "https://push.example/device"))
+            .thenReturn(AdminPushSubscriptionStatusResponse(true))
+
+        mockMvc
+            .perform(get("/api/v1/user/push/public-key"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.publicKey").value("public-key"))
+        mockMvc
+            .perform(
+                get("/api/v1/user/push/status")
+                    .queryParam("endpoint", "https://push.example/device"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.enabled").value(true))
+        mockMvc
+            .perform(
+                post("/api/v1/user/push/subscription")
+                    .header("User-Agent", "Safari")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{"endpoint":"https://push.example/device","keys":{"p256dh":"key","auth":"auth"}}""",
+                    ),
+            ).andExpect(status().isNoContent)
+        mockMvc
+            .perform(
+                delete("/api/v1/user/push/subscription")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"endpoint":"https://push.example/device"}"""),
+            ).andExpect(status().isNoContent)
+
+        verify(notifierClient).subscribe(eq("jil8885"), eq("Safari"), any())
+        verify(notifierClient).unsubscribe("jil8885", "https://push.example/device")
+    }
+
+    @Test
+    @WithCustomMockUser
+    fun `notifier failure returns service unavailable`() {
+        doThrow(RestClientException("unavailable")).whenever(notifierClient).getPublicKey()
+
+        mockMvc
+            .perform(get("/api/v1/user/push/public-key"))
+            .andExpect(status().isServiceUnavailable)
+            .andExpect(jsonPath("$.enabled").value(false))
+    }
+
+    @Test
+    @WithCustomMockUser(permissions = [AdminPermission.SHUTTLE])
+    fun `regular administrator cannot manage operational push`() {
+        mockMvc.perform(get("/api/v1/user/push/public-key")).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `anonymous user cannot manage operational push`() {
+        mockMvc.perform(get("/api/v1/user/push/public-key")).andExpect(status().isUnauthorized)
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/adminpush/NotifierClientTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminpush/NotifierClientTest.kt
@@ -1,0 +1,98 @@
+package app.hyuabot.backend.adminpush
+
+import app.hyuabot.backend.adminpush.domain.AdminPushSubscriptionKeys
+import app.hyuabot.backend.adminpush.domain.AdminPushSubscriptionRequest
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+class NotifierClientTest {
+    @Test
+    fun `client forwards authenticated subscription requests`() {
+        val requests = mutableListOf<CapturedRequest>()
+        withServer(requests) { baseURL ->
+            val client = NotifierClient(baseURL, "secret-token")
+            assertEquals("vapid-public", client.getPublicKey().publicKey)
+            assertTrue(client.getStatus("jil8885", "https://push.example/device").enabled)
+
+            val request =
+                AdminPushSubscriptionRequest(
+                    endpoint = "https://push.example/device",
+                    keys = AdminPushSubscriptionKeys("p256dh", "auth"),
+                )
+            client.subscribe("jil8885", "Safari", request)
+            client.unsubscribe("jil8885", request.endpoint)
+        }
+
+        assertEquals(listOf("GET", "GET", "POST", "DELETE"), requests.map { it.method })
+        assertTrue(requests.all { it.authorization == "Bearer secret-token" })
+        assertTrue(URLDecoder.decode(requests[1].query, StandardCharsets.UTF_8).contains("userId=jil8885"))
+        assertTrue(URLDecoder.decode(requests[1].query, StandardCharsets.UTF_8).contains("endpoint=https://push.example/device"))
+        assertTrue(requests[2].body.contains("\"userId\":\"jil8885\""))
+        assertTrue(requests[2].body.contains("\"userAgent\":\"Safari\""))
+        assertTrue(requests[3].body.contains("\"endpoint\":\"https://push.example/device\""))
+    }
+
+    @Test
+    fun `empty notifier responses are rejected`() {
+        withServer(mutableListOf(), emptyResponses = true) { baseURL ->
+            val client = NotifierClient(baseURL, "token")
+            assertThrows(IllegalArgumentException::class.java) { client.getPublicKey() }
+            assertThrows(IllegalArgumentException::class.java) { client.getStatus("user", "endpoint") }
+        }
+    }
+
+    private fun withServer(
+        requests: MutableList<CapturedRequest>,
+        emptyResponses: Boolean = false,
+        block: (String) -> Unit,
+    ) {
+        val server = HttpServer.create(InetSocketAddress(0), 0)
+        server.createContext("/") { exchange ->
+            requests += exchange.capture()
+            val response =
+                when {
+                    emptyResponses -> ""
+                    exchange.requestURI.path.endsWith("public-key") -> """{"publicKey":"vapid-public"}"""
+                    exchange.requestURI.path.endsWith("status") -> """{"enabled":true}"""
+                    else -> ""
+                }
+            if (response.isEmpty()) {
+                exchange.sendResponseHeaders(204, -1)
+            } else {
+                val bytes = response.toByteArray()
+                exchange.responseHeaders.add("Content-Type", "application/json")
+                exchange.sendResponseHeaders(200, bytes.size.toLong())
+                exchange.responseBody.use { it.write(bytes) }
+            }
+            exchange.close()
+        }
+        server.start()
+        try {
+            block("http://127.0.0.1:${server.address.port}")
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    private fun HttpExchange.capture() =
+        CapturedRequest(
+            method = requestMethod,
+            authorization = requestHeaders.getFirst("Authorization"),
+            query = requestURI.rawQuery.orEmpty(),
+            body = requestBody.bufferedReader().readText(),
+        )
+
+    private data class CapturedRequest(
+        val method: String,
+        val authorization: String?,
+        val query: String,
+        val body: String,
+    )
+}


### PR DESCRIPTION
## Summary

- Add SUPER_ADMIN-only endpoints for Web Push public-key lookup, current-device status, subscription registration, and subscription removal.
- Proxy subscription data to the independent notifier without exposing its service credential to the browser.
- Forward the authenticated administrator identifier and device user agent for subscription ownership.
- Return a safe service-unavailable response when the notifier cannot be reached.
- Enforce the new endpoints in the central Spring Security policy.

## Impact

The administrator frontend can manage per-device operations alerts while all notifier credentials remain server-side. No database schema change is required.

The paired infrastructure change must configure `NOTIFIER_BASE_URL` and `NOTIFIER_SERVICE_TOKEN` before this backend version is deployed.

## Validation

- `./gradlew clean ktlintCheck test jacocoTestReport jacocoTestCoverageVerification`
- The full test suite passed.
- New `adminpush` packages have 0 missed instructions, branches, lines, methods, and classes (100%).
