### PR TITLE
fix: Preserve concurrent administrator sessions

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/admin/AdminUserService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/admin/AdminUserService.kt
@@ -129,7 +129,7 @@ class AdminUserService(
 
         val now = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
         invitationRepository.findAllActiveRelatedForUpdate(userID).forEach { it.revokedAt = now }
-        refreshTokenRepository.findByUserID(userID)?.let(refreshTokenRepository::delete)
+        refreshTokenRepository.deleteAllByUserID(userID)
         user.active = false
         user.password = null
         user.authVersion += 1

--- a/src/main/kotlin/app/hyuabot/backend/auth/AuthService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/auth/AuthService.kt
@@ -41,7 +41,7 @@ class AuthService(
     fun refreshToken(refreshToken: String): String {
         val authentication = tokenProvider.getAuthentication(refreshToken)
         val userID = (authentication.principal as JWTUser).username
-        if (refreshTokenRepository.findByUserID(userID)?.refreshToken != refreshToken) {
+        if (refreshTokenRepository.findByUserIDAndRefreshToken(userID, refreshToken) == null) {
             throw BadCredentialsException("INVALID_REFRESH_TOKEN")
         }
         return tokenProvider.createAccessToken(authentication)
@@ -94,7 +94,7 @@ class AuthService(
                 .toByteArray()
         user.authVersion += 1
         userRepository.save(user)
-        refreshTokenRepository.findByUserID(userID)?.let(refreshTokenRepository::delete)
+        refreshTokenRepository.deleteAllByUserID(userID)
     }
 
     fun logout(
@@ -102,14 +102,16 @@ class AuthService(
         request: HttpServletRequest,
     ) {
         // Access token 무효화
-        tokenProvider.invalidateAccessToken(
-            user = userInfo,
-            accessToken =
-                request.cookies.firstOrNull { it.name == "access_token" }?.value
-                    ?: throw IllegalArgumentException("NO_ACCESS_TOKEN"),
-        )
-        refreshTokenRepository.findByUserID(userInfo.userID)?.let { refreshToken ->
-            refreshTokenRepository.delete(refreshToken)
+        val accessToken =
+            request.cookies.firstOrNull { it.name == "access_token" }?.value
+                ?: throw IllegalArgumentException("NO_ACCESS_TOKEN")
+        tokenProvider.invalidateAccessToken(accessToken)
+
+        val refreshToken =
+            request.cookies.firstOrNull { it.name == "refresh_token" }?.value
+                ?: throw IllegalArgumentException("NO_REFRESH_TOKEN")
+        refreshTokenRepository.findByUserIDAndRefreshToken(userInfo.userID, refreshToken)?.let { session ->
+            refreshTokenRepository.delete(session)
         } ?: throw IllegalArgumentException("NO_REFRESH_TOKEN")
     }
 }

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/RefreshTokenRepository.kt
@@ -5,5 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
 interface RefreshTokenRepository : JpaRepository<RefreshToken, UUID> {
-    fun findByUserID(userID: String): RefreshToken?
+    fun findByUserIDAndRefreshToken(
+        userID: String,
+        refreshToken: String,
+    ): RefreshToken?
+
+    fun deleteAllByUserID(userID: String)
 }

--- a/src/main/kotlin/app/hyuabot/backend/security/JWTTokenProvider.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/JWTTokenProvider.kt
@@ -1,7 +1,6 @@
 package app.hyuabot.backend.security
 
 import app.hyuabot.backend.database.entity.RefreshToken
-import app.hyuabot.backend.database.entity.User
 import app.hyuabot.backend.database.repository.RefreshTokenRepository
 import app.hyuabot.backend.utility.LocalDateTimeBuilder
 import io.jsonwebtoken.Claims
@@ -32,20 +31,12 @@ class JWTTokenProvider(
     private val key by lazy { Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret)) }
 
     // 기존 Access token 무효화
-    fun invalidateAccessToken(
-        user: User,
-        accessToken: String,
-    ) {
-        refreshTokenRepository.findByUserID(user.userID)?.let {
-            redisTemplate.opsForValue().set(
-                "access_token:$accessToken",
-                "logout",
-                Duration.between(
-                    ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone),
-                    it.expiredAt,
-                ),
-            )
-        }
+    fun invalidateAccessToken(accessToken: String) {
+        redisTemplate.opsForValue().set(
+            "access_token:$accessToken",
+            "logout",
+            Duration.ofMinutes(expirationMinutes),
+        )
     }
 
     // Access token 생성
@@ -72,36 +63,29 @@ class JWTTokenProvider(
     // Refresh token 생성
     fun createRefreshToken(authentication: Authentication): String {
         val userID = (authentication.principal as JWTUser).username
+        val sessionID = UUID.randomUUID()
+        val now = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
         val refreshToken =
             Jwts
                 .builder()
+                .id(sessionID.toString())
                 .issuedAt(Date())
                 .expiration(Date(System.currentTimeMillis() + refreshExpirationDays * 1000 * 60 * 60 * 24)) // 만료 시간 설정
                 .subject(userID)
                 .claim(AUTH_VERSION_CLAIM, (authentication.principal as JWTUser).authVersion)
                 .signWith(key)
                 .compact()
-        val previousRefreshToken = refreshTokenRepository.findByUserID(userID)
-        if (previousRefreshToken != null) {
-            previousRefreshToken.apply {
-                this.refreshToken = refreshToken
-                this.expiredAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone).plusDays(refreshExpirationDays)
-                this.updatedAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
-            }
-            refreshTokenRepository.save(previousRefreshToken)
-        } else {
-            refreshTokenRepository.save(
-                RefreshToken(
-                    uuid = UUID.randomUUID(),
-                    userID = userID,
-                    refreshToken = refreshToken,
-                    expiredAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone).plusDays(refreshExpirationDays),
-                    createdAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone),
-                    updatedAt = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone),
-                    user = null,
-                ),
-            )
-        }
+        refreshTokenRepository.save(
+            RefreshToken(
+                uuid = sessionID,
+                userID = userID,
+                refreshToken = refreshToken,
+                expiredAt = now.plusDays(refreshExpirationDays),
+                createdAt = now,
+                updatedAt = now,
+                user = null,
+            ),
+        )
         return refreshToken
     }
 

--- a/src/test/kotlin/app/hyuabot/backend/admin/AdminUserServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/admin/AdminUserServiceTest.kt
@@ -14,7 +14,6 @@ import app.hyuabot.backend.auth.exception.DuplicateEmailException
 import app.hyuabot.backend.auth.exception.DuplicateUserIDException
 import app.hyuabot.backend.auth.exception.InvalidUserInputException
 import app.hyuabot.backend.database.entity.AdminUserInvitation
-import app.hyuabot.backend.database.entity.RefreshToken
 import app.hyuabot.backend.database.entity.User
 import app.hyuabot.backend.database.repository.AdminUserInvitationRepository
 import app.hyuabot.backend.database.repository.RefreshTokenRepository
@@ -277,10 +276,8 @@ class AdminUserServiceTest {
                 ZonedDateTime.now().plusHours(1),
                 createdAt = ZonedDateTime.now(),
             )
-        val refreshToken = org.mockito.kotlin.mock<RefreshToken>()
         whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(target, admin))
         whenever(invitationRepository.findAllActiveRelatedForUpdate("user")).thenReturn(listOf(invitation))
