### PR TITLE
feat: Add weather status to operations overview

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewService.kt
@@ -197,6 +197,14 @@ class AdminOverviewService(
                     Duration.ofMinutes(5),
                     "/readingRoom/room",
                 ),
+                JobDefinition(
+                    "weather",
+                    "날씨",
+                    AdminPermission.NOTICE,
+                    "weather-cron-job",
+                    Duration.ofMinutes(90),
+                    "/notice/notice",
+                ),
             )
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewServiceTest.kt
@@ -218,6 +218,34 @@ class AdminOverviewServiceTest {
         assertEquals(listOf("cafeteria"), unrelated.services.map { it.id })
     }
 
+    @Test
+    fun `weather status follows notice permission and hourly freshness`() {
+        val current = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
+        whenever(prometheusClient.getCronJobRuns()).thenReturn(
+            mapOf("weather-cron-job" to CronJobRun(current.minusMinutes(89).toInstant().toString(), null)),
+        )
+
+        val normal = service.getOverview(setOf(AdminPermission.NOTICE), current).services.single()
+
+        assertEquals("weather", normal.id)
+        assertEquals("날씨", normal.title)
+        assertEquals("NORMAL", normal.status)
+        assertEquals("/notice/notice", normal.managementPath)
+
+        whenever(prometheusClient.getCronJobRuns()).thenReturn(
+            mapOf("weather-cron-job" to CronJobRun(current.minusMinutes(91).toInstant().toString(), null)),
+        )
+
+        assertEquals(
+            "WARNING",
+            service
+                .getOverview(setOf(AdminPermission.NOTICE), current)
+                .services
+                .single()
+                .status,
+        )
+    }
+
     private fun invitation(expiresAt: ZonedDateTime) =
         AdminUserInvitation(
             uuid = UUID.randomUUID(),

--- a/src/test/kotlin/app/hyuabot/backend/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/auth/AuthServiceTest.kt
@@ -272,4 +272,21 @@ class AuthServiceTest {
         assertEquals("NO_REFRESH_TOKEN", exception.message)
         verify(tokenProvider).invalidateAccessToken("accessToken")
     }
+
+    @Test
+    @DisplayName("로그아웃 테스트 (저장된 Refresh Token 없음)")
+    fun logoutNoSavedRefreshTokenTest() {
+        val user =
+            mock<User>().apply {
+                whenever(userID).thenReturn("testUser")
+            }
+        val cookies = arrayOf(Cookie("access_token", "accessToken"), Cookie("refresh_token", "refreshToken"))
+        whenever(request.cookies).thenReturn(cookies)
+        whenever(refreshTokenRepository.findByUserIDAndRefreshToken("testUser", "refreshToken")).thenReturn(null)
+
+        val exception = assertThrows<IllegalArgumentException> { authService.logout(user, request) }
+
+        assertEquals("NO_REFRESH_TOKEN", exception.message)
+        verify(tokenProvider).invalidateAccessToken("accessToken")
+    }
 }

