### PR TITLE
fix: Inject backend secrets at runtime

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -56,19 +56,6 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
           DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
-      - name: Create encrypted application.properties
-        run: |
-          echo "spring.datasource.driver-class-name=org.postgresql.Driver" > src/main/resources/encrypted.properties
-          echo "spring.datasource.url=$DATABASE_URL" >> src/main/resources/encrypted.properties
-          echo "spring.datasource.username=$DATABASE_USERNAME" >> src/main/resources/encrypted.properties
-          echo "spring.datasource.password=$DATABASE_PASSWORD" >> src/main/resources/encrypted.properties
-          echo "spring.data.redis.host=localhost" >> src/main/resources/encrypted.properties
-          echo "spring.data.redis.port=6379" >> src/main/resources/encrypted.properties
-          echo "spring.sql.init.mode=always" >> src/main/resources/encrypted.properties
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
-          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
       - name: Run unit tests
         run: |
           ./gradlew clean test jacocoTestReport

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,14 +70,6 @@ jobs:
     environment: production
     outputs:
       jar_transferred: ${{ steps.transfer.outputs.transferred }}
-    env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
-      DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
-      REDIS_URL: ${{ secrets.REDIS_URL }}
-      REDIS_PORT: ${{ secrets.REDIS_PORT }}
-      JASYPT_PASSWORD: ${{ secrets.JASYPT_PASSWORD }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -87,23 +79,16 @@ jobs:
           java-version: 25
           distribution: 'zulu'
           check-latest: 'true'
-      - name: Create encrypted application.properties
-        run: |
-          echo "spring.datasource.driver-class-name=org.postgresql.Driver" > src/main/resources/encrypted.properties
-          echo "spring.datasource.url=$DATABASE_URL" >> src/main/resources/encrypted.properties
-          echo "spring.datasource.username=$DATABASE_USERNAME" >> src/main/resources/encrypted.properties
-          echo "spring.datasource.password=$DATABASE_PASSWORD" >> src/main/resources/encrypted.properties
-          echo "spring.data.redis.host=$REDIS_URL" >> src/main/resources/encrypted.properties
-          echo "spring.data.redis.port=$REDIS_PORT" >> src/main/resources/encrypted.properties
-          echo "spring.sql.init.mode=always" >> src/main/resources/encrypted.properties
-          echo "jasypt.encryptor.password=$JASYPT_PASSWORD" >> src/main/resources/encrypted.properties
-          echo "jwt.secret=$JWT_SECRET" >> src/main/resources/encrypted.properties
-          echo "jwt.expiration=5" >> src/main/resources/encrypted.properties
-          echo "jwt.expiration.refresh=7" >> src/main/resources/encrypted.properties
       - name: Build application jar
         run: |
           ./gradlew --no-daemon bootJar -x test
           cp "$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -n 1)" build/libs/app.jar
+      - name: Verify application jar contains no generated secret properties
+        run: |
+          if jar tf build/libs/app.jar | grep -q 'BOOT-INF/classes/encrypted.properties'; then
+            echo 'Generated secret properties must not be packaged in app.jar.'
+            exit 1
+          fi
       - name: Transfer application jar to Oracle runner
         id: transfer
         env:
@@ -138,14 +123,6 @@ jobs:
     if: needs.select-build-runner.outputs.use_mac != 'true'
     runs-on: ["self-hosted", "ARM64", "1st"]
     environment: production
-    env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
-      DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
-      REDIS_URL: ${{ secrets.REDIS_URL }}
-      REDIS_PORT: ${{ secrets.REDIS_PORT }}
-      JASYPT_PASSWORD: ${{ secrets.JASYPT_PASSWORD }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -155,23 +132,16 @@ jobs:
           java-version: 25
           distribution: 'zulu'
           check-latest: 'true'
-      - name: Create encrypted application.properties
-        run: |
-          echo "spring.datasource.driver-class-name=org.postgresql.Driver" > src/main/resources/encrypted.properties
-          echo "spring.datasource.url=$DATABASE_URL" >> src/main/resources/encrypted.properties
-          echo "spring.datasource.username=$DATABASE_USERNAME" >> src/main/resources/encrypted.properties
-          echo "spring.datasource.password=$DATABASE_PASSWORD" >> src/main/resources/encrypted.properties
-          echo "spring.data.redis.host=$REDIS_URL" >> src/main/resources/encrypted.properties
-          echo "spring.data.redis.port=$REDIS_PORT" >> src/main/resources/encrypted.properties
-          echo "spring.sql.init.mode=always" >> src/main/resources/encrypted.properties
-          echo "jasypt.encryptor.password=$JASYPT_PASSWORD" >> src/main/resources/encrypted.properties
-          echo "jwt.secret=$JWT_SECRET" >> src/main/resources/encrypted.properties
-          echo "jwt.expiration=5" >> src/main/resources/encrypted.properties
-          echo "jwt.expiration.refresh=7" >> src/main/resources/encrypted.properties
       - name: Build application jar
         run: |
           ./gradlew --no-daemon bootJar -x test
           cp "$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -n 1)" build/libs/app.jar
+      - name: Verify application jar contains no generated secret properties
+        run: |
+          if jar tf build/libs/app.jar | grep -q 'BOOT-INF/classes/encrypted.properties'; then
+            echo 'Generated secret properties must not be packaged in app.jar.'
+            exit 1
+          fi
       - name: Upload application jar
         uses: actions/upload-artifact@v7
         with:
@@ -235,4 +205,4 @@ jobs:
     steps:
       - name: Restart backend service
         run: |
-          kubectl -n hyuabot rollout restart deployment/hyuabot-backend-kotlin
+          sudo k3s kubectl -n hyuabot rollout restart deployment/hyuabot-backend-kotlin

--- a/README.md
+++ b/README.md
@@ -35,28 +35,30 @@ A Spring Boot GraphQL API backend for [HYUabot](https://github.com/hyuabot-devel
 - Java 21+
 - PostgreSQL
 - Redis
-- Jasypt password (for decrypting `encrypted.properties`)
+- Runtime environment variables for database, Redis, Jasypt, and JWT configuration
 
 ## Configuration
 
-The application uses `application.properties` for base configuration and `encrypted.properties` for sensitive values (encrypted with Jasypt).
+The application uses `application.properties` for base configuration. Sensitive values are injected through runtime environment variables and are not packaged in the JAR or container image. Jasypt remains enabled for any `ENC(...)` values supplied through the Spring environment.
 
 Required environment variables / secrets:
 
 | Variable            | Description                |
 |---------------------|----------------------------|
-| `DATABASE_URL`      | PostgreSQL JDBC URL        |
-| `DATABASE_USERNAME` | Database username          |
-| `DATABASE_PASSWORD` | Database password          |
-| `REDIS_URL`         | Redis host                 |
-| `REDIS_PORT`        | Redis port                 |
-| `JASYPT_PASSWORD`   | Jasypt decryption password |
-| `JWT_SECRET`        | JWT signing secret         |
+| `SPRING_DATASOURCE_URL`      | PostgreSQL JDBC URL        |
+| `SPRING_DATASOURCE_USERNAME` | Database username          |
+| `SPRING_DATASOURCE_PASSWORD` | Database password          |
+| `SPRING_DATA_REDIS_HOST`     | Redis host                 |
+| `SPRING_DATA_REDIS_PORT`     | Redis port                 |
+| `JASYPT_ENCRYPTOR_PASSWORD`  | Jasypt decryption password |
+| `JWT_SECRET`                 | JWT signing secret         |
 
-Pass the Jasypt password at startup:
+Pass all sensitive configuration at startup. For example:
 
 ```bash
-java -Djasypt.encryptor.password=<password> -jar app.jar
+JASYPT_ENCRYPTOR_PASSWORD=<password> \
+JWT_SECRET=<jwt-secret> \
+java -jar app.jar
 ```
 
 ## Getting Started

--- a/src/main/kotlin/app/hyuabot/backend/HyuabotBackendKotlinApplication.kt
+++ b/src/main/kotlin/app/hyuabot/backend/HyuabotBackendKotlinApplication.kt
@@ -1,11 +1,9 @@
 package app.hyuabot.backend
 
-import com.ulisesbocchio.jasyptspringboot.annotation.EncryptablePropertySource
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-@EncryptablePropertySource(name = "EncryptedProperties", value = ["classpath:encrypted.properties"])
 class HyuabotBackendKotlinApplication {
     companion object {
         @JvmStatic

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,16 @@
 spring.application.name=hyuabot-backend-kotlin
+# Runtime configuration. Values are injected by the container environment and are never packaged into the image.
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.data.redis.host=${SPRING_DATA_REDIS_HOST}
+spring.data.redis.port=${SPRING_DATA_REDIS_PORT:6379}
+spring.sql.init.mode=always
+jasypt.encryptor.password=${JASYPT_ENCRYPTOR_PASSWORD}
+jwt.secret=${JWT_SECRET}
+jwt.expiration=${JWT_EXPIRATION_MINUTES:5}
+jwt.expiration.refresh=${JWT_REFRESH_EXPIRATION_DAYS:7}
 # DataSource (HikariCP) - sized above the default 10 to absorb GraphQL fan-out; keep <= Postgres max_connections
 spring.datasource.hikari.maximum-pool-size=20
 spring.datasource.hikari.connection-timeout=10000


### PR DESCRIPTION
## Summary

- Read PostgreSQL, Redis, Jasypt, and JWT configuration from runtime environment variables.
- Stop generating and packaging `encrypted.properties` during CI and deployment builds.
- Fail deployment builds if generated secret properties are present in the application JAR.
- Use the privileged K3s kubectl entry point for the self-hosted production deployment step.
- Document the runtime configuration contract.

## Root Cause

The deployment workflow wrote production secret values into `src/main/resources/encrypted.properties` before building the Spring Boot JAR. The generated resource was then packaged into the JAR and container image even though the values were only needed when the application started.

## Impact

Production values are no longer provided to the image build or stored in the application artifact. No secret value is changed or rotated.

The paired infrastructure change must be applied first, and the live Kubernetes Secret must contain `JASYPT_PASSWORD` and `JWT_SECRET`: https://github.com/hyuabot-developers/hyuabot-infrastructure/pull/17

## Validation

- `./gradlew --no-daemon ktlintCheck bootJar -x test`
- `./gradlew --no-daemon test --tests 'app.hyuabot.backend.config.JasyptConfigTest'`
- Confirmed the executable JAR contains `application.properties` and does not contain `encrypted.properties`.
- Parsed both GitHub Actions workflows as YAML.
- Ran `git diff --check`.