-        whenever(refreshTokenRepository.findByUserID("user")).thenReturn(refreshToken)
 
         service.deleteUser("user", "admin")
 
@@ -292,7 +289,7 @@ class AdminUserServiceTest {
         assertEquals("", target.phone)
         assertTrue(target.permissions.isEmpty())
         assertEquals(target.deletedAt, invitation.revokedAt)
-        verify(refreshTokenRepository).delete(refreshToken)
+        verify(refreshTokenRepository).deleteAllByUserID("user")
         verify(userRepository).save(target)
     }
 
@@ -301,11 +298,11 @@ class AdminUserServiceTest {
         val target = user(active = false)
         whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(target))
         whenever(invitationRepository.findAllActiveRelatedForUpdate("user")).thenReturn(emptyList())
-        whenever(refreshTokenRepository.findByUserID("user")).thenReturn(null)
 
         service.deleteUser("user", "admin")
 
         assertEquals(AdminUserStatus.DELETED, AdminUserResponse.from(target).status)
+        verify(refreshTokenRepository).deleteAllByUserID("user")
         verifyNoInteractions(invitationService)
     }
 

--- a/src/test/kotlin/app/hyuabot/backend/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/auth/AuthServiceTest.kt
@@ -4,7 +4,6 @@ import app.hyuabot.backend.auth.domain.ChangePasswordRequest
 import app.hyuabot.backend.auth.domain.UpdateProfileRequest
 import app.hyuabot.backend.auth.exception.DuplicateEmailException
 import app.hyuabot.backend.auth.exception.InvalidUserInputException
