### PR TITLE
feat: Expose weather forecast consensus

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewService.kt
@@ -2,6 +2,8 @@ package app.hyuabot.backend.adminoverview
 
 import app.hyuabot.backend.adminoverview.domain.AdminOverviewResponse
 import app.hyuabot.backend.adminoverview.domain.AdminServiceStatus
+import app.hyuabot.backend.adminoverview.domain.AdminWeatherForecastStatus
+import app.hyuabot.backend.adminoverview.domain.AdminWeatherSourceStatus
 import app.hyuabot.backend.adminoverview.domain.CronJobRun
 import app.hyuabot.backend.database.repository.AdminUserInvitationRepository
 import app.hyuabot.backend.holiday.audit.HolidayAuditResult
@@ -10,6 +12,7 @@ import app.hyuabot.backend.security.AdminPermission
 import app.hyuabot.backend.shuttle.service.ShuttleHolidayService
 import app.hyuabot.backend.shuttle.service.ShuttlePeriodService
 import app.hyuabot.backend.utility.LocalDateTimeBuilder
+import app.hyuabot.backend.weather.HomeWeatherService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.time.Duration
@@ -24,6 +27,7 @@ class AdminOverviewService(
     private val shuttleHolidayService: ShuttleHolidayService,
     private val holidayAuditService: HolidayAuditService,
     private val invitationRepository: AdminUserInvitationRepository,
+    private val homeWeatherService: HomeWeatherService,
     @param:Value("\${admin.overview.grafana-url:https://grafana.hyuabot.app}") private val grafanaURL: String,
 ) {
     fun getOverview(permissions: Set<AdminPermission>): AdminOverviewResponse =
@@ -65,6 +69,24 @@ class AdminOverviewService(
         return AdminOverviewResponse(
             checkedAt = now.toString(),
             services = services,
+            weatherForecast =
+                if (AdminPermission.NOTICE in permissions) {
+                    homeWeatherService.shadow()?.let { weather ->
+                        AdminWeatherForecastStatus(
+                            generatedAt = (weather.forecastUpdatedAt ?: weather.issuedAt).toString(),
+                            observedAt = weather.observedAt?.toString(),
+                            availableModelCount = weather.availableModelCount ?: 0,
+                            agreeingModelCount = weather.agreeingModelCount ?: 0,
+                            precipitationConfidence = weather.precipitationConfidence,
+                            sources =
+                                weather.sources.map { source ->
+                                    AdminWeatherSourceStatus(source.source, source.status)
+                                },
+                        )
+                    }
+                } else {
+                    null
+                },
             expiringInvitationCount = expiringInvitations,
             grafanaURL = grafanaURL,
         )

--- a/src/main/kotlin/app/hyuabot/backend/adminoverview/domain/AdminOverviewModels.kt
+++ b/src/main/kotlin/app/hyuabot/backend/adminoverview/domain/AdminOverviewModels.kt
@@ -3,8 +3,23 @@ package app.hyuabot.backend.adminoverview.domain
 data class AdminOverviewResponse(
     val checkedAt: String,
     val services: List<AdminServiceStatus>,
+    val weatherForecast: AdminWeatherForecastStatus?,
     val expiringInvitationCount: Int?,
     val grafanaURL: String,
+)
+
+data class AdminWeatherForecastStatus(
+    val generatedAt: String,
+    val observedAt: String?,
+    val availableModelCount: Int,
+    val agreeingModelCount: Int,
+    val precipitationConfidence: String?,
+    val sources: List<AdminWeatherSourceStatus>,
+)
+
+data class AdminWeatherSourceStatus(
+    val source: String,
+    val status: String,
 )
 
 data class AdminServiceStatus(

--- a/src/main/kotlin/app/hyuabot/backend/weather/HomeWeatherService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/weather/HomeWeatherService.kt
@@ -10,13 +10,28 @@ import java.time.ZonedDateTime
 data class HomeWeatherPayload(
     val issuedAt: ZonedDateTime,
     val expiresAt: ZonedDateTime,
+    val observedAt: ZonedDateTime? = null,
+    val forecastUpdatedAt: ZonedDateTime? = null,
     val currentTemperature: Double? = null,
+    val currentPrecipitationType: String? = null,
+    val currentPrecipitationAmount: Double? = null,
     val minimumTemperature: Double? = null,
     val maximumTemperature: Double? = null,
     val precipitationProbabilityMax: Int,
     val precipitationStartAt: ZonedDateTime? = null,
+    val precipitationEndAt: ZonedDateTime? = null,
     val precipitationType: String,
+    val precipitationConfidence: String? = null,
+    val availableModelCount: Int? = null,
+    val agreeingModelCount: Int? = null,
     val primaryCondition: String,
+    val attribution: String? = null,
+    val sources: List<WeatherSourceStatus> = emptyList(),
+)
+
+data class WeatherSourceStatus(
+    val source: String,
+    val status: String,
 )
 
 @Service
@@ -25,9 +40,14 @@ class HomeWeatherService(
     private val objectMapper: ObjectMapper,
     private val watchAnalyticsClock: Clock,
     @param:Value("\${weather.home.redis-key:weather:home:erica}") private val redisKey: String,
+    @param:Value("\${weather.home.shadow-redis-key:weather:home:erica:shadow}") private val shadowRedisKey: String,
 ) {
-    fun current(): HomeWeatherPayload? {
-        val value = redisTemplate.opsForValue().get(redisKey) ?: return null
+    fun current(): HomeWeatherPayload? = read(redisKey)
+
+    fun shadow(): HomeWeatherPayload? = read(shadowRedisKey)
+
+    private fun read(key: String): HomeWeatherPayload? {
+        val value = redisTemplate.opsForValue().get(key) ?: return null
         return runCatching { objectMapper.readValue(value, HomeWeatherPayload::class.java) }
             .getOrNull()
             ?.takeIf { it.expiresAt.isAfter(ZonedDateTime.now(watchAnalyticsClock)) }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -64,3 +64,4 @@ admin.push.notifier-base-url=${NOTIFIER_BASE_URL:http://127.0.0.1:8081}
 admin.push.notifier-service-token=${NOTIFIER_SERVICE_TOKEN:}
 # Home weather
 weather.home.redis-key=${WEATHER_FORECAST_REDIS_KEY:weather:home:erica}
+weather.home.shadow-redis-key=${WEATHER_FORECAST_SHADOW_REDIS_KEY:weather:home:erica:shadow}

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -19,13 +19,22 @@ type Query {
 type HomeWeather {
     issuedAt: DateTime!
     expiresAt: DateTime!
+    observedAt: DateTime
+    forecastUpdatedAt: DateTime
     currentTemperature: Float
+    currentPrecipitationType: String
+    currentPrecipitationAmount: Float
     minimumTemperature: Float
     maximumTemperature: Float
     precipitationProbabilityMax: Int!
     precipitationStartAt: DateTime
+    precipitationEndAt: DateTime
     precipitationType: String!
+    precipitationConfidence: String
+    availableModelCount: Int
+    agreeingModelCount: Int
     primaryCondition: String!
+    attribution: String
 }
 
 # 공지사항 카테고리와 공지사항을 반환하는 쿼리입니다.

--- a/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewControllerTest.kt
@@ -16,7 +16,7 @@ class AdminOverviewControllerTest {
     fun `controller passes recognized authorities to the service`() {
         val service = mock<AdminOverviewService>()
         val authentication = mock<Authentication>()
-        val response = AdminOverviewResponse("now", emptyList(), null, "grafana")
+        val response = AdminOverviewResponse("now", emptyList(), null, null, "grafana")
         whenever(authentication.authorities).thenReturn(
             listOf(SimpleGrantedAuthority("BUS"), SimpleGrantedAuthority("UNKNOWN")),
         )

--- a/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewModelsTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewModelsTest.kt
@@ -2,6 +2,8 @@ package app.hyuabot.backend.adminoverview
 
 import app.hyuabot.backend.adminoverview.domain.AdminOverviewResponse
 import app.hyuabot.backend.adminoverview.domain.AdminServiceStatus
+import app.hyuabot.backend.adminoverview.domain.AdminWeatherForecastStatus
+import app.hyuabot.backend.adminoverview.domain.AdminWeatherSourceStatus
 import app.hyuabot.backend.adminoverview.domain.CronJobRun
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -11,16 +13,25 @@ class AdminOverviewModelsTest {
     @Test
     fun `overview models expose value semantics`() {
         val status = AdminServiceStatus("id", "title", "NORMAL", "message", "success", "failure", "/path")
-        val overview = AdminOverviewResponse("now", listOf(status), 1, "grafana")
+        val source = AdminWeatherSourceStatus("JMA_MSM", "AVAILABLE")
+        val forecast = AdminWeatherForecastStatus("generated", "observed", 3, 2, "MEDIUM", listOf(source))
+        val overview = AdminOverviewResponse("now", listOf(status), forecast, 1, "grafana")
         val run = CronJobRun("success", "failure")
         val (id, title, state, message, success, failure, path) = status
-        val (checkedAt, services, invitations, grafana) = overview
+        val (checkedAt, services, weather, invitations, grafana) = overview
+        val (generatedAt, observedAt, available, agreeing, confidence, sources) = forecast
+        val (sourceName, sourceStatus) = source
         val (runSuccess, runFailure) = run
         assertEquals(
             listOf("id", "title", "NORMAL", "message", "success", "failure", "/path"),
             listOf(id, title, state, message, success, failure, path),
         )
-        assertEquals(listOf("now", listOf(status), 1, "grafana"), listOf(checkedAt, services, invitations, grafana))
+        assertEquals(listOf("now", listOf(status), forecast, 1, "grafana"), listOf(checkedAt, services, weather, invitations, grafana))
+        assertEquals(
+            listOf("generated", "observed", 3, 2, "MEDIUM", listOf(source)),
+            listOf(generatedAt, observedAt, available, agreeing, confidence, sources),
+        )
+        assertEquals(listOf("JMA_MSM", "AVAILABLE"), listOf(sourceName, sourceStatus))
         assertEquals(listOf("success", "failure"), listOf(runSuccess, runFailure))
         assertEquals("title", status.title)
         assertEquals("success", status.lastSuccessAt)
@@ -29,6 +40,8 @@ class AdminOverviewModelsTest {
         assertEquals("now", overview.checkedAt)
         assertEquals(status, status.copy())
         assertEquals(overview, overview.copy())
+        assertEquals(forecast, forecast.copy())
+        assertEquals(source, source.copy())
         assertEquals(run, run.copy())
         exerciseValue(
             status,
@@ -44,8 +57,26 @@ class AdminOverviewModelsTest {
         )
         exerciseValue(
             overview,
-            overview.copy(checkedAt = "later", services = emptyList(), expiringInvitationCount = null, grafanaURL = "other"),
+            overview.copy(
+                checkedAt = "later",
+                services = emptyList(),
+                weatherForecast = null,
+                expiringInvitationCount = null,
+                grafanaURL = "other",
+            ),
         )
+        exerciseValue(
+            forecast,
+            forecast.copy(
+                generatedAt = "later",
+                observedAt = null,
+                availableModelCount = 1,
+                agreeingModelCount = 0,
+                precipitationConfidence = null,
+                sources = emptyList(),
+            ),
+        )
+        exerciseValue(source, source.copy(source = "GFS_GLOBAL", status = "FAILED"))
         exerciseValue(run, run.copy(lastSuccessAt = null, lastFailureAt = null))
     }
 

--- a/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewServiceTest.kt
@@ -12,6 +12,9 @@ import app.hyuabot.backend.security.AdminPermission
 import app.hyuabot.backend.shuttle.service.ShuttleHolidayService
 import app.hyuabot.backend.shuttle.service.ShuttlePeriodService
 import app.hyuabot.backend.utility.LocalDateTimeBuilder
+import app.hyuabot.backend.weather.HomeWeatherPayload
+import app.hyuabot.backend.weather.HomeWeatherService
+import app.hyuabot.backend.weather.WeatherSourceStatus
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -21,6 +24,7 @@ import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.time.ZonedDateTime
 import java.util.UUID
+import kotlin.test.assertNotNull
 
 class AdminOverviewServiceTest {
     private val prometheusClient = mock<PrometheusClient>()
@@ -28,6 +32,7 @@ class AdminOverviewServiceTest {
     private val holidayService = mock<ShuttleHolidayService>()
     private val holidayAuditService = mock<HolidayAuditService>()
     private val invitationRepository = mock<AdminUserInvitationRepository>()
+    private val homeWeatherService = mock<HomeWeatherService>()
     private val service =
         AdminOverviewService(
             prometheusClient,
@@ -35,6 +40,7 @@ class AdminOverviewServiceTest {
             holidayService,
             holidayAuditService,
             invitationRepository,
+            homeWeatherService,
             "https://grafana.example",
         )
 
@@ -221,16 +227,42 @@ class AdminOverviewServiceTest {
     @Test
     fun `weather status follows notice permission and hourly freshness`() {
         val current = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
+        whenever(homeWeatherService.shadow()).thenReturn(
+            HomeWeatherPayload(
+                issuedAt = current.minusMinutes(10),
+                expiresAt = current.plusHours(1),
+                observedAt = current.minusMinutes(20),
+                forecastUpdatedAt = current.minusMinutes(10),
+                precipitationProbabilityMax = 60,
+                precipitationType = "RAIN",
+                precipitationConfidence = "MEDIUM",
+                availableModelCount = 3,
+                agreeingModelCount = 2,
+                primaryCondition = "RAIN",
+                sources =
+                    listOf(
+                        WeatherSourceStatus("JMA_MSM", "AVAILABLE"),
+                        WeatherSourceStatus("ECMWF_IFS", "AVAILABLE"),
+                        WeatherSourceStatus("GFS_GLOBAL", "AVAILABLE"),
+                    ),
+            ),
+        )
         whenever(prometheusClient.getCronJobRuns()).thenReturn(
             mapOf("weather-cron-job" to CronJobRun(current.minusMinutes(89).toInstant().toString(), null)),
         )
 
-        val normal = service.getOverview(setOf(AdminPermission.NOTICE), current).services.single()
+        val overview = service.getOverview(setOf(AdminPermission.NOTICE), current)
+        val normal = overview.services.single()
+        val diagnostics = assertNotNull(overview.weatherForecast)
 
         assertEquals("weather", normal.id)
         assertEquals("날씨", normal.title)
         assertEquals("NORMAL", normal.status)
         assertEquals("/notice/notice", normal.managementPath)
+        assertEquals(3, diagnostics.availableModelCount)
+        assertEquals(2, diagnostics.agreeingModelCount)
+        assertEquals("MEDIUM", diagnostics.precipitationConfidence)
+        assertEquals("JMA_MSM", diagnostics.sources.first().source)
 
         whenever(prometheusClient.getCronJobRuns()).thenReturn(
             mapOf("weather-cron-job" to CronJobRun(current.minusMinutes(91).toInstant().toString(), null)),
@@ -244,6 +276,30 @@ class AdminOverviewServiceTest {
                 .single()
                 .status,
         )
+    }
+
+    @Test
+    fun `weather diagnostics tolerate missing optional model values`() {
+        val current = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
+        whenever(prometheusClient.getCronJobRuns()).thenReturn(emptyMap())
+        whenever(homeWeatherService.shadow()).thenReturn(
+            HomeWeatherPayload(
+                issuedAt = current.minusMinutes(10),
+                expiresAt = current.plusHours(1),
+                precipitationProbabilityMax = 0,
+                precipitationType = "NONE",
+                primaryCondition = "CLEAR",
+            ),
+        )
+
+        val forecast = assertNotNull(service.getOverview(setOf(AdminPermission.NOTICE), current).weatherForecast)
+
+        assertEquals(current.minusMinutes(10).toString(), forecast.generatedAt)
+        assertNull(forecast.observedAt)
+        assertEquals(0, forecast.availableModelCount)
+        assertEquals(0, forecast.agreeingModelCount)
+        assertEquals(0, forecast.sources.size)
+        assertNull(service.getOverview(setOf(AdminPermission.BUS), current).weatherForecast)
     }
 
     private fun invitation(expiresAt: ZonedDateTime) =

--- a/src/test/kotlin/app/hyuabot/backend/weather/HomeWeatherServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/weather/HomeWeatherServiceTest.kt
@@ -24,6 +24,7 @@ class HomeWeatherServiceTest {
             objectMapper,
             Clock.fixed(now, ZoneOffset.UTC),
             "weather:test",
+            "weather:test:shadow",
         ).also {
             whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
         }
@@ -35,6 +36,15 @@ class HomeWeatherServiceTest {
         whenever(objectMapper.readValue("forecast-json", HomeWeatherPayload::class.java)).thenReturn(forecast)
 
         assertEquals(forecast, service.current())
+    }
+
+    @Test
+    fun `returns an unexpired shadow forecast`() {
+        val forecast = forecast(expiresAt = "2026-07-21T13:00:00+09:00")
+        whenever(valueOperations.get("weather:test:shadow")).thenReturn("shadow-json")
+        whenever(objectMapper.readValue("shadow-json", HomeWeatherPayload::class.java)).thenReturn(forecast)
+
+        assertEquals(forecast, service.shadow())
     }
 
     @Test
@@ -69,6 +79,16 @@ class HomeWeatherServiceTest {
         assertNull(forecast.maximumTemperature)
         assertEquals(0, forecast.precipitationProbabilityMax)
         assertNull(forecast.precipitationStartAt)
+        assertNull(forecast.observedAt)
+        assertNull(forecast.forecastUpdatedAt)
+        assertNull(forecast.currentPrecipitationType)
+        assertNull(forecast.currentPrecipitationAmount)
+        assertNull(forecast.precipitationEndAt)
+        assertNull(forecast.precipitationConfidence)
+        assertNull(forecast.availableModelCount)
+        assertNull(forecast.agreeingModelCount)
+        assertNull(forecast.attribution)
+        assertEquals(emptyList(), forecast.sources)
         assertEquals("NONE", forecast.precipitationType)
         assertEquals("CLEAR", forecast.primaryCondition)
     }


### PR DESCRIPTION
## Summary

- Extend the additive home weather GraphQL contract with observation time, current precipitation, forecast window, confidence, and model-count fields.
- Keep every new payload field optional so the existing KMA v1 Redis payload and older clients remain compatible.
- Read the ensemble shadow payload separately from the active app payload.
- Add shadow forecast freshness and model-source diagnostics to the administrator operations overview.
- Cover the new payload defaults, shadow lookup, administrator visibility, and value models.

## Impact

The backend can be deployed before activating the ensemble. Existing app queries continue to work unchanged, while new clients can distinguish observed current conditions from upcoming precipitation and the administrator dashboard can inspect model availability.

## Validation

- Ran `./gradlew --no-daemon ktlintCheck`.
- Ran focused weather and administrator overview tests (16 passed).
- Confirmed the main and test Kotlin sources compile.
- The full local Spring suite requires the repository PostgreSQL test configuration supplied by CI; unrelated context tests fail locally before reaching application tests when that datasource is absent.
- Ran `git diff --check`.
