### PR TITLE
fix: Update worker registry action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,7 +189,7 @@ jobs:
         run: |
           docker push ${{ env.IMAGE_NAME }}
       - name: Sync image to worker registry
-        uses: hyuabot-developers/hyuabot-infrastructure/.github/actions/sync-local-registry@2301646d60e5299a87d38fd7a1b6e4fe227430ca
+        uses: hyuabot-developers/hyuabot-infrastructure/.github/actions/sync-local-registry@a091ea37f391ae60eb7828325782a397cc7cae9c
         with:
           image: ${{ env.IMAGE_NAME }}
       - name: Clean local docker image


### PR DESCRIPTION
## Summary

- Update the pinned worker-registry synchronization action to the revision that declares an explicit Zsh command format.

## Root Cause

The previous composite action revision used `shell: zsh`, which GitHub rejected before executing the synchronization script because composite action shells require a `{0}` placeholder.

## Impact

The deployment workflow can execute the Zsh synchronization script after pushing the backend image. Running backend Pods remain unchanged until a separate rollout is requested.

## Validation

- Parsed `.github/workflows/deploy.yml` as YAML.
- Ran `git diff --check`.
- Confirmed the pinned action revision passes its Zsh syntax and mocked synchronization tests.