-import app.hyuabot.backend.database.entity.RefreshToken
 import app.hyuabot.backend.database.entity.User
 import app.hyuabot.backend.database.repository.RefreshTokenRepository
 import app.hyuabot.backend.database.repository.UserRepository
@@ -19,7 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -91,8 +89,8 @@ class AuthServiceTest {
         val savedRefreshToken = mock<app.hyuabot.backend.database.entity.RefreshToken>()
         whenever(authentication.principal).thenReturn(JWTUser("testUser", ""))
         whenever(tokenProvider.getAuthentication("refreshToken")).thenReturn(authentication)
-        whenever(savedRefreshToken.refreshToken).thenReturn("refreshToken")
-        whenever(refreshTokenRepository.findByUserID("testUser")).thenReturn(savedRefreshToken)
+        whenever(refreshTokenRepository.findByUserIDAndRefreshToken("testUser", "refreshToken"))
+            .thenReturn(savedRefreshToken)
         whenever(tokenProvider.createAccessToken(authentication)).thenReturn("newAccessToken")
         assertEquals("newAccessToken", authService.refreshToken("refreshToken"))
     }
@@ -102,7 +100,7 @@ class AuthServiceTest {
         val authentication = mock<Authentication>()
         whenever(authentication.principal).thenReturn(JWTUser("testUser", ""))
         whenever(tokenProvider.getAuthentication("refreshToken")).thenReturn(authentication)
-        whenever(refreshTokenRepository.findByUserID("testUser")).thenReturn(null)
+        whenever(refreshTokenRepository.findByUserIDAndRefreshToken("testUser", "refreshToken")).thenReturn(null)
 
         assertThrows<BadCredentialsException> { authService.refreshToken("refreshToken") }
     }
@@ -168,20 +166,18 @@ class AuthServiceTest {
     }
 
     @Test
