### PR TITLE
feat: Add holiday timetable automation and audits

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewService.kt
@@ -4,6 +4,8 @@ import app.hyuabot.backend.adminoverview.domain.AdminOverviewResponse
 import app.hyuabot.backend.adminoverview.domain.AdminServiceStatus
 import app.hyuabot.backend.adminoverview.domain.CronJobRun
 import app.hyuabot.backend.database.repository.AdminUserInvitationRepository
+import app.hyuabot.backend.holiday.audit.HolidayAuditResult
+import app.hyuabot.backend.holiday.audit.HolidayAuditService
 import app.hyuabot.backend.security.AdminPermission
 import app.hyuabot.backend.shuttle.service.ShuttleHolidayService
 import app.hyuabot.backend.shuttle.service.ShuttlePeriodService
@@ -20,6 +22,7 @@ class AdminOverviewService(
     private val prometheusClient: PrometheusClient,
     private val shuttlePeriodService: ShuttlePeriodService,
     private val shuttleHolidayService: ShuttleHolidayService,
+    private val holidayAuditService: HolidayAuditService,
     private val invitationRepository: AdminUserInvitationRepository,
     @param:Value("\${admin.overview.grafana-url:https://grafana.hyuabot.app}") private val grafanaURL: String,
 ) {
@@ -31,9 +34,22 @@ class AdminOverviewService(
         now: ZonedDateTime,
     ): AdminOverviewResponse {
         val jobs = runCatching { prometheusClient.getCronJobRuns() }.getOrNull()
+        val holidayAudit =
+            if (permissions.any {
+                    it == AdminPermission.SUPER_ADMIN ||
+                        it == AdminPermission.SHUTTLE ||
+                        it == AdminPermission.BUS ||
+                        it == AdminPermission.SUBWAY
+                }
+            ) {
+                holidayAuditService.audit(permissions, now)
+            } else {
+                null
+            }
         val services =
             buildList {
                 if (AdminPermission.SHUTTLE in permissions) add(shuttleStatus(now.toLocalDate()))
+                holidayAudit?.let { add(holidayStatus(it)) }
                 JOBS.filter { it.permission in permissions }.forEach { definition ->
                     add(jobStatus(definition, jobs?.get(definition.jobName), now.toInstant()))
                 }
@@ -73,6 +89,34 @@ class AdminOverviewService(
             lastSuccessAt = null,
             lastFailureAt = null,
             managementPath = "/shuttle/period",
+        )
+    }
+
+    private fun holidayStatus(audit: HolidayAuditResult): AdminServiceStatus {
+        val errors = audit.issues.count { it.severity == "ERROR" }
+        val warnings = audit.issues.size - errors
+        val status =
+            if (errors > 0) {
+                "ERROR"
+            } else if (warnings > 0) {
+                "WARNING"
+            } else {
+                "NORMAL"
+            }
+        val message =
+            when {
+                errors > 0 -> "임박한 휴일 설정 문제 ${errors}건과 확인 항목 ${warnings}건이 있습니다."
+                warnings > 0 -> "확인이 필요한 휴일 설정이 ${warnings}건 있습니다."
+                else -> "향후 90일의 휴일 시간표 설정이 정상입니다."
+            }
+        return AdminServiceStatus(
+            id = "holiday-configuration",
+            title = "휴일 시간표",
+            status = status,
+            message = message,
+            lastSuccessAt = audit.lastSuccessAt?.toString(),
+            lastFailureAt = null,
+            managementPath = "/operations/holiday-audit",
         )
     }
 

--- a/src/main/kotlin/app/hyuabot/backend/database/entity/HolidaySyncState.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/entity/HolidaySyncState.kt
@@ -1,0 +1,13 @@
+package app.hyuabot.backend.database.entity
+
+import java.time.LocalDate
+import java.time.ZonedDateTime
+
+data class HolidaySyncState(
+    val source: String,
+    val lastAttemptAt: ZonedDateTime?,
+    val lastSuccessAt: ZonedDateTime?,
+    val rangeStart: LocalDate?,
+    val rangeEnd: LocalDate?,
+    val lastError: String?,
+)

--- a/src/main/kotlin/app/hyuabot/backend/database/entity/ShuttleHoliday.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/entity/ShuttleHoliday.kt
@@ -15,7 +15,7 @@ import java.time.LocalDate
 @Table(
     name = "shuttle_holiday",
     indexes = [
-        Index(name = "idx_shuttle_holiday_date", columnList = "holiday_date, holiday_type, calendar_type", unique = true),
+        Index(name = "idx_shuttle_holiday_date", columnList = "holiday_date, calendar_type", unique = true),
     ],
 )
 @SequenceGenerator(name = "shuttle_holiday_seq_seq", allocationSize = 1)

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/BusTimetableRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/BusTimetableRepository.kt
@@ -1,11 +1,24 @@
 package app.hyuabot.backend.database.repository
 
 import app.hyuabot.backend.database.entity.BusTimetable
+import app.hyuabot.backend.holiday.audit.BusHolidayCoverageGap
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import java.time.LocalTime
 
 interface BusTimetableRepository : JpaRepository<BusTimetable, Int> {
+    @Query(
+        """
+        SELECT new app.hyuabot.backend.holiday.audit.BusHolidayCoverageGap(t.routeID, t.startStopID)
+        FROM bus_timetable t
+        GROUP BY t.routeID, t.startStopID
+        HAVING SUM(CASE WHEN t.weekday = 'weekdays' THEN 1 ELSE 0 END) > 0
+           AND SUM(CASE WHEN t.weekday = 'sunday' THEN 1 ELSE 0 END) = 0
+        """,
+    )
+    fun findHolidayCoverageGaps(): List<BusHolidayCoverageGap>
+
     fun findByRouteIDAndStartStopIDAndWeekdayAndDepartureTime(
         routeID: Int,
         startStopID: Int,

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/HolidaySyncStateRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/HolidaySyncStateRepository.kt
@@ -1,0 +1,31 @@
+package app.hyuabot.backend.database.repository
+
+import app.hyuabot.backend.database.entity.HolidaySyncState
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class HolidaySyncStateRepository(
+    private val jdbcTemplate: JdbcTemplate,
+) {
+    fun findBySource(source: String): HolidaySyncState? =
+        jdbcTemplate
+            .query(
+                """
+                SELECT source, last_attempt_at, last_success_at, range_start, range_end, last_error
+                FROM holiday_sync_state
+                WHERE source = ?
+                """.trimIndent(),
+                { resultSet, _ ->
+                    HolidaySyncState(
+                        source = resultSet.getString("source"),
+                        lastAttemptAt = resultSet.getObject("last_attempt_at", java.time.OffsetDateTime::class.java)?.toZonedDateTime(),
+                        lastSuccessAt = resultSet.getObject("last_success_at", java.time.OffsetDateTime::class.java)?.toZonedDateTime(),
+                        rangeStart = resultSet.getObject("range_start", java.time.LocalDate::class.java),
+                        rangeEnd = resultSet.getObject("range_end", java.time.LocalDate::class.java),
+                        lastError = resultSet.getString("last_error"),
+                    )
+                },
+                source,
+            ).firstOrNull()
+}

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/PublicHolidayRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/PublicHolidayRepository.kt
@@ -28,4 +28,22 @@ interface PublicHolidayRepository : JpaRepository<PublicHoliday, Int> {
         solarDate: LocalDate,
         lunarDate: LocalDate,
     ): PublicHoliday?
+
+    @Query(
+        value = """
+            SELECT seq, holiday_date, holiday_name, calendar_type
+            FROM public_holiday
+            WHERE source = :source
+              AND calendar_type = :calendarType
+              AND holiday_date BETWEEN :start AND :end
+            ORDER BY holiday_date
+        """,
+        nativeQuery = true,
+    )
+    fun findOfficialHolidaysBetween(
+        source: String,
+        calendarType: String,
+        start: LocalDate,
+        end: LocalDate,
+    ): List<PublicHoliday>
 }

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/ShuttleTimetableRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/ShuttleTimetableRepository.kt
@@ -22,6 +22,11 @@ interface ShuttleTimetableRepository : JpaRepository<ShuttleTimetable, Int> {
 
     fun findByPeriodType(periodType: String): List<ShuttleTimetable>
 
+    fun existsByPeriodTypeAndWeekday(
+        periodType: String,
+        weekday: Boolean,
+    ): Boolean
+
     fun findByRouteNameAndWeekday(
         routeName: String,
         isWeekdays: Boolean,

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/SubwayTimetableRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/SubwayTimetableRepository.kt
@@ -1,6 +1,7 @@
 package app.hyuabot.backend.database.repository
 
 import app.hyuabot.backend.database.entity.SubwayTimetable
+import app.hyuabot.backend.holiday.audit.SubwayHolidayCoverageGap
 import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
@@ -9,6 +10,17 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.LocalTime
 
 interface SubwayTimetableRepository : JpaRepository<SubwayTimetable, Int> {
+    @Query(
+        """
+        SELECT new app.hyuabot.backend.holiday.audit.SubwayHolidayCoverageGap(t.stationID, t.heading)
+        FROM subway_timetable t
+        GROUP BY t.stationID, t.heading
+        HAVING SUM(CASE WHEN t.weekday = 'weekdays' THEN 1 ELSE 0 END) > 0
+           AND SUM(CASE WHEN t.weekday = 'weekends' THEN 1 ELSE 0 END) = 0
+        """,
+    )
+    fun findHolidayCoverageGaps(): List<SubwayHolidayCoverageGap>
+
     fun findByStationID(stationID: String): List<SubwayTimetable>
 
     fun findByStationIDIn(stationIDs: List<String>): List<SubwayTimetable>

--- a/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayAuditController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayAuditController.kt
@@ -1,0 +1,21 @@
+package app.hyuabot.backend.holiday.audit
+
+import app.hyuabot.backend.security.AdminPermission
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/user/overview/holiday-audit")
+class HolidayAuditController(
+    private val service: HolidayAuditService,
+) {
+    @GetMapping
+    fun getAudit(authentication: Authentication): HolidayAuditResult =
+        service.audit(
+            authentication.authorities
+                .mapNotNull { authority -> AdminPermission.entries.find { it.name == authority.authority } }
+                .toSet(),
+        )
+}

--- a/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayAuditMetrics.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayAuditMetrics.kt
@@ -1,0 +1,45 @@
+package app.hyuabot.backend.holiday.audit
+
+import app.hyuabot.backend.security.AdminPermission
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+
+@Component
+class HolidayAuditMetrics(
+    private val service: HolidayAuditService,
+    meterRegistry: MeterRegistry,
+) {
+    private var cachedAt = Instant.EPOCH
+    private var cachedResult: HolidayAuditResult? = null
+
+    init {
+        listOf("WARNING", "ERROR").forEach { severity ->
+            Gauge
+                .builder("hyuabot.holiday.configuration.issues") {
+                    snapshot().issues.count { it.severity == severity }.toDouble()
+                }.tag("severity", severity.lowercase())
+                .register(meterRegistry)
+        }
+        Gauge
+            .builder("hyuabot.holiday.sync.age.seconds") {
+                snapshot().lastSuccessAt?.let { Duration.between(it, snapshot().checkedAt).seconds.toDouble() } ?: -1.0
+            }.register(meterRegistry)
+    }
+
+    @Synchronized
+    internal fun snapshot(now: Instant = Instant.now()): HolidayAuditResult {
+        val current = cachedResult
+        if (current == null || Duration.between(cachedAt, now) >= CACHE_DURATION) {
+            cachedAt = now
+            cachedResult = service.audit(AdminPermission.entries.toSet())
+        }
+        return cachedResult!!
+    }
+
+    companion object {
+        private val CACHE_DURATION = Duration.ofMinutes(5)
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayAuditModels.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayAuditModels.kt
@@ -1,0 +1,19 @@
+package app.hyuabot.backend.holiday.audit
+
+import java.time.LocalDate
+import java.time.ZonedDateTime
+
+data class HolidayAuditIssue(
+    val code: String,
+    val service: String,
+    val date: LocalDate?,
+    val message: String,
+    val severity: String,
+    val managementPath: String,
+)
+
+data class HolidayAuditResult(
+    val checkedAt: ZonedDateTime,
+    val lastSuccessAt: ZonedDateTime?,
+    val issues: List<HolidayAuditIssue>,
+)

--- a/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayAuditService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayAuditService.kt
@@ -1,0 +1,167 @@
+package app.hyuabot.backend.holiday.audit
+
+import app.hyuabot.backend.database.repository.BusTimetableRepository
+import app.hyuabot.backend.database.repository.HolidaySyncStateRepository
+import app.hyuabot.backend.database.repository.PublicHolidayRepository
+import app.hyuabot.backend.database.repository.ShuttleHolidayRepository
+import app.hyuabot.backend.database.repository.ShuttleTimetableRepository
+import app.hyuabot.backend.database.repository.SubwayTimetableRepository
+import app.hyuabot.backend.security.AdminPermission
+import app.hyuabot.backend.shuttle.service.ShuttlePeriodService
+import app.hyuabot.backend.utility.LocalDateTimeBuilder
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+
+@Service
+class HolidayAuditService(
+    private val syncStateRepository: HolidaySyncStateRepository,
+    private val publicHolidayRepository: PublicHolidayRepository,
+    private val shuttleHolidayRepository: ShuttleHolidayRepository,
+    private val shuttleTimetableRepository: ShuttleTimetableRepository,
+    private val shuttlePeriodService: ShuttlePeriodService,
+    private val busTimetableRepository: BusTimetableRepository,
+    private val subwayTimetableRepository: SubwayTimetableRepository,
+) {
+    fun audit(
+        permissions: Set<AdminPermission>,
+        now: ZonedDateTime = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone),
+    ): HolidayAuditResult {
+        val effectivePermissions =
+            if (AdminPermission.SUPER_ADMIN in permissions) AdminPermission.entries.toSet() else permissions
+        val syncState = syncStateRepository.findBySource(SOURCE)
+        val issues = mutableListOf<HolidayAuditIssue>()
+        val hasTransportPermission =
+            effectivePermissions.any { it == AdminPermission.SHUTTLE || it == AdminPermission.BUS || it == AdminPermission.SUBWAY }
+        if (hasTransportPermission && (syncState?.lastSuccessAt == null || Duration.between(syncState.lastSuccessAt, now) > MAX_SYNC_AGE)) {
+            issues +=
+                issue(
+                    code = "PUBLIC_HOLIDAY_SYNC_STALE",
+                    service = "holiday",
+                    message = "공식 공휴일 동기화가 36시간 이상 완료되지 않았습니다.",
+                    path = publicHolidayPath(effectivePermissions),
+                )
+        }
+        if (AdminPermission.SHUTTLE in effectivePermissions) {
+            issues += auditShuttle(now.toLocalDate())
+        }
+        if (AdminPermission.BUS in effectivePermissions) {
+            issues +=
+                busTimetableRepository.findHolidayCoverageGaps().map { gap ->
+                    issue(
+                        code = "BUS_HOLIDAY_TIMETABLE_EMPTY",
+                        service = "bus",
+                        message = "노선 ${gap.routeID}의 기점 ${gap.startStopID}에 공휴일 시간표가 없습니다.",
+                        path = "/bus/timetable",
+                    )
+                }
+        }
+        if (AdminPermission.SUBWAY in effectivePermissions) {
+            issues +=
+                subwayTimetableRepository.findHolidayCoverageGaps().map { gap ->
+                    issue(
+                        code = "SUBWAY_HOLIDAY_TIMETABLE_EMPTY",
+                        service = "subway",
+                        message = "${gap.stationID}역 ${gap.heading} 방향에 주말 시간표가 없습니다.",
+                        path = "/subway/timetable",
+                    )
+                }
+        }
+        return HolidayAuditResult(now, syncState?.lastSuccessAt, issues.sortedWith(compareBy({ it.date }, { it.code }, { it.message })))
+    }
+
+    private fun auditShuttle(today: LocalDate): List<HolidayAuditIssue> {
+        val issues = mutableListOf<HolidayAuditIssue>()
+        val end = today.plusDays(AUDIT_DAYS)
+        shuttleHolidayRepository.findAll().forEach { holiday ->
+            if (holiday.type !in SHUTTLE_TYPES || holiday.calendarType !in CALENDAR_TYPES) {
+                issues +=
+                    issue(
+                        code = "SHUTTLE_DECISION_INVALID",
+                        service = "shuttle",
+                        date = holiday.date,
+                        message = "${holiday.date} 셔틀 휴일 설정값을 확인해주세요.",
+                        path = "/shuttle/holiday",
+                        today = today,
+                    )
+            }
+        }
+        val checkedWeekendPeriods = mutableSetOf<String>()
+        publicHolidayRepository
+            .findOfficialHolidaysBetween(SOURCE, "solar", today, end)
+            .forEach { publicHoliday ->
+                val decision = shuttleHolidayRepository.findByDateAndCalendarType(publicHoliday.date, "solar")
+                if (decision == null) {
+                    issues +=
+                        issue(
+                            code = "SHUTTLE_DECISION_MISSING",
+                            service = "shuttle",
+                            date = publicHoliday.date,
+                            message = "${publicHoliday.date} ${publicHoliday.name}의 셔틀 운행 방식을 결정해주세요.",
+                            path = "/shuttle/holiday",
+                            today = today,
+                        )
+                }
+                val period = shuttlePeriodService.findShuttlePeriod(publicHoliday.date)
+                if (period == null) {
+                    issues +=
+                        issue(
+                            code = "SHUTTLE_PERIOD_MISSING",
+                            service = "shuttle",
+                            date = publicHoliday.date,
+                            message = "${publicHoliday.date}에 적용되는 셔틀 운행 기간이 없습니다.",
+                            path = "/shuttle/period",
+                            today = today,
+                        )
+                } else if (decision?.type != "halt" &&
+                    checkedWeekendPeriods.add(period.type) &&
+                    !shuttleTimetableRepository.existsByPeriodTypeAndWeekday(period.type, false)
+                ) {
+                    issues +=
+                        issue(
+                            code = "SHUTTLE_WEEKEND_TIMETABLE_EMPTY",
+                            service = "shuttle",
+                            date = publicHoliday.date,
+                            message = "${period.type} 기간에 적용할 셔틀 주말 시간표가 없습니다.",
+                            path = "/shuttle/timetable",
+                            today = today,
+                        )
+                }
+            }
+        return issues
+    }
+
+    private fun issue(
+        code: String,
+        service: String,
+        message: String,
+        path: String,
+        date: LocalDate? = null,
+        today: LocalDate? = null,
+    ) = HolidayAuditIssue(
+        code = code,
+        service = service,
+        date = date,
+        message = message,
+        severity = if (date != null && today != null && ChronoUnit.DAYS.between(today, date) <= CRITICAL_DAYS) "ERROR" else "WARNING",
+        managementPath = path,
+    )
+
+    private fun publicHolidayPath(permissions: Set<AdminPermission>) =
+        when {
+            AdminPermission.BUS in permissions -> "/bus/holiday"
+            AdminPermission.SUBWAY in permissions -> "/subway/holiday"
+            else -> "/shuttle/holiday"
+        }
+
+    companion object {
+        private const val SOURCE = "KASI"
+        private const val AUDIT_DAYS = 90L
+        private const val CRITICAL_DAYS = 3L
+        private val MAX_SYNC_AGE = Duration.ofHours(36)
+        private val SHUTTLE_TYPES = setOf("weekends", "halt")
+        private val CALENDAR_TYPES = setOf("solar", "lunar")
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayCoverage.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayCoverage.kt
@@ -1,0 +1,11 @@
+package app.hyuabot.backend.holiday.audit
+
+data class BusHolidayCoverageGap(
+    val routeID: Int,
+    val startStopID: Int,
+)
+
+data class SubwayHolidayCoverageGap(
+    val stationID: String,
+    val heading: String,
+)

--- a/src/main/kotlin/app/hyuabot/backend/holiday/controller/PublicHolidayController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/controller/PublicHolidayController.kt
@@ -116,6 +116,8 @@ class PublicHolidayController {
             }
         } catch (_: LocalDateNotValidException) {
             ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("LOCAL_DATE_NOT_VALID"))
+        } catch (_: IllegalArgumentException) {
+            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("INVALID_HOLIDAY_TYPE"))
         } catch (_: DuplicatePublicHolidayException) {
             ResponseBuilder.response(HttpStatus.CONFLICT, ResponseBuilder.Message("DUPLICATE_PUBLIC_HOLIDAY"))
         } catch (e: Exception) {
@@ -215,6 +217,8 @@ class PublicHolidayController {
             }
         } catch (_: LocalDateNotValidException) {
             ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("LOCAL_DATE_NOT_VALID"))
+        } catch (_: IllegalArgumentException) {
+            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("INVALID_HOLIDAY_TYPE"))
         } catch (_: PublicHolidayNotFoundException) {
             ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("PUBLIC_HOLIDAY_NOT_FOUND"))
         } catch (_: DuplicatePublicHolidayException) {

--- a/src/main/kotlin/app/hyuabot/backend/holiday/controller/PublicHolidayController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/controller/PublicHolidayController.kt
@@ -217,10 +217,10 @@ class PublicHolidayController {
             }
         } catch (_: LocalDateNotValidException) {
             ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("LOCAL_DATE_NOT_VALID"))
-        } catch (_: IllegalArgumentException) {
-            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("INVALID_HOLIDAY_TYPE"))
         } catch (_: PublicHolidayNotFoundException) {
             ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("PUBLIC_HOLIDAY_NOT_FOUND"))
+        } catch (_: IllegalArgumentException) {
+            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("INVALID_HOLIDAY_TYPE"))
         } catch (_: DuplicatePublicHolidayException) {
             ResponseBuilder.response(HttpStatus.CONFLICT, ResponseBuilder.Message("DUPLICATE_PUBLIC_HOLIDAY"))
         } catch (e: Exception) {

--- a/src/main/kotlin/app/hyuabot/backend/holiday/service/PublicHolidayService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/service/PublicHolidayService.kt
@@ -19,6 +19,7 @@ class PublicHolidayService(
     fun getPublicHolidayList() = publicHolidayRepository.findAll().sortedBy { it.date }
 
     fun createPublicHoliday(payload: PublicHolidayRequest): PublicHoliday {
+        require(payload.calendarType in CALENDAR_TYPES) { "Unsupported calendar type" }
         if (!LocalDateTimeBuilder.checkLocalDateFormat(payload.date)) {
             throw LocalDateNotValidException()
         }
@@ -45,6 +46,7 @@ class PublicHolidayService(
         seq: Int,
         payload: PublicHolidayRequest,
     ): PublicHoliday {
+        require(payload.calendarType in CALENDAR_TYPES) { "Unsupported calendar type" }
         if (!LocalDateTimeBuilder.checkLocalDateFormat(payload.date)) {
             throw LocalDateNotValidException()
         }
@@ -79,5 +81,9 @@ class PublicHolidayService(
             date,
             LocalDate.parse(lunarDate.lunarIsoFormat, dateFormatter),
         )
+    }
+
+    companion object {
+        private val CALENDAR_TYPES = setOf("solar", "lunar")
     }
 }

--- a/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
@@ -91,7 +91,7 @@ class SecurityConfig(
                         AdminPermission.CONTACT.name,
                     ).requestMatchers("/api/v1/user/push/**")
                     .hasAuthority(AdminPermission.SUPER_ADMIN.name)
-                    .requestMatchers("/api/v1/user/profile", "/api/v1/user/password", "/api/v1/user/overview")
+                    .requestMatchers("/api/v1/user/profile", "/api/v1/user/password", "/api/v1/user/overview/**")
                     .authenticated()
                     .anyRequest()
                     .denyAll()

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleDataFetcher.kt
@@ -12,6 +12,7 @@ import app.hyuabot.backend.codegen.types.ShuttleStop
 import app.hyuabot.backend.codegen.types.ShuttleTimetable
 import app.hyuabot.backend.codegen.types.ShuttleTimetableEntry
 import app.hyuabot.backend.codegen.types.ShuttleTimetableGroup
+import app.hyuabot.backend.holiday.service.PublicHolidayService
 import app.hyuabot.backend.shuttle.domain.ShuttleFilterContext
 import app.hyuabot.backend.shuttle.domain.ShuttleTimetableKey
 import app.hyuabot.backend.shuttle.domain.ShuttleTimetableResult
@@ -31,6 +32,7 @@ import java.util.concurrent.CompletableFuture
 @DgsComponent
 class ShuttleDataFetcher(
     private val holidayService: ShuttleHolidayService,
+    private val publicHolidayService: PublicHolidayService,
     private val periodService: ShuttlePeriodService,
     private val stopService: ShuttleStopService,
 ) {
@@ -219,10 +221,12 @@ class ShuttleDataFetcher(
             } else {
                 Triple(listOf(periods.type), listOf(false), true)
             }
-        } else {
-            val isWeekends = date.dayOfWeek.value == 6 || date.dayOfWeek.value == 7
-            return Triple(listOf(periods.type), listOf(!isWeekends), false)
         }
+        if (publicHolidayService.findPublicHoliday(date) != null) {
+            return Triple(listOf(periods.type), listOf(false), false)
+        }
+        val isWeekends = date.dayOfWeek.value == 6 || date.dayOfWeek.value == 7
+        return Triple(listOf(periods.type), listOf(!isWeekends), false)
     }
 
     private fun ShuttleTimetableViewItem.toTimetableEntry() =

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleHolidayController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleHolidayController.kt
@@ -272,15 +272,15 @@ class ShuttleHolidayController {
                 HttpStatus.BAD_REQUEST,
                 ResponseBuilder.Message("LOCAL_DATE_NOT_VALID"),
             )
-        } catch (_: IllegalArgumentException) {
-            ResponseBuilder.response(
-                HttpStatus.BAD_REQUEST,
-                ResponseBuilder.Message("INVALID_HOLIDAY_TYPE"),
-            )
         } catch (_: ShuttleHolidayNotFoundException) {
             ResponseBuilder.response(
                 HttpStatus.NOT_FOUND,
                 ResponseBuilder.Message("SHUTTLE_HOLIDAY_NOT_FOUND"),
+            )
+        } catch (_: IllegalArgumentException) {
+            ResponseBuilder.response(
+                HttpStatus.BAD_REQUEST,
+                ResponseBuilder.Message("INVALID_HOLIDAY_TYPE"),
             )
         } catch (_: DuplicateShuttleHolidayException) {
             ResponseBuilder.response(

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleHolidayController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleHolidayController.kt
@@ -119,6 +119,11 @@ class ShuttleHolidayController {
                 HttpStatus.BAD_REQUEST,
                 ResponseBuilder.Message("LOCAL_DATE_NOT_VALID"),
             )
+        } catch (_: IllegalArgumentException) {
+            ResponseBuilder.response(
+                HttpStatus.BAD_REQUEST,
+                ResponseBuilder.Message("INVALID_HOLIDAY_TYPE"),
+            )
         } catch (_: DuplicateShuttleHolidayException) {
             ResponseBuilder.response(
                 HttpStatus.CONFLICT,
@@ -266,6 +271,11 @@ class ShuttleHolidayController {
             ResponseBuilder.response(
                 HttpStatus.BAD_REQUEST,
                 ResponseBuilder.Message("LOCAL_DATE_NOT_VALID"),
+            )
+        } catch (_: IllegalArgumentException) {
+            ResponseBuilder.response(
+                HttpStatus.BAD_REQUEST,
+                ResponseBuilder.Message("INVALID_HOLIDAY_TYPE"),
             )
         } catch (_: ShuttleHolidayNotFoundException) {
             ResponseBuilder.response(

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/service/ShuttleHolidayService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/service/ShuttleHolidayService.kt
@@ -20,6 +20,7 @@ class ShuttleHolidayService(
     fun getShuttleHolidayList() = shuttleHolidayRepository.findAll().sortedBy { it.date }
 
     fun createShuttleHoliday(payload: ShuttleHolidayRequest): ShuttleHoliday {
+        validateTypes(payload)
         if (!LocalDateTimeBuilder.checkLocalDateFormat(payload.date)) {
             throw LocalDateNotValidException()
         }
@@ -46,6 +47,7 @@ class ShuttleHolidayService(
         seq: Int,
         payload: ShuttleHolidayRequest,
     ): ShuttleHoliday {
+        validateTypes(payload)
         if (!LocalDateTimeBuilder.checkLocalDateFormat(payload.date)) {
             throw LocalDateNotValidException()
         }
@@ -97,5 +99,15 @@ class ShuttleHolidayService(
                     )
                 }
             }.toList()
+    }
+
+    private fun validateTypes(payload: ShuttleHolidayRequest) {
+        require(payload.type in HOLIDAY_TYPES) { "Unsupported shuttle holiday type" }
+        require(payload.calendarType in CALENDAR_TYPES) { "Unsupported calendar type" }
+    }
+
+    companion object {
+        private val HOLIDAY_TYPES = setOf("weekends", "halt")
+        private val CALENDAR_TYPES = setOf("solar", "lunar")
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewServiceTest.kt
@@ -5,6 +5,9 @@ import app.hyuabot.backend.database.entity.AdminUserInvitation
 import app.hyuabot.backend.database.entity.ShuttleHoliday
 import app.hyuabot.backend.database.entity.ShuttlePeriod
 import app.hyuabot.backend.database.repository.AdminUserInvitationRepository
+import app.hyuabot.backend.holiday.audit.HolidayAuditIssue
+import app.hyuabot.backend.holiday.audit.HolidayAuditResult
+import app.hyuabot.backend.holiday.audit.HolidayAuditService
 import app.hyuabot.backend.security.AdminPermission
 import app.hyuabot.backend.shuttle.service.ShuttleHolidayService
 import app.hyuabot.backend.shuttle.service.ShuttlePeriodService
@@ -23,9 +26,23 @@ class AdminOverviewServiceTest {
     private val prometheusClient = mock<PrometheusClient>()
     private val periodService = mock<ShuttlePeriodService>()
     private val holidayService = mock<ShuttleHolidayService>()
+    private val holidayAuditService = mock<HolidayAuditService>()
     private val invitationRepository = mock<AdminUserInvitationRepository>()
     private val service =
-        AdminOverviewService(prometheusClient, periodService, holidayService, invitationRepository, "https://grafana.example")
+        AdminOverviewService(
+            prometheusClient,
+            periodService,
+            holidayService,
+            holidayAuditService,
+            invitationRepository,
+            "https://grafana.example",
+        )
+
+    init {
+        whenever(holidayAuditService.audit(any(), any())).thenAnswer { invocation ->
+            HolidayAuditResult(invocation.getArgument(1), null, emptyList())
+        }
+    }
 
     @Test
     fun `overview summarizes service health shuttle holiday and expiring invitations`() {
@@ -60,6 +77,7 @@ class AdminOverviewServiceTest {
         assertEquals("ERROR", result.services.first { it.id == "subway" }.status)
         assertEquals("WARNING", result.services.first { it.id == "cafeteria" }.status)
         assertEquals("UNKNOWN", result.services.first { it.id == "reading-room" }.status)
+        assertEquals("NORMAL", result.services.first { it.id == "holiday-configuration" }.status)
     }
 
     @Test
@@ -103,7 +121,7 @@ class AdminOverviewServiceTest {
 
         val result = service.getOverview(setOf(AdminPermission.SHUTTLE))
 
-        assertEquals("special · 오늘은 special-day입니다.", result.services.single().message)
+        assertEquals("special · 오늘은 special-day입니다.", result.services.first { it.id == "shuttle" }.message)
     }
 
     @Test
@@ -115,8 +133,8 @@ class AdminOverviewServiceTest {
 
         val result = service.getOverview(setOf(AdminPermission.BUS), overnight)
 
-        assertEquals("NORMAL", result.services.single().status)
-        assertEquals("현재는 실시간 수집 운영 시간 외입니다.", result.services.single().message)
+        assertEquals("NORMAL", result.services.first { it.id == "bus" }.status)
+        assertEquals("현재는 실시간 수집 운영 시간 외입니다.", result.services.first { it.id == "bus" }.message)
 
         val earlyMorning = overnight.withHour(1)
         whenever(prometheusClient.getCronJobRuns()).thenReturn(
@@ -127,9 +145,77 @@ class AdminOverviewServiceTest {
             service
                 .getOverview(setOf(AdminPermission.BUS), earlyMorning)
                 .services
-                .single()
+                .first { it.id == "bus" }
                 .message,
         )
+    }
+
+    @Test
+    fun `holiday configuration card promotes imminent issues to error`() {
+        val now = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
+        whenever(holidayAuditService.audit(any(), any())).thenReturn(
+            HolidayAuditResult(
+                checkedAt = now,
+                lastSuccessAt = now.minusHours(1),
+                issues =
+                    listOf(
+                        HolidayAuditIssue(
+                            code = "SHUTTLE_DECISION_MISSING",
+                            service = "shuttle",
+                            date = now.toLocalDate(),
+                            message = "설정이 필요합니다.",
+                            severity = "ERROR",
+                            managementPath = "/shuttle/holiday",
+                        ),
+                        HolidayAuditIssue(
+                            code = "PUBLIC_HOLIDAY_SYNC_STALE",
+                            service = "holiday",
+                            date = null,
+                            message = "동기화를 확인해주세요.",
+                            severity = "WARNING",
+                            managementPath = "/bus/holiday",
+                        ),
+                    ),
+            ),
+        )
+        whenever(prometheusClient.getCronJobRuns()).thenReturn(emptyMap())
+
+        val card = service.getOverview(setOf(AdminPermission.BUS), now).services.first { it.id == "holiday-configuration" }
+
+        assertEquals("ERROR", card.status)
+        assertEquals("임박한 휴일 설정 문제 1건과 확인 항목 1건이 있습니다.", card.message)
+        assertEquals(now.minusHours(1).toString(), card.lastSuccessAt)
+        assertEquals("/operations/holiday-audit", card.managementPath)
+    }
+
+    @Test
+    fun `holiday configuration card distinguishes warnings and unrelated permissions`() {
+        val now = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
+        whenever(holidayAuditService.audit(any(), any())).thenReturn(
+            HolidayAuditResult(
+                checkedAt = now,
+                lastSuccessAt = now.minusHours(1),
+                issues =
+                    listOf(
+                        HolidayAuditIssue(
+                            code = "PUBLIC_HOLIDAY_SYNC_STALE",
+                            service = "holiday",
+                            date = null,
+                            message = "동기화를 확인해주세요.",
+                            severity = "WARNING",
+                            managementPath = "/bus/holiday",
+                        ),
+                    ),
+            ),
+        )
+        whenever(prometheusClient.getCronJobRuns()).thenReturn(emptyMap())
+
+        val warning = service.getOverview(setOf(AdminPermission.BUS), now).services.first { it.id == "holiday-configuration" }
+        val unrelated = service.getOverview(setOf(AdminPermission.CAFETERIA), now)
+
+        assertEquals("WARNING", warning.status)
+        assertEquals("확인이 필요한 휴일 설정이 1건 있습니다.", warning.message)
+        assertEquals(listOf("cafeteria"), unrelated.services.map { it.id })
     }
 
     private fun invitation(expiresAt: ZonedDateTime) =

--- a/src/test/kotlin/app/hyuabot/backend/holiday/HolidayAuditControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/HolidayAuditControllerTest.kt
@@ -1,0 +1,38 @@
+package app.hyuabot.backend.holiday
+
+import app.hyuabot.backend.holiday.audit.HolidayAuditController
+import app.hyuabot.backend.holiday.audit.HolidayAuditResult
+import app.hyuabot.backend.holiday.audit.HolidayAuditService
+import app.hyuabot.backend.security.AdminPermission
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class HolidayAuditControllerTest {
+    @Test
+    fun `controller maps known authorities to audit permissions`() {
+        val service = mock<HolidayAuditService>()
+        val now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
+        val expected = HolidayAuditResult(now, null, emptyList())
+        val permissions = argumentCaptor<Set<AdminPermission>>()
+        whenever(service.audit(permissions.capture(), any())).thenReturn(expected)
+        val authentication =
+            UsernamePasswordAuthenticationToken(
+                "admin",
+                null,
+                listOf(SimpleGrantedAuthority("BUS"), SimpleGrantedAuthority("UNKNOWN")),
+            )
+
+        val result = HolidayAuditController(service).getAudit(authentication)
+
+        assertEquals(expected, result)
+        assertEquals(setOf(AdminPermission.BUS), permissions.firstValue)
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/holiday/HolidayAuditMetricsTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/HolidayAuditMetricsTest.kt
@@ -1,0 +1,86 @@
+package app.hyuabot.backend.holiday
+
+import app.hyuabot.backend.holiday.audit.HolidayAuditIssue
+import app.hyuabot.backend.holiday.audit.HolidayAuditMetrics
+import app.hyuabot.backend.holiday.audit.HolidayAuditResult
+import app.hyuabot.backend.holiday.audit.HolidayAuditService
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class HolidayAuditMetricsTest {
+    @Test
+    fun `gauges publish issue counts and synchronized age from a cached audit`() {
+        val service = mock<HolidayAuditService>()
+        val registry = SimpleMeterRegistry()
+        val checkedAt = ZonedDateTime.of(2026, 7, 17, 9, 0, 0, 0, ZoneId.of("Asia/Seoul"))
+        whenever(service.audit(any(), any())).thenReturn(
+            HolidayAuditResult(
+                checkedAt,
+                checkedAt.minusHours(2),
+                listOf(
+                    issue("WARNING"),
+                    issue("ERROR"),
+                    issue("ERROR"),
+                ),
+            ),
+        )
+        val metrics = HolidayAuditMetrics(service, registry)
+        val firstRead = Instant.now()
+        metrics.snapshot(firstRead)
+
+        assertEquals(
+            1.0,
+            registry
+                .get("hyuabot.holiday.configuration.issues")
+                .tag("severity", "warning")
+                .gauge()
+                .value(),
+        )
+        assertEquals(
+            2.0,
+            registry
+                .get("hyuabot.holiday.configuration.issues")
+                .tag("severity", "error")
+                .gauge()
+                .value(),
+        )
+        assertEquals(7200.0, registry.get("hyuabot.holiday.sync.age.seconds").gauge().value())
+        metrics.snapshot(firstRead.plusSeconds(4 * 60))
+        metrics.snapshot(firstRead.plusSeconds(6 * 60))
+
+        verify(service, times(2)).audit(any(), any())
+    }
+
+    @Test
+    fun `missing successful sync is exported as negative age`() {
+        val service = mock<HolidayAuditService>()
+        val registry = SimpleMeterRegistry()
+        whenever(service.audit(any(), any())).thenReturn(
+            HolidayAuditResult(ZonedDateTime.now(ZoneId.of("Asia/Seoul")), null, emptyList()),
+        )
+
+        HolidayAuditMetrics(service, registry)
+
+        assertEquals(-1.0, registry.get("hyuabot.holiday.sync.age.seconds").gauge().value())
+    }
+
+    private fun issue(severity: String) =
+        HolidayAuditIssue(
+            code = "TEST",
+            service = "holiday",
+            date = LocalDate.of(2026, 7, 17),
+            message = "test",
+            severity = severity,
+            managementPath = "/holiday",
+        )
+}

--- a/src/test/kotlin/app/hyuabot/backend/holiday/HolidayAuditServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/HolidayAuditServiceTest.kt
@@ -1,0 +1,166 @@
+package app.hyuabot.backend.holiday
+
+import app.hyuabot.backend.database.entity.HolidaySyncState
+import app.hyuabot.backend.database.entity.PublicHoliday
+import app.hyuabot.backend.database.entity.ShuttleHoliday
+import app.hyuabot.backend.database.repository.BusTimetableRepository
+import app.hyuabot.backend.database.repository.HolidaySyncStateRepository
+import app.hyuabot.backend.database.repository.PublicHolidayRepository
+import app.hyuabot.backend.database.repository.ShuttleHolidayRepository
+import app.hyuabot.backend.database.repository.ShuttleTimetableRepository
+import app.hyuabot.backend.database.repository.SubwayTimetableRepository
+import app.hyuabot.backend.holiday.audit.BusHolidayCoverageGap
+import app.hyuabot.backend.holiday.audit.HolidayAuditService
+import app.hyuabot.backend.holiday.audit.SubwayHolidayCoverageGap
+import app.hyuabot.backend.security.AdminPermission
+import app.hyuabot.backend.shuttle.service.ShuttlePeriodService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+@ExtendWith(MockitoExtension::class)
+class HolidayAuditServiceTest {
+    @Mock private lateinit var syncStateRepository: HolidaySyncStateRepository
+
+    @Mock private lateinit var publicHolidayRepository: PublicHolidayRepository
+
+    @Mock private lateinit var shuttleHolidayRepository: ShuttleHolidayRepository
+
+    @Mock private lateinit var shuttleTimetableRepository: ShuttleTimetableRepository
+
+    @Mock private lateinit var shuttlePeriodService: ShuttlePeriodService
+
+    @Mock private lateinit var busTimetableRepository: BusTimetableRepository
+
+    @Mock private lateinit var subwayTimetableRepository: SubwayTimetableRepository
+
+    private val now = ZonedDateTime.of(2026, 7, 17, 9, 0, 0, 0, ZoneId.of("Asia/Seoul"))
+
+    private fun service() =
+        HolidayAuditService(
+            syncStateRepository,
+            publicHolidayRepository,
+            shuttleHolidayRepository,
+            shuttleTimetableRepository,
+            shuttlePeriodService,
+            busTimetableRepository,
+            subwayTimetableRepository,
+        )
+
+    @Test
+    fun `super admin receives sync shuttle bus and subway issues`() {
+        val imminent = now.toLocalDate().plusDays(2)
+        val later = now.toLocalDate().plusDays(10)
+        whenever(syncStateRepository.findBySource("KASI")).thenReturn(null)
+        whenever(shuttleHolidayRepository.findAll()).thenReturn(
+            listOf(ShuttleHoliday(1, LocalDate.of(2026, 1, 1), "legacy", "gregorian")),
+        )
+        whenever(
+            publicHolidayRepository.findOfficialHolidaysBetween(
+                "KASI",
+                "solar",
+                now.toLocalDate(),
+                now.toLocalDate().plusDays(90),
+            ),
+        ).thenReturn(
+            listOf(
+                PublicHoliday(1, imminent, "제헌절", "solar"),
+                PublicHoliday(2, later, "광복절", "solar"),
+            ),
+        )
+        whenever(shuttleHolidayRepository.findByDateAndCalendarType(imminent, "solar")).thenReturn(null)
+        whenever(shuttleHolidayRepository.findByDateAndCalendarType(later, "solar")).thenReturn(
+            ShuttleHoliday(2, later, "weekends", "solar"),
+        )
+        whenever(shuttlePeriodService.findShuttlePeriod(imminent)).thenReturn(null)
+        whenever(shuttlePeriodService.findShuttlePeriod(later)).thenReturn(
+            app.hyuabot.backend.database.entity.ShuttlePeriod(
+                1,
+                "vacation",
+                now.minusDays(1),
+                now.plusDays(30),
+                null,
+            ),
+        )
+        whenever(shuttleTimetableRepository.existsByPeriodTypeAndWeekday("vacation", false)).thenReturn(false)
+        whenever(busTimetableRepository.findHolidayCoverageGaps()).thenReturn(listOf(BusHolidayCoverageGap(10, 20)))
+        whenever(subwayTimetableRepository.findHolidayCoverageGaps()).thenReturn(listOf(SubwayHolidayCoverageGap("K449", "UP")))
+
+        val result = service().audit(setOf(AdminPermission.SUPER_ADMIN), now)
+
+        assertEquals(now, result.checkedAt)
+        assertEquals(null, result.lastSuccessAt)
+        assertEquals(
+            setOf(
+                "PUBLIC_HOLIDAY_SYNC_STALE",
+                "SHUTTLE_DECISION_INVALID",
+                "SHUTTLE_DECISION_MISSING",
+                "SHUTTLE_PERIOD_MISSING",
+                "SHUTTLE_WEEKEND_TIMETABLE_EMPTY",
+                "BUS_HOLIDAY_TIMETABLE_EMPTY",
+                "SUBWAY_HOLIDAY_TIMETABLE_EMPTY",
+            ),
+            result.issues.map { it.code }.toSet(),
+        )
+        assertTrue(result.issues.filter { it.date == imminent }.all { it.severity == "ERROR" })
+        assertTrue(result.issues.filter { it.date == later }.all { it.severity == "WARNING" })
+        assertEquals("/bus/holiday", result.issues.first { it.code == "PUBLIC_HOLIDAY_SYNC_STALE" }.managementPath)
+    }
+
+    @Test
+    fun `fresh sync and halted shuttle holiday require no corrective action`() {
+        val date = now.toLocalDate().plusDays(5)
+        val syncState =
+            HolidaySyncState(
+                source = "KASI",
+                lastAttemptAt = now.minusHours(1),
+                lastSuccessAt = now.minusHours(1),
+                rangeStart = now.toLocalDate(),
+                rangeEnd = now.toLocalDate().plusYears(1),
+                lastError = null,
+            )
+        whenever(syncStateRepository.findBySource("KASI")).thenReturn(syncState)
+        whenever(shuttleHolidayRepository.findAll()).thenReturn(emptyList())
+        whenever(publicHolidayRepository.findOfficialHolidaysBetween(any(), any(), any(), any())).thenReturn(
+            listOf(PublicHoliday(1, date, "광복절", "solar")),
+        )
+        whenever(shuttleHolidayRepository.findByDateAndCalendarType(date, "solar")).thenReturn(
+            ShuttleHoliday(1, date, "halt", "solar"),
+        )
+        whenever(shuttlePeriodService.findShuttlePeriod(date)).thenReturn(
+            app.hyuabot.backend.database.entity
+                .ShuttlePeriod(1, "semester", now.minusDays(1), now.plusDays(30), null),
+        )
+
+        val result = service().audit(setOf(AdminPermission.SHUTTLE), now)
+
+        assertTrue(result.issues.isEmpty())
+        assertEquals(syncState.lastSuccessAt, result.lastSuccessAt)
+        verify(shuttleTimetableRepository, never()).existsByPeriodTypeAndWeekday(any(), any())
+    }
+
+    @Test
+    fun `permissions limit audit scope and select available management path`() {
+        whenever(syncStateRepository.findBySource("KASI")).thenReturn(null)
+        whenever(subwayTimetableRepository.findHolidayCoverageGaps()).thenReturn(emptyList())
+
+        val subway = service().audit(setOf(AdminPermission.SUBWAY), now)
+        val shuttle = service().audit(setOf(AdminPermission.SHUTTLE), now)
+        val unrelated = service().audit(setOf(AdminPermission.CAFETERIA), now)
+
+        assertEquals("/subway/holiday", subway.issues.single().managementPath)
+        assertEquals("/shuttle/holiday", shuttle.issues.single().managementPath)
+        assertTrue(unrelated.issues.isEmpty())
+        verify(busTimetableRepository, never()).findHolidayCoverageGaps()
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/holiday/HolidaySyncStateRepositoryTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/HolidaySyncStateRepositoryTest.kt
@@ -1,0 +1,50 @@
+package app.hyuabot.backend.holiday
+
+import app.hyuabot.backend.database.entity.HolidaySyncState
+import app.hyuabot.backend.database.repository.HolidaySyncStateRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.RowMapper
+import java.sql.ResultSet
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+class HolidaySyncStateRepositoryTest {
+    private val jdbcTemplate = mock<JdbcTemplate>()
+    private val repository = HolidaySyncStateRepository(jdbcTemplate)
+
+    @Test
+    fun `sync state row is mapped without registering a JPA entity`() {
+        val resultSet = mock<ResultSet>()
+        val success = OffsetDateTime.parse("2026-07-17T03:10:00+09:00")
+        whenever(resultSet.getString("source")).thenReturn("KASI")
+        whenever(resultSet.getObject("last_attempt_at", OffsetDateTime::class.java)).thenReturn(success)
+        whenever(resultSet.getObject("last_success_at", OffsetDateTime::class.java)).thenReturn(success)
+        whenever(resultSet.getObject("range_start", LocalDate::class.java)).thenReturn(LocalDate.of(2026, 1, 1))
+        whenever(resultSet.getObject("range_end", LocalDate::class.java)).thenReturn(LocalDate.of(2027, 12, 31))
+        whenever(resultSet.getString("last_error")).thenReturn(null)
+        whenever(jdbcTemplate.query(any<String>(), any<RowMapper<HolidaySyncState>>(), eq("KASI"))).thenAnswer { invocation ->
+            val mapper = invocation.getArgument<RowMapper<HolidaySyncState>>(1)
+            listOf(mapper.mapRow(resultSet, 0))
+        }
+
+        val result = repository.findBySource("KASI")
+
+        assertEquals(success.toZonedDateTime(), result?.lastSuccessAt)
+        assertEquals(LocalDate.of(2027, 12, 31), result?.rangeEnd)
+        assertNull(result?.lastError)
+    }
+
+    @Test
+    fun `missing sync state returns null`() {
+        whenever(jdbcTemplate.query(any<String>(), any<RowMapper<HolidaySyncState>>(), eq("KASI"))).thenReturn(emptyList())
+
+        assertNull(repository.findBySource("KASI"))
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/holiday/PublicHolidayControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/PublicHolidayControllerTest.kt
@@ -114,6 +114,22 @@ class PublicHolidayControllerTest {
     }
 
     @Test
+    @DisplayName("공휴일 항목 추가 - 잘못된 달력 유형")
+    @WithCustomMockUser(username = "test_user")
+    fun testCreatePublicHolidayInvalidCalendarType() {
+        val request = PublicHolidayRequest(date = "2025-03-01", name = "삼일절", calendarType = "gregorian")
+        doThrow(IllegalArgumentException()).whenever(service).createPublicHoliday(request)
+
+        mockMvc
+            .perform(
+                post("/api/v1/holiday")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").value("INVALID_HOLIDAY_TYPE"))
+    }
+
+    @Test
     @DisplayName("공휴일 항목 추가 - 중복된 날짜")
     @WithCustomMockUser(username = "test_user")
     fun testCreatePublicHolidayDuplicateDate() {
@@ -241,6 +257,22 @@ class PublicHolidayControllerTest {
             ).andExpect(status().isBadRequest)
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.message").value("LOCAL_DATE_NOT_VALID"))
+    }
+
+    @Test
+    @DisplayName("공휴일 항목 수정 - 잘못된 달력 유형")
+    @WithCustomMockUser(username = "test_user")
+    fun testUpdatePublicHolidayInvalidCalendarType() {
+        val request = PublicHolidayRequest(date = "2025-03-01", name = "삼일절", calendarType = "gregorian")
+        doThrow(IllegalArgumentException()).whenever(service).updatePublicHoliday(1, request)
+
+        mockMvc
+            .perform(
+                put("/api/v1/holiday/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").value("INVALID_HOLIDAY_TYPE"))
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/holiday/PublicHolidayServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/PublicHolidayServiceTest.kt
@@ -213,4 +213,25 @@ class PublicHolidayServiceTest {
         val result = service.findPublicHoliday(solarDate)
         assertEquals(null, result)
     }
+
+    @Test
+    @DisplayName("공휴일 생성 - 잘못된 달력 유형")
+    fun testCreatePublicHolidayInvalidCalendarType() {
+        assertThrows<IllegalArgumentException> {
+            service.createPublicHoliday(
+                PublicHolidayRequest(date = "2026-01-01", name = "테스트", calendarType = "gregorian"),
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("공휴일 수정 - 잘못된 달력 유형")
+    fun testUpdatePublicHolidayInvalidCalendarType() {
+        assertThrows<IllegalArgumentException> {
+            service.updatePublicHoliday(
+                1,
+                PublicHolidayRequest(date = "2026-01-01", name = "테스트", calendarType = "gregorian"),
+            )
+        }
+    }
 }

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleDataFetcherTest.kt
@@ -1,9 +1,11 @@
 package app.hyuabot.backend.shuttle
 
 import app.hyuabot.backend.codegen.types.ShuttleLimitInput
+import app.hyuabot.backend.database.entity.PublicHoliday
 import app.hyuabot.backend.database.entity.ShuttleHoliday
 import app.hyuabot.backend.database.entity.ShuttlePeriod
 import app.hyuabot.backend.database.entity.ShuttleStop
+import app.hyuabot.backend.holiday.service.PublicHolidayService
 import app.hyuabot.backend.shuttle.controller.ShuttleDataFetcher
 import app.hyuabot.backend.shuttle.controller.ShuttleTimetableDataLoader
 import app.hyuabot.backend.shuttle.domain.ShuttleArrivalItem
@@ -24,6 +26,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
@@ -41,6 +45,8 @@ class ShuttleDataFetcherTest {
     @Autowired lateinit var dgsQueryExecutor: DgsQueryExecutor
 
     @MockitoBean lateinit var holidayService: ShuttleHolidayService
+
+    @MockitoBean lateinit var publicHolidayService: PublicHolidayService
 
     @MockitoBean lateinit var periodService: ShuttlePeriodService
 
@@ -642,5 +648,37 @@ class ShuttleDataFetcherTest {
         assertEquals(1, result!!.size)
         val timetable = result[0]["timetable"] as Map<*, *>
         assertEquals(0, (timetable["order"] as List<*>).size)
+    }
+
+    @Test
+    @DisplayName("셔틀버스 시간표 조회 - 공식 공휴일 주말 시간표 폴백")
+    fun testShuttleTimetableUsesWeekendScheduleOnPublicHoliday() {
+        whenever(periodService.findShuttlePeriod(today)).thenReturn(createPeriod())
+        whenever(holidayService.findShuttleHoliday(today)).thenReturn(null)
+        whenever(publicHolidayService.findPublicHoliday(today)).thenReturn(
+            PublicHoliday(date = today, name = "삼일절 대체공휴일", calendarType = "solar"),
+        )
+        whenever(stopService.getAllStops()).thenReturn(listOf(createStop()))
+        whenever(timetableService.getShuttleTimetableBatch(any())).thenAnswer { invocation ->
+            invocation.getArgument<Set<ShuttleTimetableKey>>(0).associateWith { createTimetableResult(emptyList()) }
+        }
+
+        dgsQueryExecutor.execute(
+            """
+            {
+                shuttle(input: { date: "${dateFormatter.format(today)}" }) {
+                    stops {
+                        name
+                        timetable { order { seq } }
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val keys = argumentCaptor<Set<ShuttleTimetableKey>>()
+        verify(timetableService).getShuttleTimetableBatch(keys.capture())
+        assertEquals(setOf(false), keys.firstValue.single().weekdays)
+        assertEquals(setOf("semester"), keys.firstValue.single().periods)
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleHolidayControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleHolidayControllerTest.kt
@@ -146,6 +146,22 @@ class ShuttleHolidayControllerTest {
     }
 
     @Test
+    @DisplayName("셔틀 공휴일 추가 - 잘못된 운행 유형")
+    @WithCustomMockUser(username = "test_user")
+    fun testAddShuttleHolidayInvalidType() {
+        val request = ShuttleHolidayRequest(date = "2020-12-25", calendarType = "solar", type = "unknown")
+        doThrow(IllegalArgumentException()).whenever(service).createShuttleHoliday(request)
+
+        mockMvc
+            .perform(
+                post("/api/v1/shuttle/holiday")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").value("INVALID_HOLIDAY_TYPE"))
+    }
+
+    @Test
     @DisplayName("셔틀 공휴일 추가 - 중복된 날짜")
     @WithCustomMockUser(username = "test_user")
     fun testAddShuttleHolidayDuplicateDate() {
@@ -347,6 +363,22 @@ class ShuttleHolidayControllerTest {
             ).andExpect(status().isBadRequest)
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.message").value("LOCAL_DATE_NOT_VALID"))
+    }
+
+    @Test
+    @DisplayName("셔틀 공휴일 수정 - 잘못된 운행 유형")
+    @WithCustomMockUser(username = "test_user")
+    fun testUpdateShuttleHolidayInvalidType() {
+        val request = ShuttleHolidayRequest(date = "2020-12-31", calendarType = "solar", type = "unknown")
+        doThrow(IllegalArgumentException()).whenever(service).updateShuttleHoliday(1, request)
+
+        mockMvc
+            .perform(
+                put("/api/v1/shuttle/holiday/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").value("INVALID_HOLIDAY_TYPE"))
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleHolidayServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleHolidayServiceTest.kt
@@ -69,14 +69,14 @@ class ShuttleHolidayServiceTest {
                 seq = 3,
                 date = LocalDate.of(2024, 3, 1),
                 calendarType = "solar",
-                type = "Independence Movement Day",
+                type = "weekends",
             )
         whenever(
             repository.save(
                 argThat<ShuttleHoliday> {
                     date == LocalDate.of(2024, 3, 1) &&
                         calendarType == "solar" &&
-                        type == "Independence Movement Day"
+                        type == "weekends"
                 },
             ),
         ).thenReturn(newHoliday)
@@ -85,13 +85,13 @@ class ShuttleHolidayServiceTest {
                 ShuttleHolidayRequest(
                     date = "2024-03-01",
                     calendarType = "solar",
-                    type = "Independence Movement Day",
+                    type = "weekends",
                 ),
             )
         assertEquals(3, createdHoliday.seq)
         assertEquals("2024-03-01", createdHoliday.date.toString())
         assertEquals("solar", createdHoliday.calendarType)
-        assertEquals("Independence Movement Day", createdHoliday.type)
+        assertEquals("weekends", createdHoliday.type)
     }
 
     @Test
@@ -102,7 +102,7 @@ class ShuttleHolidayServiceTest {
                 ShuttleHolidayRequest(
                     date = "2024-31-12",
                     calendarType = "solar",
-                    type = "Invalid Date Test",
+                    type = "weekends",
                 ),
             )
         }
@@ -129,7 +129,7 @@ class ShuttleHolidayServiceTest {
                 ShuttleHolidayRequest(
                     date = "2024-01-01",
                     calendarType = "solar",
-                    type = "Duplicate Date Test",
+                    type = "weekends",
                 ),
             )
         }
@@ -177,7 +177,7 @@ class ShuttleHolidayServiceTest {
                 seq = 1,
                 date = LocalDate.of(2024, 1, 2),
                 calendarType = "solar",
-                type = "New Year's Holiday",
+                type = "halt",
             )
         whenever(repository.findById(1)).thenReturn(Optional.of(existingHoliday))
         whenever(
@@ -194,13 +194,13 @@ class ShuttleHolidayServiceTest {
                 ShuttleHolidayRequest(
                     date = "2024-01-02",
                     calendarType = "solar",
-                    type = "New Year's Holiday",
+                    type = "halt",
                 ),
             )
         assertEquals(1, result.seq)
         assertEquals("2024-01-02", result.date.toString())
         assertEquals("solar", result.calendarType)
-        assertEquals("New Year's Holiday", result.type)
+        assertEquals("halt", result.type)
     }
 
     @Test
@@ -212,7 +212,7 @@ class ShuttleHolidayServiceTest {
                 ShuttleHolidayRequest(
                     date = "2024-31-12",
                     calendarType = "solar",
-                    type = "Invalid Date Test",
+                    type = "weekends",
                 ),
             )
         }
@@ -228,7 +228,7 @@ class ShuttleHolidayServiceTest {
                 ShuttleHolidayRequest(
                     date = "2024-01-01",
                     calendarType = "solar",
-                    type = "Non-existent ID Test",
+                    type = "weekends",
                 ),
             )
         }
@@ -265,7 +265,7 @@ class ShuttleHolidayServiceTest {
                 ShuttleHolidayRequest(
                     date = "2024-02-09",
                     calendarType = "lunar",
-                    type = "Duplicate Date Test",
+                    type = "halt",
                 ),
             )
         }
@@ -364,6 +364,27 @@ class ShuttleHolidayServiceTest {
             service.findShuttleHolidayOccurrences(
                 LocalDate.of(2026, 3, 3),
                 LocalDate.of(2026, 3, 1),
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("셔틀 공휴일 생성 - 잘못된 운행 유형")
+    fun testCreateShuttleHolidayInvalidType() {
+        assertThrows<IllegalArgumentException> {
+            service.createShuttleHoliday(
+                ShuttleHolidayRequest(date = "2026-01-01", calendarType = "solar", type = "unknown"),
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("셔틀 공휴일 수정 - 잘못된 달력 유형")
+    fun testUpdateShuttleHolidayInvalidCalendarType() {
+        assertThrows<IllegalArgumentException> {
+            service.updateShuttleHoliday(
+                1,
+                ShuttleHolidayRequest(date = "2026-01-01", calendarType = "gregorian", type = "weekends"),
             )
         }
     }


### PR DESCRIPTION
## Summary
- apply official public holidays to shuttle weekend timetables when no explicit shuttle decision exists
- validate shuttle holiday decisions and expose a permission-aware 90-day holiday audit API
- publish dashboard status and Prometheus metrics for missing or stale holiday operations

## Impact
- bus and subway holiday coverage gaps become visible to administrators
- shuttle administrators can explicitly choose weekend operation or service suspension
- deploy after the infrastructure database migration is applied

## Validation
- ktlint
- Kotlin compilation
- focused unit and GraphQL tests (58 tests)
- full Spring integration tests delegated to CI database services