### PR TITLE
fix: Expose due holiday configuration metrics

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayAuditMetrics.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayAuditMetrics.kt
@@ -23,6 +23,15 @@ class HolidayAuditMetrics(
                 }.tag("severity", severity.lowercase())
                 .register(meterRegistry)
         }
+        listOf("today" to 0L, "tomorrow" to 1L).forEach { (window, daysFromToday) ->
+            Gauge
+                .builder("hyuabot.holiday.configuration.due.issues") {
+                    val audit = snapshot()
+                    val targetDate = audit.checkedAt.toLocalDate().plusDays(daysFromToday)
+                    audit.issues.count { it.date == targetDate }.toDouble()
+                }.tag("window", window)
+                .register(meterRegistry)
+        }
         Gauge
             .builder("hyuabot.holiday.sync.age.seconds") {
                 snapshot().lastSuccessAt?.let { Duration.between(it, snapshot().checkedAt).seconds.toDouble() } ?: -1.0

--- a/src/test/kotlin/app/hyuabot/backend/holiday/HolidayAuditMetricsTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/HolidayAuditMetricsTest.kt
@@ -28,9 +28,9 @@ class HolidayAuditMetricsTest {
                 checkedAt,
                 checkedAt.minusHours(2),
                 listOf(
-                    issue("WARNING"),
-                    issue("ERROR"),
-                    issue("ERROR"),
+                    issue("WARNING", checkedAt.toLocalDate().plusDays(2)),
+                    issue("ERROR", checkedAt.toLocalDate()),
+                    issue("ERROR", checkedAt.toLocalDate().plusDays(1)),
                 ),
             ),
         )
@@ -54,6 +54,22 @@ class HolidayAuditMetricsTest {
                 .gauge()
                 .value(),
         )
+        assertEquals(
+            1.0,
+            registry
+                .get("hyuabot.holiday.configuration.due.issues")
+                .tag("window", "today")
+                .gauge()
+                .value(),
+        )
+        assertEquals(
+            1.0,
+            registry
+                .get("hyuabot.holiday.configuration.due.issues")
+                .tag("window", "tomorrow")
+                .gauge()
+                .value(),
+        )
         assertEquals(7200.0, registry.get("hyuabot.holiday.sync.age.seconds").gauge().value())
         metrics.snapshot(firstRead.plusSeconds(4 * 60))
         metrics.snapshot(firstRead.plusSeconds(6 * 60))
@@ -74,13 +90,15 @@ class HolidayAuditMetricsTest {
         assertEquals(-1.0, registry.get("hyuabot.holiday.sync.age.seconds").gauge().value())
     }
 
-    private fun issue(severity: String) =
-        HolidayAuditIssue(
-            code = "TEST",
-            service = "holiday",
-            date = LocalDate.of(2026, 7, 17),
-            message = "test",
-            severity = severity,
-            managementPath = "/holiday",
-        )
+    private fun issue(
+        severity: String,
+        date: LocalDate,
+    ) = HolidayAuditIssue(
+        code = "TEST",
+        service = "holiday",
+        date = date,
+        message = "test",
+        severity = severity,
+        managementPath = "/holiday",
+    )
 }


### PR DESCRIPTION
## Summary
- expose separate unresolved holiday configuration gauges for today and tomorrow
- keep the existing 90-day audit and D-3 severity indicators for the administrator dashboard
- cover both due windows in the Micrometer metrics tests

## Impact
- monitoring can notify operators close to the affected service date without sending long-lived advance alerts
- unresolved future shuttle decisions remain visible in the administrator dashboard

## Validation
- `./gradlew ktlintCheck test --tests 'app.hyuabot.backend.holiday.HolidayAuditMetricsTest' --tests 'app.hyuabot.backend.holiday.HolidayAuditServiceTest'`