-    fun changePasswordRevokesRefreshTokenAndIncrementsAuthVersion() {
+    fun changePasswordRevokesAllRefreshTokensAndIncrementsAuthVersion() {
         val user = user()
-        val refreshToken = mock<RefreshToken>()
         whenever(userRepository.findByUserIDAndActiveIsTrue("testUser")).thenReturn(user)
         whenever(passwordEncoder.matches("current", "encoded-password")).thenReturn(true)
         whenever(passwordEncoder.encode("Password1!")).thenReturn("new-encoded")
-        whenever(refreshTokenRepository.findByUserID("testUser")).thenReturn(refreshToken)
 
         authService.changePassword("testUser", ChangePasswordRequest("current", "Password1!"))
 
         assertEquals("new-encoded", user.password?.decodeToString())
         assertEquals(1, user.authVersion)
         verify(userRepository).save(user)
-        verify(refreshTokenRepository).delete(refreshToken)
+        verify(refreshTokenRepository).deleteAllByUserID("testUser")
     }
 
     @Test
@@ -190,12 +186,11 @@ class AuthServiceTest {
         whenever(userRepository.findByUserIDAndActiveIsTrue("testUser")).thenReturn(user)
         whenever(passwordEncoder.matches("current", "encoded-password")).thenReturn(true)
         whenever(passwordEncoder.encode("Password1!")).thenReturn("new-encoded")
-        whenever(refreshTokenRepository.findByUserID("testUser")).thenReturn(null)
-
         authService.changePassword("testUser", ChangePasswordRequest("current", "Password1!"))
 
         assertEquals("new-encoded", user.password?.decodeToString())
         assertEquals(1, user.authVersion)
+        verify(refreshTokenRepository).deleteAllByUserID("testUser")
     }
 
     @Test
@@ -238,12 +233,14 @@ class AuthServiceTest {
                 whenever(userID).thenReturn("testUser")
             }
         val accessToken = "accessToken"
-        val cookies = arrayOf(Cookie("access_token", accessToken))
+        val refreshToken = "refreshToken"
+        val cookies = arrayOf(Cookie("access_token", accessToken), Cookie("refresh_token", refreshToken))
+        val savedSession = mock<app.hyuabot.backend.database.entity.RefreshToken>()
         whenever(request.cookies).thenReturn(cookies)
-        whenever(refreshTokenRepository.findByUserID(user.userID)).thenReturn(mock())
+        whenever(refreshTokenRepository.findByUserIDAndRefreshToken(user.userID, refreshToken)).thenReturn(savedSession)
         authService.logout(user, request)
-        verify(tokenProvider).invalidateAccessToken(user, accessToken)
-        verify(refreshTokenRepository).delete(any())
+        verify(tokenProvider).invalidateAccessToken(accessToken)
+        verify(refreshTokenRepository).delete(savedSession)
     }
 
     @Test