--- a/src/test/kotlin/app/hyuabot/backend/holiday/HolidayAuditServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/HolidayAuditServiceTest.kt
@@ -51,9 +51,13 @@ class HolidayAuditServiceTest {
     fun `super admin receives sync and shuttle issues`() {
         val imminent = now.toLocalDate().plusDays(2)
         val later = now.toLocalDate().plusDays(10)
+        val undecided = now.toLocalDate().plusDays(20)
         whenever(syncStateRepository.findBySource("KASI")).thenReturn(null)
         whenever(shuttleHolidayRepository.findAll()).thenReturn(
-            listOf(ShuttleHoliday(1, LocalDate.of(2026, 1, 1), "legacy", "gregorian")),
+            listOf(
+                ShuttleHoliday(1, LocalDate.of(2026, 1, 1), "legacy", "gregorian"),
+                ShuttleHoliday(2, LocalDate.of(2026, 1, 1), "weekends", "gregorian"),
+            ),
         )
         whenever(
             publicHolidayRepository.findOfficialHolidaysBetween(
@@ -66,16 +70,27 @@ class HolidayAuditServiceTest {
             listOf(
                 PublicHoliday(1, imminent, "제헌절", "solar"),
                 PublicHoliday(2, later, "광복절", "solar"),
+                PublicHoliday(3, undecided, "추가 공휴일", "solar"),
             ),
         )
         whenever(shuttleHolidayRepository.findByDateAndCalendarType(imminent, "solar")).thenReturn(null)
         whenever(shuttleHolidayRepository.findByDateAndCalendarType(later, "solar")).thenReturn(
             ShuttleHoliday(2, later, "weekends", "solar"),
         )
+        whenever(shuttleHolidayRepository.findByDateAndCalendarType(undecided, "solar")).thenReturn(null)
         whenever(shuttlePeriodService.findShuttlePeriod(imminent)).thenReturn(null)
         whenever(shuttlePeriodService.findShuttlePeriod(later)).thenReturn(
             app.hyuabot.backend.database.entity.ShuttlePeriod(
                 1,
+                "vacation",
+                now.minusDays(1),
+                now.plusDays(30),
+                null,
+            ),
+        )
+        whenever(shuttlePeriodService.findShuttlePeriod(undecided)).thenReturn(
+            app.hyuabot.backend.database.entity.ShuttlePeriod(
+                2,
                 "vacation",
                 now.minusDays(1),
                 now.plusDays(30),
@@ -100,6 +115,9 @@ class HolidayAuditServiceTest {
         assertTrue(result.issues.filter { it.date == imminent }.all { it.severity == "ERROR" })
         assertTrue(result.issues.filter { it.date == later }.all { it.severity == "WARNING" })
         assertEquals("/bus/holiday", result.issues.first { it.code == "PUBLIC_HOLIDAY_SYNC_STALE" }.managementPath)
+        val invalidDecision = result.issues.first { it.code == "SHUTTLE_DECISION_INVALID" }
+        assertEquals("shuttle", invalidDecision.service)
+        assertEquals("2026-01-01 셔틀 휴일 설정값을 확인해주세요.", invalidDecision.message)
     }
 
     @Test
@@ -115,7 +133,9 @@ class HolidayAuditServiceTest {
                 lastError = null,
             )
         whenever(syncStateRepository.findBySource("KASI")).thenReturn(syncState)
-        whenever(shuttleHolidayRepository.findAll()).thenReturn(emptyList())
+        whenever(shuttleHolidayRepository.findAll()).thenReturn(
+            listOf(ShuttleHoliday(1, date, "halt", "solar")),
+        )
         whenever(publicHolidayRepository.findOfficialHolidaysBetween(any(), any(), any(), any())).thenReturn(
             listOf(PublicHoliday(1, date, "광복절", "solar")),
         )
@@ -130,7 +150,10 @@ class HolidayAuditServiceTest {
         val result = service().audit(setOf(AdminPermission.SHUTTLE), now)
 
         assertTrue(result.issues.isEmpty())
+        assertEquals("KASI", syncState.source)
+        assertEquals(now.minusHours(1), syncState.lastAttemptAt)
         assertEquals(syncState.lastSuccessAt, result.lastSuccessAt)
+        assertEquals(now.toLocalDate(), syncState.rangeStart)
         verify(shuttleTimetableRepository, never()).existsByPeriodTypeAndWeekday(any(), any())
     }
 

--- a/src/test/kotlin/app/hyuabot/backend/holiday/HolidaySyncStateRepositoryTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/HolidaySyncStateRepositoryTest.kt
@@ -36,9 +36,29 @@ class HolidaySyncStateRepositoryTest {
 
         val result = repository.findBySource("KASI")
 
+        assertEquals("KASI", result?.source)
+        assertEquals(success.toZonedDateTime(), result?.lastAttemptAt)
         assertEquals(success.toZonedDateTime(), result?.lastSuccessAt)
+        assertEquals(LocalDate.of(2026, 1, 1), result?.rangeStart)
         assertEquals(LocalDate.of(2027, 12, 31), result?.rangeEnd)
         assertNull(result?.lastError)
+    }
+
+    @Test
+    fun `nullable sync timestamps are mapped`() {
+        val resultSet = mock<ResultSet>()
+        whenever(resultSet.getString("source")).thenReturn("KASI")
+        whenever(resultSet.getObject("last_attempt_at", OffsetDateTime::class.java)).thenReturn(null)
+        whenever(resultSet.getObject("last_success_at", OffsetDateTime::class.java)).thenReturn(null)
+        whenever(jdbcTemplate.query(any<String>(), any<RowMapper<HolidaySyncState>>(), eq("KASI"))).thenAnswer { invocation ->
+            val mapper = invocation.getArgument<RowMapper<HolidaySyncState>>(1)
+            listOf(mapper.mapRow(resultSet, 0))
+        }
+
+        val result = repository.findBySource("KASI")
+
+        assertNull(result?.lastAttemptAt)
+        assertNull(result?.lastSuccessAt)
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/weather/HomeWeatherServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/weather/HomeWeatherServiceTest.kt
@@ -63,10 +63,14 @@ class HomeWeatherServiceTest {
                 primaryCondition = "CLEAR",
             )
 
+        assertEquals(ZonedDateTime.parse("2026-07-21T11:00:00+09:00"), forecast.issuedAt)
         assertNull(forecast.currentTemperature)
         assertNull(forecast.minimumTemperature)
         assertNull(forecast.maximumTemperature)
+        assertEquals(0, forecast.precipitationProbabilityMax)
         assertNull(forecast.precipitationStartAt)
+        assertEquals("NONE", forecast.precipitationType)
+        assertEquals("CLEAR", forecast.primaryCondition)
     }
 
     private fun forecast(expiresAt: String) =


### PR DESCRIPTION
## Summary

- Add the hourly weather updater to the administrator operations overview.
- Show the card only to notice administrators and link it to notice management.
- Mark weather collection stale when no successful CronJob run is recorded for 90 minutes.
- Cover the remaining project behaviors so the overall JaCoCo instruction coverage is 100%.

## Impact

Administrators with notice permissions can see the weather collection health and last successful update alongside the existing data collection services. No API contract or database schema changes are required.

## Validation

- `./gradlew --no-daemon ktlintCheck test jacocoTestReport`
- JaCoCo: 40,393 of 40,393 instructions covered
- `git diff --check`