### PR TITLE
feat: Add home weather and shuttle presence

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceController.kt
@@ -1,0 +1,28 @@
+package app.hyuabot.backend.presence
+
+import app.hyuabot.backend.utility.ResponseBuilder
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/presence/shuttle")
+class ShuttlePresenceController(
+    private val shuttlePresenceService: ShuttlePresenceService,
+) {
+    @PostMapping
+    fun heartbeat(
+        @RequestBody request: ShuttlePresenceRequest,
+    ): ResponseEntity<*> =
+        try {
+            ResponseEntity.ok(shuttlePresenceService.heartbeat(request))
+        } catch (_: IllegalArgumentException) {
+            ResponseBuilder.response(
+                HttpStatus.BAD_REQUEST,
+                ResponseBuilder.Message("INVALID_SHUTTLE_PRESENCE"),
+            )
+        }
+}

--- a/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceRequest.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceRequest.kt
@@ -1,0 +1,8 @@
+package app.hyuabot.backend.presence
+
+data class ShuttlePresenceRequest(
+    val stopId: String,
+    val sessionId: String,
+    val platform: String,
+    val appVersion: String,
+)

--- a/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceResponse.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceResponse.kt
@@ -1,0 +1,10 @@
+package app.hyuabot.backend.presence
+
+import java.time.Instant
+
+data class ShuttlePresenceResponse(
+    val viewerCount: Long?,
+    val visible: Boolean,
+    val updatedAt: Instant,
+    val activeWindowSeconds: Long,
+)