@@ -268,14 +265,11 @@ class AuthServiceTest {
     @Test
     @DisplayName("로그아웃 테스트 (Refresh Token 없음)")
     fun logoutNoRefreshTokenTest() {
-        val user =
-            mock<User>().apply {
-                whenever(userID).thenReturn("testUser")
-            }
+        val user = mock<User>()
         val cookies = arrayOf(Cookie("access_token", "accessToken"))
         whenever(request.cookies).thenReturn(cookies)
-        whenever(refreshTokenRepository.findByUserID(user.userID)).thenReturn(null)
         val exception = assertThrows<IllegalArgumentException> { authService.logout(user, request) }
         assertEquals("NO_REFRESH_TOKEN", exception.message)
+        verify(tokenProvider).invalidateAccessToken("accessToken")
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/database/repository/UserRepositoryTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/database/repository/UserRepositoryTest.kt
@@ -122,9 +122,9 @@ class UserRepositoryTest {
     }
 
     @Test
-    @DisplayName("사용자별 인증 토큰 조회")
-    fun testFindTokenByUserID() {
-        val token = refreshTokenRepository.findByUserID("user123")
+    @DisplayName("사용자와 토큰 값으로 인증 세션 조회")
+    fun testFindTokenByUserIDAndRefreshToken() {
+        val token = refreshTokenRepository.findByUserIDAndRefreshToken("user123", "refreshToken")
         assert(token != null)
         assert(token?.uuid == uuid)
         assert(token?.userID == "user123")
@@ -133,23 +133,32 @@ class UserRepositoryTest {
         assert(token?.createdAt == currentTime)
         assert(token?.updatedAt == currentTime)
         assert(token?.user?.userID == "user123")
-        val nonExistentToken = refreshTokenRepository.findByUserID("nonexistent")
+        val nonExistentToken =
+            refreshTokenRepository.findByUserIDAndRefreshToken("user123", "nonexistentRefreshToken")
         assert(nonExistentToken == null)
     }
 
     @Test
-    @DisplayName("사용자별 인증 토큰 갱신")
-    fun testUpdateTokenByUserID() {
-        val token = refreshTokenRepository.findByUserID("user123")
-        assert(token != null)
-        token?.let {
-            it.refreshToken = "newRefreshToken"
-            it.expiredAt = currentTime.plusDays(60)
-            it.updatedAt = currentTime
-            refreshTokenRepository.save(it)
-        }
-        val updatedToken = refreshTokenRepository.findByUserID("user123")
-        assert(updatedToken?.refreshToken == "newRefreshToken")
-        assert(updatedToken?.expiredAt == currentTime.plusDays(60))
+    @DisplayName("한 사용자의 여러 인증 세션 저장 및 전체 삭제")
+    fun testMultipleSessionsAndDeleteAllByUserID() {
+        refreshTokenRepository.save(
+            RefreshToken(
+                uuid = UUID.randomUUID(),
+                userID = "user123",
+                refreshToken = "secondRefreshToken",
+                expiredAt = currentTime.plusDays(30),
+                createdAt = currentTime,
+                updatedAt = currentTime,
+                user = userRepository.findByUserID("user123"),
+            ),
+        )
+
+        assert(refreshTokenRepository.findByUserIDAndRefreshToken("user123", "refreshToken") != null)
+        assert(refreshTokenRepository.findByUserIDAndRefreshToken("user123", "secondRefreshToken") != null)
+
+        refreshTokenRepository.deleteAllByUserID("user123")
+
+        assert(refreshTokenRepository.findByUserIDAndRefreshToken("user123", "refreshToken") == null)
+        assert(refreshTokenRepository.findByUserIDAndRefreshToken("user123", "secondRefreshToken") == null)
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/security/JWTTokenProviderTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/security/JWTTokenProviderTest.kt
@@ -1,7 +1,5 @@
 package app.hyuabot.backend.security
 
-import app.hyuabot.backend.database.entity.RefreshToken
-import app.hyuabot.backend.database.entity.User
 import app.hyuabot.backend.database.repository.RefreshTokenRepository
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
@@ -14,16 +12,15 @@ import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
-import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.ValueOperations
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.core.Authentication
 import java.time.Duration
-import java.time.ZonedDateTime
 import java.util.Base64
-import java.util.UUID
 import org.springframework.security.core.userdetails.User as SpringUser
 
 class JWTTokenProviderTest {
@@ -90,35 +87,31 @@ class JWTTokenProviderTest {
 
     @Test
     fun testCreateRefreshToken() {
-        // Check if the refresh token is not stored in the repository
-        given(refreshTokenRepository.findByUserID("testUser")).willReturn(null)
         val token = jwtTokenProvider.createRefreshToken(authentication)
+        val savedSession = argumentCaptor<app.hyuabot.backend.database.entity.RefreshToken>()
+
         assert(token.isNotBlank())
-        then(refreshTokenRepository).should().findByUserID("testUser")
+        then(refreshTokenRepository).should().save(savedSession.capture())
+        assert(savedSession.firstValue.userID == "testUser")
+        assert(savedSession.firstValue.refreshToken == token)
+        assert(savedSession.firstValue.uuid.toString() == parseClaims(token).id)
     }
 
     @Test
-    fun testExtendRefreshToken() {
-        // Mock existing refresh token
-        val now = ZonedDateTime.now()
-        val existingToken =
-            RefreshToken(
-                uuid = UUID.randomUUID(),
-                userID = "testUser",
-                refreshToken = "previousRefreshToken",
-                expiredAt = now.plusDays(1),
-                createdAt = now.minusDays(10),
-                updatedAt = now.minusDays(1),
-                user = null,
-            )
-        given(refreshTokenRepository.findByUserID("testUser")).willReturn(existingToken)
-        // Extend the refresh token
-        val newToken = jwtTokenProvider.createRefreshToken(authentication)
-        assert(newToken.isNotBlank())
-        assert(existingToken.refreshToken == newToken)
-        assert(existingToken.expiredAt.isAfter(now))
-        assert(existingToken.updatedAt.isAfter(now.minusDays(1)))
-        then(refreshTokenRepository).should().save(existingToken)
+    fun testCreateRefreshTokenCreatesIndependentSessions() {
+        val firstToken = jwtTokenProvider.createRefreshToken(authentication)
+        val secondToken = jwtTokenProvider.createRefreshToken(authentication)
+        val savedSessions = argumentCaptor<app.hyuabot.backend.database.entity.RefreshToken>()
+
+        then(refreshTokenRepository).should(times(2)).save(savedSessions.capture())
+        assert(firstToken != secondToken)
+        assert(
+            savedSessions.allValues
+                .map { it.uuid }
+                .distinct()
+                .size == 2,
+        )
+        assert(savedSessions.allValues.map { it.refreshToken } == listOf(firstToken, secondToken))
     }
 
     @Test
@@ -164,56 +157,15 @@ class JWTTokenProviderTest {
 
     @Test
     fun testInvalidateAccessToken() {
-        // Mock existing refresh token
-        val now = ZonedDateTime.now()
-        val existingToken =
-            RefreshToken(
-                uuid = UUID.randomUUID(),
-                userID = "testUser",
-                refreshToken = "previousRefreshToken",
-                expiredAt = now.plusDays(1),
-                createdAt = now.minusDays(10),
-                updatedAt = now.minusDays(1),
-                user = null,
-            )
-        given(refreshTokenRepository.findByUserID("testUser")).willReturn(existingToken)
-        // Invalidate the access token
-        val user =
-            User(
-                userID = "testUser",
-                password = ByteArray(0),
-                name = "Test User",
-                email = "",
-                phone = "",
-                active = true,
-            )
         val accessToken = jwtTokenProvider.createAccessToken("testUser")
-        jwtTokenProvider.invalidateAccessToken(user, accessToken)
+        jwtTokenProvider.invalidateAccessToken(accessToken)
+
         then(valueOperations).should().set(
             startsWith("access_token:"),
             eq("logout"),
-            any<Duration>(),
+            eq(Duration.ofMinutes(expirationMinutes)),
         )
-    }
-
-    @Test
-    fun testInvalidAccessTokenWithoutRefreshToken() {
-        // Mock no existing refresh token
-        given(refreshTokenRepository.findByUserID("testUser")).willReturn(null)
-        // Attempt to invalidate access token without a refresh token
-        val user =
-            User(
-                userID = "testUser",
-                password = ByteArray(0),
-                name = "Test User",
-                email = "",
-                phone = "",
-                active = true,
-            )
-        val accessToken = jwtTokenProvider.createAccessToken("testUser")
-        jwtTokenProvider.invalidateAccessToken(user, accessToken)
-        // Verify that no interaction with redisTemplate occurred
-        then(valueOperations).shouldHaveNoInteractions()
+        then(refreshTokenRepository).shouldHaveNoInteractions()
     }
 
     fun parseClaims(token: String): Claims {


### PR DESCRIPTION
## Summary
- Store a separate refresh-token session for every administrator login instead of replacing the account's existing session.
- Validate and revoke the exact refresh-token session supplied by the current browser.
- Revoke all sessions after a password change or administrator deletion.
- Give each refresh token a unique session identifier and limit access-token blacklist entries to the access-token lifetime.
- Cover independent sessions, session-specific logout, and account-wide revocation.

## Root Cause
The backend looked up refresh tokens only by administrator ID and replaced the existing row during every login. A login from another browser therefore invalidated the previous browser's refresh token, forcing it back to the login screen when its five-minute access token expired.

## Impact
The same administrator account can remain signed in across multiple browsers or devices. Logging out one browser no longer signs out the others, while password changes and account deletion still revoke every active session.

No database schema, frontend, infrastructure, or secret change is required because `auth_refresh_token` already permits multiple rows per user.

## Validation
- `./gradlew ktlintCheck test --tests 'app.hyuabot.backend.security.JWTTokenProviderTest' --tests 'app.hyuabot.backend.auth.AuthServiceTest' --tests 'app.hyuabot.backend.admin.AdminUserServiceTest'`
- Changed executable source files have 100% line coverage in the focused JaCoCo report.
- The database-backed repository test for multiple sessions and account-wide deletion is included for the CI database environment.
