### PR TITLE
fix: Sync backend image to worker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -188,6 +188,10 @@ jobs:
       - name: Push docker image
         run: |
           docker push ${{ env.IMAGE_NAME }}
+      - name: Sync image to worker registry
+        uses: hyuabot-developers/hyuabot-infrastructure/.github/actions/sync-local-registry@2301646d60e5299a87d38fd7a1b6e4fe227430ca
+        with:
+          image: ${{ env.IMAGE_NAME }}
       - name: Clean local docker image
         if: always()
         run: |


### PR DESCRIPTION
## Summary

- Synchronize every newly pushed backend image from the first-node registry to the worker-local registry.
- Pin the shared synchronization action to an immutable infrastructure commit.
- Verify config and layer content before the deployment job can succeed.

## Root Cause

Both K3s nodes resolve `localhost:5000` to separate registry instances. The backend deployment workflow pushed only to the first node, so a Pod scheduled on the worker could pull an older `latest` image.

## Impact

A backend image build now succeeds only after both local registries contain equivalent image content. The worker registry remains loopback-only and transfer uses the runner's existing authenticated SSH connection.

This change does not restart the running backend after a pull-request merge.

## Validation

- Parsed `.github/workflows/deploy.yml` as YAML.
- Ran `git diff --check`.
- The pinned composite action includes Zsh syntax and mocked content-verification tests.