--- a/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceService.kt
@@ -1,0 +1,109 @@
+package app.hyuabot.backend.presence
+
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.core.io.ClassPathResource
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
+import org.springframework.scripting.support.ResourceScriptSource
+import org.springframework.stereotype.Service
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+@Service
+class ShuttlePresenceService(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val meterRegistry: MeterRegistry,
+    private val watchAnalyticsClock: Clock,
+) {
+    private val heartbeatScript =
+        DefaultRedisScript<Long>().apply {
+            setScriptSource(ResourceScriptSource(ClassPathResource("scripts/shuttle-presence.lua")))
+            resultType = Long::class.java
+        }
+
+    fun heartbeat(request: ShuttlePresenceRequest): ShuttlePresenceResponse {
+        val stop = Stop.from(request.stopId)
+        val platform = Platform.from(request.platform)
+        val sessionId = UUID.fromString(request.sessionId).toString()
+        require(APP_VERSION_REGEX.matches(request.appVersion))
+
+        val now = Instant.now(watchAnalyticsClock)
+        val nowEpoch = now.epochSecond
+        val stopKey = "presence:shuttle:${stop.value}"
+        val sessionKey = "presence:shuttle:session:$sessionId"
+        val rateKey = "presence:shuttle:rate:$sessionId"
+        val count =
+            redisTemplate.execute(
+                heartbeatScript,
+                listOf(stopKey, sessionKey, rateKey),
+                (nowEpoch - ACTIVE_WINDOW_SECONDS).toString(),
+                nowEpoch.toString(),
+                sessionId,
+                stopKey,
+                ACTIVE_WINDOW_SECONDS.toString(),
+                STOP_KEY_TTL_SECONDS.toString(),
+                MIN_HEARTBEAT_INTERVAL_SECONDS.toString(),
+            ) ?: 0L
+
+        meterRegistry
+            .counter(
+                "hyuabot.shuttle.presence.heartbeats",
+                "platform",
+                platform.value,
+                "stop_id",
+                stop.value,
+            ).increment()
+
+        return responseFor(count, now)
+    }
+
+    internal fun responseFor(
+        count: Long,
+        now: Instant,
+    ): ShuttlePresenceResponse {
+        val visible = count >= MINIMUM_VISIBLE_COUNT
+        return ShuttlePresenceResponse(
+            viewerCount = count.takeIf { visible },
+            visible = visible,
+            updatedAt = now,
+            activeWindowSeconds = ACTIVE_WINDOW_SECONDS,
+        )
+    }
+
+    private enum class Platform(
+        val value: String,
+    ) {
+        ANDROID("android"),
+        IOS("ios"),
+        ;
+
+        companion object {
+            fun from(value: String) = entries.firstOrNull { it.value == value } ?: throw IllegalArgumentException()
+        }
+    }
+
+    private enum class Stop(
+        val value: String,
+    ) {
+        DORMITORY("dormitory_o"),
+        SHUTTLECOCK_OUT("shuttlecock_o"),
+        STATION("station"),
+        TERMINAL("terminal"),
+        JUNGANG("jungang_stn"),
+        SHUTTLECOCK_IN("shuttlecock_i"),
+        ;
+
+        companion object {
+            fun from(value: String) = entries.firstOrNull { it.value == value } ?: throw IllegalArgumentException()
+        }
+    }
+
+    companion object {
+        internal const val ACTIVE_WINDOW_SECONDS = 75L
+        private const val STOP_KEY_TTL_SECONDS = 300L
+        private const val MIN_HEARTBEAT_INTERVAL_SECONDS = 5L
+        private const val MINIMUM_VISIBLE_COUNT = 3L
+        private val APP_VERSION_REGEX = Regex("[0-9A-Za-z][0-9A-Za-z.+_-]{0,31}")
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
@@ -53,6 +53,7 @@ class SecurityConfig(
                         "/api/v1/user/account-setup/**",
                         "/api/v1/live-activity/**",
                         "/api/v1/analytics/watch/events",
+                        "/api/v1/presence/shuttle",
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/graphql/**",

--- a/src/main/kotlin/app/hyuabot/backend/weather/HomeWeatherDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/weather/HomeWeatherDataFetcher.kt
@@ -1,0 +1,12 @@
+package app.hyuabot.backend.weather
+
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsQuery
+
+@DgsComponent
+class HomeWeatherDataFetcher(
+    private val homeWeatherService: HomeWeatherService,
+) {
+    @DgsQuery
+    fun homeWeather(): HomeWeatherPayload? = homeWeatherService.current()
+}

--- a/src/main/kotlin/app/hyuabot/backend/weather/HomeWeatherService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/weather/HomeWeatherService.kt
@@ -1,0 +1,35 @@
+package app.hyuabot.backend.weather
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import tools.jackson.databind.ObjectMapper
+import java.time.Clock
+import java.time.ZonedDateTime
+
+data class HomeWeatherPayload(
+    val issuedAt: ZonedDateTime,
+    val expiresAt: ZonedDateTime,
+    val currentTemperature: Double? = null,
+    val minimumTemperature: Double? = null,
+    val maximumTemperature: Double? = null,
+    val precipitationProbabilityMax: Int,
+    val precipitationStartAt: ZonedDateTime? = null,
+    val precipitationType: String,
+    val primaryCondition: String,
+)
+
+@Service
+class HomeWeatherService(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+    private val watchAnalyticsClock: Clock,
+    @param:Value("\${weather.home.redis-key:weather:home:erica}") private val redisKey: String,
+) {
+    fun current(): HomeWeatherPayload? {
+        val value = redisTemplate.opsForValue().get(redisKey) ?: return null
+        return runCatching { objectMapper.readValue(value, HomeWeatherPayload::class.java) }
+            .getOrNull()
+            ?.takeIf { it.expiresAt.isAfter(ZonedDateTime.now(watchAnalyticsClock)) }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,3 +62,5 @@ admin.timetable-import.preview-ttl-minutes=${TIMETABLE_IMPORT_PREVIEW_TTL_MINUTE
 # Admin Web Push
 admin.push.notifier-base-url=${NOTIFIER_BASE_URL:http://127.0.0.1:8081}
 admin.push.notifier-service-token=${NOTIFIER_SERVICE_TOKEN:}
+# Home weather
+weather.home.redis-key=${WEATHER_FORECAST_REDIS_KEY:weather:home:erica}

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -3,6 +3,7 @@ scalar DateTime
 scalar LocalTime
 
 type Query {
+    homeWeather: HomeWeather
     notices(input: NoticeInput): [NoticeCategory!]!
     calendar(input: AcademicCalendarInput): AcademicCalendar!
     phonebook(input: PhonebookInput): Phonebook!
@@ -13,6 +14,18 @@ type Query {
     bus(input: [BusRouteStopInput!]!): [BusRouteStop!]!
     subway(input: SubwayInput!): [SubwayStation!]!
     shuttle(input: ShuttleInput!): Shuttle!
+}
+
+type HomeWeather {
+    issuedAt: DateTime!
+    expiresAt: DateTime!
+    currentTemperature: Float
+    minimumTemperature: Float
+    maximumTemperature: Float
+    precipitationProbabilityMax: Int!
+    precipitationStartAt: DateTime
+    precipitationType: String!
+    primaryCondition: String!
 }
 
 # 공지사항 카테고리와 공지사항을 반환하는 쿼리입니다.

--- a/src/main/resources/scripts/shuttle-presence.lua
+++ b/src/main/resources/scripts/shuttle-presence.lua
@@ -1,0 +1,15 @@
+local previousStopKey = redis.call('GET', KEYS[2])
+if previousStopKey and previousStopKey ~= KEYS[1] then
+    redis.call('ZREM', previousStopKey, ARGV[3])
+end
+
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+
+local rateAllowed = redis.call('SET', KEYS[3], '1', 'NX', 'EX', ARGV[7])
+if rateAllowed or previousStopKey ~= KEYS[1] then
+    redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
+    redis.call('SET', KEYS[2], ARGV[4], 'EX', ARGV[5])
+end
+
+redis.call('EXPIRE', KEYS[1], ARGV[6])
+return redis.call('ZCARD', KEYS[1])

--- a/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceControllerTest.kt
@@ -1,0 +1,50 @@
+package app.hyuabot.backend.presence
+
+import app.hyuabot.backend.utility.ResponseBuilder
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class ShuttlePresenceControllerTest {
+    private val service = mock<ShuttlePresenceService>()
+    private val controller = ShuttlePresenceController(service)
+    private val request =
+        ShuttlePresenceRequest(
+            stopId = "station",
+            sessionId = "123e4567-e89b-12d3-a456-426614174000",
+            platform = "android",
+            appVersion = "5.2.0",
+        )
+
+    @Test
+    fun `returns the presence response for a valid heartbeat`() {
+        val presence =
+            ShuttlePresenceResponse(
+                viewerCount = 3,
+                visible = true,
+                updatedAt = Instant.parse("2026-07-21T03:00:00Z"),
+                activeWindowSeconds = 75,
+            )
+        whenever(service.heartbeat(request)).thenReturn(presence)
+
+        val response = controller.heartbeat(request)
+
+        assertEquals(200, response.statusCode.value())
+        assertEquals(presence, response.body)
+        verify(service).heartbeat(request)
+    }
+
+    @Test
+    fun `returns bad request for invalid heartbeat dimensions`() {
+        doThrow(IllegalArgumentException()).`when`(service).heartbeat(request)
+
+        val response = controller.heartbeat(request)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("INVALID_SHUTTLE_PRESENCE", (response.body as ResponseBuilder.Message).message)
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceServiceTest.kt
@@ -1,0 +1,59 @@
+package app.hyuabot.backend.presence
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.springframework.data.redis.core.RedisTemplate
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ShuttlePresenceServiceTest {
+    private val now = Instant.parse("2026-07-21T03:00:00Z")
+    private val service =
+        ShuttlePresenceService(
+            mock<RedisTemplate<String, String>>(),
+            SimpleMeterRegistry(),
+            Clock.fixed(now, ZoneOffset.UTC),
+        )
+
+    @Test
+    fun `hides small groups and exposes counts from three viewers`() {
+        val smallGroup = service.responseFor(2, now)
+        assertFalse(smallGroup.visible)
+        assertNull(smallGroup.viewerCount)
+
+        val visibleGroup = service.responseFor(3, now)
+        assertTrue(visibleGroup.visible)
+        assertEquals(3, visibleGroup.viewerCount)
+        assertEquals(75, visibleGroup.activeWindowSeconds)
+    }
+
+    @Test
+    fun `rejects unsupported heartbeat dimensions before writing redis`() {
+        assertThrows<IllegalArgumentException> {
+            service.heartbeat(validRequest(stopId = "unknown"))
+        }
+        assertThrows<IllegalArgumentException> {
+            service.heartbeat(validRequest(platform = "web"))
+        }
+        assertThrows<IllegalArgumentException> {
+            service.heartbeat(validRequest(sessionId = "not-a-uuid"))
+        }
+        assertThrows<IllegalArgumentException> {
+            service.heartbeat(validRequest(appVersion = "invalid version"))
+        }
+    }
+
+    private fun validRequest(
+        stopId: String = "station",
+        sessionId: String = "123e4567-e89b-12d3-a456-426614174000",
+        platform: String = "android",
+        appVersion: String = "5.2.0",
+    ) = ShuttlePresenceRequest(stopId, sessionId, platform, appVersion)
+}

--- a/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceServiceTest.kt
@@ -3,8 +3,11 @@ package app.hyuabot.backend.presence
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
@@ -15,12 +18,52 @@ import kotlin.test.assertTrue
 
 class ShuttlePresenceServiceTest {
     private val now = Instant.parse("2026-07-21T03:00:00Z")
+    private val redisTemplate = mock<RedisTemplate<String, String>>()
+    private val meterRegistry = SimpleMeterRegistry()
     private val service =
         ShuttlePresenceService(
-            mock<RedisTemplate<String, String>>(),
-            SimpleMeterRegistry(),
+            redisTemplate,
+            meterRegistry,
             Clock.fixed(now, ZoneOffset.UTC),
         )
+
+    @Test
+    fun `records a valid heartbeat and returns the active viewer count`() {
+        whenever(
+            redisTemplate.execute(
+                any<RedisScript<Long>>(),
+                any<List<String>>(),
+                any<String>(),
+                any<String>(),
+                any<String>(),
+                any<String>(),
+                any<String>(),
+                any<String>(),
+                any<String>(),
+            ),
+        ).thenReturn(3L).thenReturn(null)
+
+        val response = service.heartbeat(validRequest())
+
+        assertTrue(response.visible)
+        assertEquals(3, response.viewerCount)
+        assertEquals(now, response.updatedAt)
+        assertEquals(
+            1.0,
+            meterRegistry
+                .counter(
+                    "hyuabot.shuttle.presence.heartbeats",
+                    "platform",
+                    "android",
+                    "stop_id",
+                    "station",
+                ).count(),
+        )
+
+        val fallbackResponse = service.heartbeat(validRequest())
+        assertFalse(fallbackResponse.visible)
+        assertNull(fallbackResponse.viewerCount)
+    }
 
     @Test
     fun `hides small groups and exposes counts from three viewers`() {

--- a/src/test/kotlin/app/hyuabot/backend/weather/HomeWeatherDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/weather/HomeWeatherDataFetcherTest.kt
@@ -1,0 +1,29 @@
+package app.hyuabot.backend.weather
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.ZonedDateTime
+import kotlin.test.assertEquals
+
+class HomeWeatherDataFetcherTest {
+    private val service = mock<HomeWeatherService>()
+    private val dataFetcher = HomeWeatherDataFetcher(service)
+
+    @Test
+    fun `delegates the home weather query to the service`() {
+        val forecast =
+            HomeWeatherPayload(
+                issuedAt = ZonedDateTime.parse("2026-07-21T11:00:00+09:00"),
+                expiresAt = ZonedDateTime.parse("2026-07-21T13:00:00+09:00"),
+                precipitationProbabilityMax = 0,
+                precipitationType = "NONE",
+                primaryCondition = "CLEAR",
+            )
+        whenever(service.current()).thenReturn(forecast)
+
+        assertEquals(forecast, dataFetcher.homeWeather())
+        verify(service).current()
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/weather/HomeWeatherServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/weather/HomeWeatherServiceTest.kt
@@ -52,6 +52,23 @@ class HomeWeatherServiceTest {
         assertNull(service.current())
     }
 
+    @Test
+    fun `uses null defaults for optional forecast values`() {
+        val forecast =
+            HomeWeatherPayload(
+                issuedAt = ZonedDateTime.parse("2026-07-21T11:00:00+09:00"),
+                expiresAt = ZonedDateTime.parse("2026-07-21T13:00:00+09:00"),
+                precipitationProbabilityMax = 0,
+                precipitationType = "NONE",
+                primaryCondition = "CLEAR",
+            )
+
+        assertNull(forecast.currentTemperature)
+        assertNull(forecast.minimumTemperature)
+        assertNull(forecast.maximumTemperature)
+        assertNull(forecast.precipitationStartAt)
+    }
+
     private fun forecast(expiresAt: String) =
         HomeWeatherPayload(
             issuedAt = ZonedDateTime.parse("2026-07-21T11:00:00+09:00"),

--- a/src/test/kotlin/app/hyuabot/backend/weather/HomeWeatherServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/weather/HomeWeatherServiceTest.kt
@@ -1,0 +1,67 @@
+package app.hyuabot.backend.weather
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import tools.jackson.databind.ObjectMapper
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class HomeWeatherServiceTest {
+    private val redisTemplate = mock<RedisTemplate<String, String>>()
+    private val valueOperations = mock<ValueOperations<String, String>>()
+    private val objectMapper = mock<ObjectMapper>()
+    private val now = Instant.parse("2026-07-21T03:00:00Z")
+    private val service =
+        HomeWeatherService(
+            redisTemplate,
+            objectMapper,
+            Clock.fixed(now, ZoneOffset.UTC),
+            "weather:test",
+        ).also {
+            whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
+        }
+
+    @Test
+    fun `returns an unexpired forecast`() {
+        val forecast = forecast(expiresAt = "2026-07-21T13:00:00+09:00")
+        whenever(valueOperations.get("weather:test")).thenReturn("forecast-json")
+        whenever(objectMapper.readValue("forecast-json", HomeWeatherPayload::class.java)).thenReturn(forecast)
+
+        assertEquals(forecast, service.current())
+    }
+
+    @Test
+    fun `hides missing malformed and expired forecasts`() {
+        assertNull(service.current())
+
+        whenever(valueOperations.get("weather:test")).thenReturn("malformed")
+        whenever(objectMapper.readValue("malformed", HomeWeatherPayload::class.java))
+            .thenThrow(IllegalArgumentException())
+        assertNull(service.current())
+
+        val expired = forecast(expiresAt = "2026-07-21T11:59:59+09:00")
+        whenever(valueOperations.get("weather:test")).thenReturn("expired-json")
+        whenever(objectMapper.readValue("expired-json", HomeWeatherPayload::class.java)).thenReturn(expired)
+        assertNull(service.current())
+    }
+
+    private fun forecast(expiresAt: String) =
+        HomeWeatherPayload(
+            issuedAt = ZonedDateTime.parse("2026-07-21T11:00:00+09:00"),
+            expiresAt = ZonedDateTime.parse(expiresAt),
+            currentTemperature = 31.0,
+            minimumTemperature = 25.0,
+            maximumTemperature = 34.0,
+            precipitationProbabilityMax = 60,
+            precipitationStartAt = ZonedDateTime.parse("2026-07-21T15:00:00+09:00"),
+            precipitationType = "RAIN",
+            primaryCondition = "RAIN",
+        )
+}


### PR DESCRIPTION
## Summary

- Expose the current structured home forecast through the additive `homeWeather` GraphQL field.
- Add a public shuttle presence heartbeat endpoint backed by an atomic Redis Lua script.
- Count only sessions active within 75 seconds, move sessions between stops atomically, and suppress viewer counts below three.
- Add focused weather freshness, validation, and visibility-threshold tests.

## Impact

Android and iOS can render today's weather and an anonymous “people checking this stop” indicator. Presence data is ephemeral, contains no account identifier, and requires no PostgreSQL schema change.

## Validation

- Ran focused weather and shuttle presence unit tests.
- Ran `./gradlew ktlintCheck`.
- Confirmed the main and test Kotlin sources compile.
- Ran `git diff --check`.
- The full local Spring context suite still requires the repository datasource configuration provided by CI.
