### PR TITLE
chore: Speed up CI workflows

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: 'zulu'
@@ -30,9 +30,9 @@ jobs:
     runs-on: ["self-hosted", "X64"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: 'zulu'
@@ -78,7 +78,7 @@ jobs:
           ./gradlew jacocoTestCoverageVerification
       - name: Upload coverage report as comment
         if: github.event_name == 'pull_request'
-        uses: madrapps/jacoco-report@v1.7.2
+        uses: madrapps/jacoco-report@v1.8.0
         with:
           title: Test Coverage Report
           paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
@@ -88,7 +88,7 @@ jobs:
           update-comment: 'true'
       - name: Upload JaCoCo report artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jacoco-coverage-report
           path: build/reports/jacoco/test

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -1,15 +1,16 @@
 name: Code Check and Test
 on:
-  push:
-    branches-ignore:
-      - main
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+concurrency:
+  group: code-check-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
 jobs:
   ktlint:
     name: Check Kotlin code style
-    runs-on: ["self-hosted", "X64"]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -19,6 +20,7 @@ jobs:
           java-version: 25
           distribution: 'zulu'
           check-latest: 'true'
+          cache: gradle
       - name: Run ktlint
         run: |
           ./gradlew ktlintCheck
@@ -35,6 +37,7 @@ jobs:
           java-version: 25
           distribution: 'zulu'
           check-latest: 'true'
+          cache: gradle
       - name: Create application-test.properties
         run: |
           echo "spring.datasource.driver-class-name=org.postgresql.Driver" > src/main/resources/application-test.properties
@@ -69,51 +72,12 @@ jobs:
       - name: Run unit tests
         run: |
           ./gradlew clean test jacocoTestReport
-  junit-coverage:
-    name: Check unit test coverage
-    timeout-minutes: 20
-    runs-on: ["self-hosted", "X64"]
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up JDK 25
-        uses: actions/setup-java@v4
-        with:
-          java-version: 25
-          distribution: 'zulu'
-          check-latest: 'true'
-      - name: Create application-test.properties
-        run: |
-          echo "spring.datasource.driver-class-name=org.postgresql.Driver" > src/main/resources/application-test.properties
-          echo "spring.datasource.url=$DATABASE_URL" >> src/main/resources/application-test.properties
-          echo "spring.datasource.username=$DATABASE_USERNAME" >> src/main/resources/application-test.properties
-          echo "spring.datasource.password=$DATABASE_PASSWORD" >> src/main/resources/application-test.properties
-          echo "spring.data.redis.host=localhost" >> src/main/resources/application-test.properties
-          echo "spring.data.redis.port=6379" >> src/main/resources/application-test.properties
-          echo "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect" >> src/main/resources/application-test.properties
-          echo "spring.sql.init.mode=always" >> src/main/resources/application-test.properties
-          echo "jwt.secret=secret" >> src/main/resources/application-test.properties
-          echo "jwt.expiration=3600" >> src/main/resources/application-test.properties
-          echo "jwt.expiration.refresh=604800" >> src/main/resources/application-test.properties
-          echo "jasypt.encryptor.password=secret" >> src/main/resources/application-test.properties
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
-          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
-      - name: Create encrypted application.properties
-        run: |
-          echo "spring.datasource.driver-class-name=org.postgresql.Driver" > src/main/resources/encrypted.properties
-          echo "spring.datasource.url=$DATABASE_URL" >> src/main/resources/encrypted.properties
-          echo "spring.datasource.username=$DATABASE_USERNAME" >> src/main/resources/encrypted.properties
-          echo "spring.datasource.password=$DATABASE_PASSWORD" >> src/main/resources/encrypted.properties
-          echo "spring.data.redis.host=localhost" >> src/main/resources/encrypted.properties
-          echo "spring.data.redis.port=6379" >> src/main/resources/encrypted.properties
-          echo "spring.sql.init.mode=always" >> src/main/resources/encrypted.properties
       - name: Check unit test coverage
+        if: github.event_name == 'pull_request'
         run: |
-          ./gradlew clean test jacocoTestReport jacocoTestCoverageVerification
+          ./gradlew jacocoTestCoverageVerification
       - name: Upload coverage report as comment
+        if: github.event_name == 'pull_request'
         uses: madrapps/jacoco-report@v1.7.2
         with:
           title: Test Coverage Report
@@ -123,7 +87,7 @@ jobs:
           min-coverage-changed-files: 100
           update-comment: 'true'
       - name: Upload JaCoCo report artifact
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-coverage-report


### PR DESCRIPTION
## Summary

- Run Kotlin style checks on a GitHub-hosted runner while keeping database-dependent tests on the internal runner.
- Reuse Gradle dependency caches across checks.
- Run tests and JaCoCo report generation once, then verify and publish coverage from the same job.
- Cancel stale checks for the same branch.
- Upgrade checkout, Java, JaCoCo, and artifact actions to Node.js 24-based releases.

## Validation

- Parsed all workflow files as YAML.
- Validated the modified workflow with actionlint.
- Ran `./gradlew ktlintCheck` successfully.
- Confirmed every referenced action uses the Node.js 24 runtime.
