### PR TITLE
fix: Verify immutable backend deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,8 @@ jobs:
           image: ${{ env.IMAGE_NAME }}
 
   deploy:
+    # Merged pull requests publish and sync the immutable SHA image only.
+    # Production rollout remains an explicit manual action.
     if: github.event_name == 'workflow_dispatch'
     needs: sync
     runs-on: [self-hosted, ARM64, Linux, 1st]
@@ -107,6 +109,15 @@ jobs:
           kubectl -n hyuabot rollout status \
             deployment/hyuabot-backend-kotlin \
             --timeout=300s
+          deployed_image="$(
+            kubectl -n hyuabot get \
+              deployment/hyuabot-backend-kotlin \
+              -o jsonpath='{.spec.template.spec.containers[?(@.name=="api")].image}'
+          )"
+          if [[ "$deployed_image" != "$IMAGE_NAME" ]]; then
+            print -u2 -r -- "Expected ${IMAGE_NAME}, deployed ${deployed_image}"
+            exit 1
+          fi
       - name: Verify backend health
         run: |
           curl --fail --show-error --silent \

--- a/README.md
+++ b/README.md
@@ -138,9 +138,13 @@ The Dockerfile uses a multi-stage build with `eclipse-temurin:21-jre-alpine` as 
 | Workflow | Trigger | Actions |
 |---|---|---|
 | `code-check.yml` | Push / PR | ktlint check, tests, JaCoCo coverage |
-| `deploy.yml` | Merged PR / manual | Docker build & push, Kubernetes rolling restart |
+| `deploy.yml` | Merged PR | Build and publish a commit-SHA image to both node registries |
+| `deploy.yml` | Manual | Build and publish a commit-SHA image, then roll it out to Kubernetes and verify backend health |
 
 Deployment targets a Kubernetes cluster under the `hyuabot` namespace.
+The workflow is the only owner of the live Deployment container image. Runtime
+Kubernetes patches must omit `spec.template.spec.containers[].image` so a
+configuration update cannot replace the immutable SHA tag.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

- Verify that the live backend Deployment uses the exact commit-SHA image after a manual rollout.
- Clarify that merged pull requests publish and synchronize images without deploying them.
- Document that runtime Kubernetes patches must leave the workflow-owned image field untouched.

## Root Cause

The workflow rolled out and health-checked the backend but did not assert that the Deployment image matched the expected immutable SHA. The CI/CD table also implied that every merged pull request restarted Kubernetes even though production deployment is intentionally manual.

## Impact

A manual deployment now fails if Kubernetes does not retain the expected SHA image, while merged pull requests continue to publish images without changing the running workload. The repository documentation matches the actual deployment gate.

## Validation

- Parsed `.github/workflows/deploy.yml` as YAML.
- Validated the Kubernetes JSONPath expression against the backend bootstrap Deployment.
- Ran `git diff --check`.
