### PR TITLE
feat: Add shuttle initial stop rules

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/database/entity/ShuttleInitialStopRule.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/entity/ShuttleInitialStopRule.kt
@@ -1,0 +1,70 @@
+package app.hyuabot.backend.database.entity
+
+import app.hyuabot.backend.shuttle.domain.ShuttleGeoPoint
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import org.hibernate.Hibernate
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.type.SqlTypes
+import java.time.LocalTime
+import java.time.OffsetDateTime
+
+@Entity(name = "shuttle_initial_stop_rule")
+@Table(
+    name = "shuttle_initial_stop_rule",
+    indexes = [
+        Index(
+            name = "idx_shuttle_initial_stop_rule_active",
+            columnList = "enabled, period_type, weekday, priority DESC, seq",
+        ),
+    ],
+)
+@SequenceGenerator(name = "shuttle_initial_stop_rule_seq_seq", allocationSize = 1)
+class ShuttleInitialStopRule(
+    @Id
+    @Column(name = "seq", columnDefinition = "serial")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "shuttle_initial_stop_rule_seq_seq")
+    val seq: Int? = null,
+    @Column(name = "rule_name", length = 80, nullable = false)
+    var name: String,
+    @Column(name = "period_type", length = 20, nullable = false)
+    var periodType: String,
+    @Column(name = "weekday", nullable = false)
+    var weekday: Boolean,
+    @Column(name = "start_time")
+    var startTime: LocalTime?,
+    @Column(name = "end_time")
+    var endTime: LocalTime?,
+    @Column(name = "stop_name", length = 15, nullable = false)
+    var stopName: String,
+    @Column(name = "priority", nullable = false)
+    var priority: Int,
+    @Column(name = "enabled", nullable = false)
+    var enabled: Boolean,
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "polygon", columnDefinition = "jsonb", nullable = false)
+    var polygon: List<ShuttleGeoPoint>,
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: OffsetDateTime? = null,
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: OffsetDateTime? = null,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+        other as ShuttleInitialStopRule
+        return seq != null && seq == other.seq
+    }
+
+    override fun hashCode(): Int = Hibernate.getClass(this).hashCode()
+}

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/ShuttleInitialStopRuleRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/ShuttleInitialStopRuleRepository.kt
@@ -1,0 +1,13 @@
+package app.hyuabot.backend.database.repository
+
+import app.hyuabot.backend.database.entity.ShuttleInitialStopRule
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ShuttleInitialStopRuleRepository : JpaRepository<ShuttleInitialStopRule, Int> {
+    fun findAllByOrderByPriorityDescSeqAsc(): List<ShuttleInitialStopRule>
+
+    fun findByPeriodTypeInAndWeekdayInAndEnabledTrueOrderByPriorityDescSeqAsc(
+        periodTypes: Collection<String>,
+        weekdays: Collection<Boolean>,
+    ): List<ShuttleInitialStopRule>
+}

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleDataFetcher.kt
@@ -2,7 +2,9 @@ package app.hyuabot.backend.shuttle.controller
 
 import app.hyuabot.backend.codegen.types.Shuttle
 import app.hyuabot.backend.codegen.types.ShuttleArrival
+import app.hyuabot.backend.codegen.types.ShuttleGeoPoint
 import app.hyuabot.backend.codegen.types.ShuttleHoliday
+import app.hyuabot.backend.codegen.types.ShuttleInitialStopRule
 import app.hyuabot.backend.codegen.types.ShuttleInput
 import app.hyuabot.backend.codegen.types.ShuttleLimitInput
 import app.hyuabot.backend.codegen.types.ShuttlePeriod
@@ -18,6 +20,7 @@ import app.hyuabot.backend.shuttle.domain.ShuttleTimetableKey
 import app.hyuabot.backend.shuttle.domain.ShuttleTimetableResult
 import app.hyuabot.backend.shuttle.domain.ShuttleTimetableViewItem
 import app.hyuabot.backend.shuttle.service.ShuttleHolidayService
+import app.hyuabot.backend.shuttle.service.ShuttleInitialStopRuleService
 import app.hyuabot.backend.shuttle.service.ShuttlePeriodService
 import app.hyuabot.backend.shuttle.service.ShuttleStopService
 import app.hyuabot.backend.utility.LocalDateTimeBuilder
@@ -27,6 +30,7 @@ import com.netflix.graphql.dgs.DgsDataFetchingEnvironment
 import com.netflix.graphql.dgs.DgsQuery
 import com.netflix.graphql.dgs.InputArgument
 import java.time.LocalDate
+import java.time.LocalTime
 import java.util.concurrent.CompletableFuture
 
 @DgsComponent
@@ -35,6 +39,7 @@ class ShuttleDataFetcher(
     private val publicHolidayService: PublicHolidayService,
     private val periodService: ShuttlePeriodService,
     private val stopService: ShuttleStopService,
+    private val initialStopRuleService: ShuttleInitialStopRuleService,
 ) {
     @DgsQuery
     fun shuttle(
@@ -60,8 +65,39 @@ class ShuttleDataFetcher(
             period = null,
             holiday = null,
             serviceNotices = emptyList(),
+            initialStopRules = emptyList(),
             stops = emptyList(),
         )
+    }
+
+    @DgsData(parentType = "Shuttle")
+    fun initialStopRules(dfe: DgsDataFetchingEnvironment): List<ShuttleInitialStopRule> {
+        val filter = dfe.graphQlContext.get<ShuttleFilterContext>("filter")
+        return initialStopRuleService
+            .getActive(
+                periodTypes = filter.periods,
+                weekdays = filter.weekdays,
+                time = LocalTime.now(LocalDateTimeBuilder.serviceTimezone),
+                isHalt = filter.isHalt,
+            ).map {
+                ShuttleInitialStopRule(
+                    seq = requireNotNull(it.seq),
+                    name = it.name,
+                    periodType = it.periodType,
+                    weekday = it.weekday,
+                    startTime = it.startTime,
+                    endTime = it.endTime,
+                    stopName = it.stopName,
+                    priority = it.priority,
+                    polygon =
+                        it.polygon.map { point ->
+                            ShuttleGeoPoint(
+                                latitude = point.latitude,
+                                longitude = point.longitude,
+                            )
+                        },
+                )
+            }
     }
 
     @DgsData(parentType = "Shuttle")

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleInitialStopRuleController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/controller/ShuttleInitialStopRuleController.kt
@@ -1,0 +1,90 @@
+package app.hyuabot.backend.shuttle.controller
+
+import app.hyuabot.backend.database.entity.ShuttleInitialStopRule
+import app.hyuabot.backend.shuttle.domain.ShuttleInitialStopRuleListResponse
+import app.hyuabot.backend.shuttle.domain.ShuttleInitialStopRuleRequest
+import app.hyuabot.backend.shuttle.domain.ShuttleInitialStopRuleResponse
+import app.hyuabot.backend.shuttle.exception.InvalidShuttleInitialStopRuleException
+import app.hyuabot.backend.shuttle.exception.ShuttleInitialStopRuleNotFoundException
+import app.hyuabot.backend.shuttle.service.ShuttleInitialStopRuleService
+import app.hyuabot.backend.utility.ResponseBuilder
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/shuttle/initial-stop-rule")
+@RestController
+@Tag(name = "Shuttle", description = "셔틀버스 관련 API")
+class ShuttleInitialStopRuleController(
+    private val service: ShuttleInitialStopRuleService,
+) {
+    @GetMapping
+    @Operation(summary = "초기 정류장 규칙 목록 조회")
+    fun getAll(): ShuttleInitialStopRuleListResponse = ShuttleInitialStopRuleListResponse(service.getAll().map { it.toResponse() })
+
+    @GetMapping("/{seq}")
+    @Operation(summary = "초기 정류장 규칙 조회")
+    fun get(
+        @PathVariable seq: Int,
+    ): ShuttleInitialStopRuleResponse = service.get(seq).toResponse()
+
+    @PostMapping
+    @Operation(summary = "초기 정류장 규칙 생성")
+    fun create(
+        @RequestBody request: ShuttleInitialStopRuleRequest,
+    ): ResponseEntity<ShuttleInitialStopRuleResponse> = ResponseEntity.status(HttpStatus.CREATED).body(service.create(request).toResponse())
+
+    @PutMapping("/{seq}")
+    @Operation(summary = "초기 정류장 규칙 수정")
+    fun update(
+        @PathVariable seq: Int,
+        @RequestBody request: ShuttleInitialStopRuleRequest,
+    ): ShuttleInitialStopRuleResponse = service.update(seq, request).toResponse()
+
+    @DeleteMapping("/{seq}")
+    @Operation(summary = "초기 정류장 규칙 삭제")
+    fun delete(
+        @PathVariable seq: Int,
+    ): ResponseEntity<Void> {
+        service.delete(seq)
+        return ResponseEntity.noContent().build()
+    }
+
+    @ExceptionHandler(ShuttleInitialStopRuleNotFoundException::class)
+    fun handleNotFound(): ResponseEntity<ResponseBuilder.Message> =
+        ResponseBuilder.response(
+            HttpStatus.NOT_FOUND,
+            ResponseBuilder.Message("SHUTTLE_INITIAL_STOP_RULE_NOT_FOUND"),
+        )
+
+    @ExceptionHandler(InvalidShuttleInitialStopRuleException::class)
+    fun handleInvalid(): ResponseEntity<ResponseBuilder.Message> =
+        ResponseBuilder.response(
+            HttpStatus.BAD_REQUEST,
+            ResponseBuilder.Message("INVALID_SHUTTLE_INITIAL_STOP_RULE"),
+        )
+
+    private fun ShuttleInitialStopRule.toResponse() =
+        ShuttleInitialStopRuleResponse(
+            seq = requireNotNull(seq),
+            name = name,
+            periodType = periodType,
+            weekday = weekday,
+            startTime = startTime,
+            endTime = endTime,
+            stopName = stopName,
+            priority = priority,
+            enabled = enabled,
+            polygon = polygon,
+        )
+}

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/domain/ShuttleInitialStopRuleModels.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/domain/ShuttleInitialStopRuleModels.kt
@@ -1,0 +1,49 @@
+package app.hyuabot.backend.shuttle.domain
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalTime
+
+data class ShuttleGeoPoint(
+    @get:Schema(description = "위도", example = "37.2964")
+    val latitude: Double,
+    @get:Schema(description = "경도", example = "126.8352")
+    val longitude: Double,
+)
+
+data class ShuttleInitialStopRuleRequest(
+    @get:Schema(description = "관리자용 규칙 이름", example = "ERICA 캠퍼스 평일 오전")
+    val name: String,
+    @get:Schema(description = "학기 유형", example = "semester")
+    val periodType: String,
+    @get:Schema(description = "평일 시간표 적용 여부", example = "true")
+    val weekday: Boolean,
+    @get:Schema(description = "적용 시작 시간. 종료 시간과 함께 비우면 종일", example = "07:00:00")
+    val startTime: LocalTime?,
+    @get:Schema(description = "적용 종료 시간. 시작 시간보다 이르면 자정을 넘김", example = "10:00:00")
+    val endTime: LocalTime?,
+    @get:Schema(description = "초기 정류장 이름", example = "dormitory_o")
+    val stopName: String,
+    @get:Schema(description = "높을수록 먼저 평가하는 우선순위", example = "100")
+    val priority: Int,
+    @get:Schema(description = "규칙 활성 여부", example = "true")
+    val enabled: Boolean,
+    @get:Schema(description = "Geofence 다각형 꼭짓점")
+    val polygon: List<ShuttleGeoPoint>,
+)
+
+data class ShuttleInitialStopRuleResponse(
+    val seq: Int,
+    val name: String,
+    val periodType: String,
+    val weekday: Boolean,
+    val startTime: LocalTime?,
+    val endTime: LocalTime?,
+    val stopName: String,
+    val priority: Int,
+    val enabled: Boolean,
+    val polygon: List<ShuttleGeoPoint>,
+)
+
+data class ShuttleInitialStopRuleListResponse(
+    val result: List<ShuttleInitialStopRuleResponse>,
+)

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/exception/ShuttleInitialStopRuleExceptions.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/exception/ShuttleInitialStopRuleExceptions.kt
@@ -1,0 +1,7 @@
+package app.hyuabot.backend.shuttle.exception
+
+class ShuttleInitialStopRuleNotFoundException : RuntimeException()
+
+class InvalidShuttleInitialStopRuleException(
+    message: String,
+) : IllegalArgumentException(message)

--- a/src/main/kotlin/app/hyuabot/backend/shuttle/service/ShuttleInitialStopRuleService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/shuttle/service/ShuttleInitialStopRuleService.kt
@@ -1,0 +1,175 @@
+package app.hyuabot.backend.shuttle.service
+
+import app.hyuabot.backend.database.entity.ShuttleInitialStopRule
+import app.hyuabot.backend.database.repository.ShuttleInitialStopRuleRepository
+import app.hyuabot.backend.database.repository.ShuttlePeriodTypeRepository
+import app.hyuabot.backend.database.repository.ShuttleStopRepository
+import app.hyuabot.backend.shuttle.domain.ShuttleGeoPoint
+import app.hyuabot.backend.shuttle.domain.ShuttleInitialStopRuleRequest
+import app.hyuabot.backend.shuttle.exception.InvalidShuttleInitialStopRuleException
+import app.hyuabot.backend.shuttle.exception.ShuttleInitialStopRuleNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalTime
+import kotlin.math.abs
+
+@Service
+class ShuttleInitialStopRuleService(
+    private val repository: ShuttleInitialStopRuleRepository,
+    private val periodTypeRepository: ShuttlePeriodTypeRepository,
+    private val stopRepository: ShuttleStopRepository,
+) {
+    fun getAll(): List<ShuttleInitialStopRule> = repository.findAllByOrderByPriorityDescSeqAsc()
+
+    fun get(seq: Int): ShuttleInitialStopRule = repository.findById(seq).orElseThrow { ShuttleInitialStopRuleNotFoundException() }
+
+    @Transactional
+    fun create(request: ShuttleInitialStopRuleRequest): ShuttleInitialStopRule {
+        validate(request)
+        return repository.save(
+            ShuttleInitialStopRule(
+                name = request.name.trim(),
+                periodType = request.periodType,
+                weekday = request.weekday,
+                startTime = request.startTime,
+                endTime = request.endTime,
+                stopName = request.stopName,
+                priority = request.priority,
+                enabled = request.enabled,
+                polygon = request.polygon,
+            ),
+        )
+    }
+
+    @Transactional
+    fun update(
+        seq: Int,
+        request: ShuttleInitialStopRuleRequest,
+    ): ShuttleInitialStopRule {
+        validate(request)
+        val rule = get(seq)
+        rule.name = request.name.trim()
+        rule.periodType = request.periodType
+        rule.weekday = request.weekday
+        rule.startTime = request.startTime
+        rule.endTime = request.endTime
+        rule.stopName = request.stopName
+        rule.priority = request.priority
+        rule.enabled = request.enabled
+        rule.polygon = request.polygon
+        return repository.save(rule)
+    }
+
+    @Transactional
+    fun delete(seq: Int) {
+        repository.delete(get(seq))
+    }
+
+    fun getActive(
+        periodTypes: Collection<String>,
+        weekdays: Collection<Boolean>,
+        time: LocalTime,
+        isHalt: Boolean,
+    ): List<ShuttleInitialStopRule> {
+        if (isHalt || periodTypes.isEmpty() || weekdays.isEmpty()) return emptyList()
+        return repository
+            .findByPeriodTypeInAndWeekdayInAndEnabledTrueOrderByPriorityDescSeqAsc(periodTypes, weekdays)
+            .filter { isActiveAt(it, time) }
+    }
+
+    internal fun isActiveAt(
+        rule: ShuttleInitialStopRule,
+        time: LocalTime,
+    ): Boolean {
+        val start = rule.startTime ?: return true
+        val end = rule.endTime ?: return true
+        return if (start < end) {
+            time >= start && time < end
+        } else {
+            time >= start || time < end
+        }
+    }
+
+    private fun validate(request: ShuttleInitialStopRuleRequest) {
+        if (request.name.isBlank() || request.name.trim().length > 80) {
+            throw InvalidShuttleInitialStopRuleException("Rule name must contain 1 to 80 characters")
+        }
+        if (!periodTypeRepository.existsById(request.periodType)) {
+            throw InvalidShuttleInitialStopRuleException("Unknown shuttle period type")
+        }
+        if (!stopRepository.existsById(request.stopName)) {
+            throw InvalidShuttleInitialStopRuleException("Unknown shuttle stop")
+        }
+        if (
+            (request.startTime == null) != (request.endTime == null) ||
+            (request.startTime != null && request.startTime == request.endTime)
+        ) {
+            throw InvalidShuttleInitialStopRuleException("Start and end time must both be empty or distinct")
+        }
+        validatePolygon(request.polygon)
+    }
+
+    private fun validatePolygon(polygon: List<ShuttleGeoPoint>) {
+        if (polygon.size !in 3..MAX_POLYGON_VERTICES) {
+            throw InvalidShuttleInitialStopRuleException("Polygon must contain 3 to $MAX_POLYGON_VERTICES vertices")
+        }
+        if (polygon.any { it.latitude !in -90.0..90.0 || it.longitude !in -180.0..180.0 }) {
+            throw InvalidShuttleInitialStopRuleException("Polygon contains an invalid coordinate")
+        }
+        if (polygon.distinct().size < 3 || abs(signedArea(polygon)) < MIN_POLYGON_AREA) {
+            throw InvalidShuttleInitialStopRuleException("Polygon must have a non-zero area")
+        }
+        if (hasSelfIntersection(polygon)) {
+            throw InvalidShuttleInitialStopRuleException("Polygon must not intersect itself")
+        }
+    }
+
+    private fun signedArea(polygon: List<ShuttleGeoPoint>): Double =
+        polygon.indices.sumOf { index ->
+            val current = polygon[index]
+            val next = polygon[(index + 1) % polygon.size]
+            current.longitude * next.latitude - next.longitude * current.latitude
+        } / 2.0
+
+    private fun hasSelfIntersection(polygon: List<ShuttleGeoPoint>): Boolean =
+        polygon.indices.any { first ->
+            polygon.indices.any { second ->
+                if (first == second || (first + 1) % polygon.size == second || first == (second + 1) % polygon.size) {
+                    false
+                } else {
+                    segmentsIntersect(
+                        polygon[first],
+                        polygon[(first + 1) % polygon.size],
+                        polygon[second],
+                        polygon[(second + 1) % polygon.size],
+                    )
+                }
+            }
+        }
+
+    private fun segmentsIntersect(
+        a: ShuttleGeoPoint,
+        b: ShuttleGeoPoint,
+        c: ShuttleGeoPoint,
+        d: ShuttleGeoPoint,
+    ): Boolean {
+        val abC = cross(a, b, c)
+        val abD = cross(a, b, d)
+        val cdA = cross(c, d, a)
+        val cdB = cross(c, d, b)
+        return abC * abD < 0 && cdA * cdB < 0
+    }
+
+    private fun cross(
+        a: ShuttleGeoPoint,
+        b: ShuttleGeoPoint,
+        c: ShuttleGeoPoint,
+    ): Double =
+        (b.longitude - a.longitude) * (c.latitude - a.latitude) -
+            (b.latitude - a.latitude) * (c.longitude - a.longitude)
+
+    companion object {
+        private const val MAX_POLYGON_VERTICES = 100
+        private const val MIN_POLYGON_AREA = 1e-12
+    }
+}

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -407,7 +407,25 @@ type Shuttle {
     period: ShuttlePeriod
     holiday: ShuttleHoliday
     serviceNotices(start: Date!, end: Date!): [ShuttleServiceNotice!]!
+    initialStopRules: [ShuttleInitialStopRule!]!
     stops: [ShuttleStop!]!
+}
+
+type ShuttleInitialStopRule {
+    seq: Int!
+    name: String!
+    periodType: String!
+    weekday: Boolean!
+    startTime: LocalTime
+    endTime: LocalTime
+    stopName: String!
+    priority: Int!
+    polygon: [ShuttleGeoPoint!]!
+}
+
+type ShuttleGeoPoint {
+    latitude: Float!
+    longitude: Float!
 }
 
 type ShuttleServiceNotice {

--- a/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewModelsTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewModelsTest.kt
@@ -34,6 +34,8 @@ class AdminOverviewModelsTest {
         assertEquals(listOf("JMA_MSM", "AVAILABLE"), listOf(sourceName, sourceStatus))
         assertEquals(listOf("success", "failure"), listOf(runSuccess, runFailure))
         assertEquals("title", status.title)
+        assertEquals("JMA_MSM", source.source)
+        assertEquals("AVAILABLE", source.status)
         assertEquals("success", status.lastSuccessAt)
         assertEquals("failure", status.lastFailureAt)
         assertEquals("/path", status.managementPath)

--- a/src/test/kotlin/app/hyuabot/backend/database/entity/ShuttleInitialStopRuleTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/database/entity/ShuttleInitialStopRuleTest.kt
@@ -1,0 +1,48 @@
+package app.hyuabot.backend.database.entity
+
+import app.hyuabot.backend.shuttle.domain.ShuttleGeoPoint
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ShuttleInitialStopRuleTest {
+    private fun create(seq: Int? = 1) =
+        ShuttleInitialStopRule(
+            seq = seq,
+            name = "Campus",
+            periodType = "semester",
+            weekday = true,
+            startTime = null,
+            endTime = null,
+            stopName = "station",
+            priority = 1,
+            enabled = true,
+            polygon =
+                listOf(
+                    ShuttleGeoPoint(0.0, 0.0),
+                    ShuttleGeoPoint(1.0, 0.0),
+                    ShuttleGeoPoint(0.0, 1.0),
+                ),
+            createdAt = OffsetDateTime.parse("2026-01-01T00:00:00+09:00"),
+            updatedAt = OffsetDateTime.parse("2026-01-02T00:00:00+09:00"),
+        )
+
+    @Test
+    fun equalsAndHashCode() {
+        ShuttleInitialStopRule::class.java.getDeclaredConstructor().newInstance()
+        val value = create()
+        assertEquals(OffsetDateTime.parse("2026-01-01T00:00:00+09:00"), value.createdAt)
+        value.createdAt = OffsetDateTime.parse("2026-01-03T00:00:00+09:00")
+        assertEquals(OffsetDateTime.parse("2026-01-02T00:00:00+09:00"), value.updatedAt)
+        value.updatedAt = OffsetDateTime.parse("2026-01-04T00:00:00+09:00")
+        assertTrue(value == value)
+        assertFalse(value.equals(null))
+        assertFalse(value.equals(Any()))
+        assertEquals(value, create())
+        assertEquals(value.hashCode(), create().hashCode())
+        assertFalse(value == create(2))
+        assertFalse(create(null) == create(null))
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleDataFetcherTest.kt
@@ -3,17 +3,20 @@ package app.hyuabot.backend.shuttle
 import app.hyuabot.backend.codegen.types.ShuttleLimitInput
 import app.hyuabot.backend.database.entity.PublicHoliday
 import app.hyuabot.backend.database.entity.ShuttleHoliday
+import app.hyuabot.backend.database.entity.ShuttleInitialStopRule
 import app.hyuabot.backend.database.entity.ShuttlePeriod
 import app.hyuabot.backend.database.entity.ShuttleStop
 import app.hyuabot.backend.holiday.service.PublicHolidayService
 import app.hyuabot.backend.shuttle.controller.ShuttleDataFetcher
 import app.hyuabot.backend.shuttle.controller.ShuttleTimetableDataLoader
 import app.hyuabot.backend.shuttle.domain.ShuttleArrivalItem
+import app.hyuabot.backend.shuttle.domain.ShuttleGeoPoint
 import app.hyuabot.backend.shuttle.domain.ShuttleHolidayOccurrence
 import app.hyuabot.backend.shuttle.domain.ShuttleTimetableKey
 import app.hyuabot.backend.shuttle.domain.ShuttleTimetableResult
 import app.hyuabot.backend.shuttle.domain.ShuttleTimetableViewItem
 import app.hyuabot.backend.shuttle.service.ShuttleHolidayService
+import app.hyuabot.backend.shuttle.service.ShuttleInitialStopRuleService
 import app.hyuabot.backend.shuttle.service.ShuttlePeriodService
 import app.hyuabot.backend.shuttle.service.ShuttleStopService
 import app.hyuabot.backend.shuttle.service.ShuttleTimetableService
@@ -27,6 +30,7 @@ import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
@@ -51,6 +55,8 @@ class ShuttleDataFetcherTest {
     @MockitoBean lateinit var periodService: ShuttlePeriodService
 
     @MockitoBean lateinit var stopService: ShuttleStopService
+
+    @MockitoBean lateinit var initialStopRuleService: ShuttleInitialStopRuleService
 
     @MockitoBean lateinit var timetableService: ShuttleTimetableService
 
@@ -95,6 +101,58 @@ class ShuttleDataFetcherTest {
         routeToStart = mutableListOf(),
         routeToEnd = mutableListOf(),
     )
+
+    @Test
+    @DisplayName("셔틀버스 초기 정류장 규칙 조회")
+    fun testInitialStopRules() {
+        whenever(
+            initialStopRuleService.getActive(
+                periodTypes = eq(listOf("semester")),
+                weekdays = eq(listOf(true)),
+                time = any(),
+                isHalt = eq(false),
+            ),
+        ).thenReturn(
+            listOf(
+                ShuttleInitialStopRule(
+                    seq = 1,
+                    name = "Campus morning",
+                    periodType = "semester",
+                    weekday = true,
+                    startTime = LocalTime.of(7, 0),
+                    endTime = LocalTime.of(10, 0),
+                    stopName = "station",
+                    priority = 100,
+                    enabled = true,
+                    polygon =
+                        listOf(
+                            ShuttleGeoPoint(37.29, 126.83),
+                            ShuttleGeoPoint(37.30, 126.83),
+                            ShuttleGeoPoint(37.30, 126.84),
+                        ),
+                ),
+            ),
+        )
+
+        val result =
+            dgsQueryExecutor.executeAndExtractJsonPath<Map<String, Any>>(
+                """
+                {
+                    shuttle(input: { periods: ["semester"], weekdays: [true] }) {
+                        initialStopRules {
+                            seq name periodType weekday startTime endTime stopName priority
+                            polygon { latitude longitude }
+                        }
+                    }
+                }
+                """.trimIndent(),
+                "data.shuttle.initialStopRules[0]",
+            )
+
+        assertEquals("Campus morning", result["name"])
+        assertEquals("station", result["stopName"])
+        assertEquals(3, (result["polygon"] as List<*>).size)
+    }
 
     private fun createTimetableView(
         seq: Int = 1,

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleDataFetcherTest.kt
@@ -24,6 +24,7 @@ import app.hyuabot.backend.utility.ScalarRegistration
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.test.EnableDgsTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
@@ -152,6 +153,44 @@ class ShuttleDataFetcherTest {
         assertEquals("Campus morning", result["name"])
         assertEquals("station", result["stopName"])
         assertEquals(3, (result["polygon"] as List<*>).size)
+
+        whenever(
+            initialStopRuleService.getActive(
+                periodTypes = eq(listOf("semester")),
+                weekdays = eq(listOf(true)),
+                time = any(),
+                isHalt = eq(false),
+            ),
+        ).thenReturn(
+            listOf(
+                ShuttleInitialStopRule(
+                    seq = null,
+                    name = "Invalid rule",
+                    periodType = "semester",
+                    weekday = true,
+                    startTime = null,
+                    endTime = null,
+                    stopName = "station",
+                    priority = 0,
+                    enabled = true,
+                    polygon = emptyList(),
+                ),
+            ),
+        )
+
+        assertTrue(
+            dgsQueryExecutor
+                .execute(
+                    """
+                    {
+                        shuttle(input: { periods: ["semester"], weekdays: [true] }) {
+                            initialStopRules { seq }
+                        }
+                    }
+                    """.trimIndent(),
+                ).errors
+                .isNotEmpty(),
+        )
     }
 
     private fun createTimetableView(

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleInitialStopRuleControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleInitialStopRuleControllerTest.kt
@@ -1,0 +1,88 @@
+package app.hyuabot.backend.shuttle
+
+import app.hyuabot.backend.database.entity.ShuttleInitialStopRule
+import app.hyuabot.backend.shuttle.controller.ShuttleInitialStopRuleController
+import app.hyuabot.backend.shuttle.domain.ShuttleGeoPoint
+import app.hyuabot.backend.shuttle.domain.ShuttleInitialStopRuleRequest
+import app.hyuabot.backend.shuttle.service.ShuttleInitialStopRuleService
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import java.time.LocalTime
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class ShuttleInitialStopRuleControllerTest {
+    @Mock lateinit var service: ShuttleInitialStopRuleService
+
+    private val polygon =
+        listOf(
+            ShuttleGeoPoint(37.29, 126.83),
+            ShuttleGeoPoint(37.30, 126.83),
+            ShuttleGeoPoint(37.30, 126.84),
+        )
+
+    private val request =
+        ShuttleInitialStopRuleRequest(
+            name = "Campus morning",
+            periodType = "semester",
+            weekday = true,
+            startTime = LocalTime.of(7, 0),
+            endTime = LocalTime.of(10, 0),
+            stopName = "station",
+            priority = 100,
+            enabled = true,
+            polygon = polygon,
+        )
+
+    private val rule =
+        ShuttleInitialStopRule(
+            seq = 1,
+            name = request.name,
+            periodType = request.periodType,
+            weekday = request.weekday,
+            startTime = request.startTime,
+            endTime = request.endTime,
+            stopName = request.stopName,
+            priority = request.priority,
+            enabled = request.enabled,
+            polygon = request.polygon,
+        )
+
+    @Test
+    fun crudAndExceptionHandlers() {
+        val controller = ShuttleInitialStopRuleController(service)
+        whenever(service.getAll()).thenReturn(listOf(rule))
+        whenever(service.get(1)).thenReturn(rule)
+        whenever(service.create(request)).thenReturn(rule)
+        whenever(service.update(1, request)).thenReturn(rule)
+        doNothing().whenever(service).delete(1)
+
+        assertEquals(
+            "Campus morning",
+            controller
+                .getAll()
+                .result
+                .single()
+                .name,
+        )
+        assertEquals("station", controller.get(1).stopName)
+        assertEquals(HttpStatus.CREATED, controller.create(request).statusCode)
+        assertEquals(100, controller.update(1, request).priority)
+        assertEquals(HttpStatus.NO_CONTENT, controller.delete(1).statusCode)
+        assertEquals(HttpStatus.NOT_FOUND, controller.handleNotFound().statusCode)
+        assertEquals(
+            "SHUTTLE_INITIAL_STOP_RULE_NOT_FOUND",
+            controller.handleNotFound().body?.message,
+        )
+        assertEquals(HttpStatus.BAD_REQUEST, controller.handleInvalid().statusCode)
+        assertEquals(
+            "INVALID_SHUTTLE_INITIAL_STOP_RULE",
+            controller.handleInvalid().body?.message,
+        )
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleInitialStopRuleControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleInitialStopRuleControllerTest.kt
@@ -6,6 +6,7 @@ import app.hyuabot.backend.shuttle.domain.ShuttleGeoPoint
 import app.hyuabot.backend.shuttle.domain.ShuttleInitialStopRuleRequest
 import app.hyuabot.backend.shuttle.service.ShuttleInitialStopRuleService
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
@@ -70,7 +71,15 @@ class ShuttleInitialStopRuleControllerTest {
                 .single()
                 .name,
         )
-        assertEquals("station", controller.get(1).stopName)
+        val response = controller.get(1)
+        assertEquals(1, response.seq)
+        assertEquals("semester", response.periodType)
+        assertEquals(true, response.weekday)
+        assertEquals(LocalTime.of(7, 0), response.startTime)
+        assertEquals(LocalTime.of(10, 0), response.endTime)
+        assertEquals("station", response.stopName)
+        assertEquals(true, response.enabled)
+        assertEquals(polygon, response.polygon)
         assertEquals(HttpStatus.CREATED, controller.create(request).statusCode)
         assertEquals(100, controller.update(1, request).priority)
         assertEquals(HttpStatus.NO_CONTENT, controller.delete(1).statusCode)
@@ -84,5 +93,21 @@ class ShuttleInitialStopRuleControllerTest {
             "INVALID_SHUTTLE_INITIAL_STOP_RULE",
             controller.handleInvalid().body?.message,
         )
+
+        whenever(service.get(2)).thenReturn(
+            ShuttleInitialStopRule(
+                seq = null,
+                name = rule.name,
+                periodType = rule.periodType,
+                weekday = rule.weekday,
+                startTime = rule.startTime,
+                endTime = rule.endTime,
+                stopName = rule.stopName,
+                priority = rule.priority,
+                enabled = rule.enabled,
+                polygon = rule.polygon,
+            ),
+        )
+        assertThrows<IllegalArgumentException> { controller.get(2) }
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleInitialStopRuleServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleInitialStopRuleServiceTest.kt
@@ -1,0 +1,187 @@
+package app.hyuabot.backend.shuttle
+
+import app.hyuabot.backend.database.entity.ShuttleInitialStopRule
+import app.hyuabot.backend.database.repository.ShuttleInitialStopRuleRepository
+import app.hyuabot.backend.database.repository.ShuttlePeriodTypeRepository
+import app.hyuabot.backend.database.repository.ShuttleStopRepository
+import app.hyuabot.backend.shuttle.domain.ShuttleGeoPoint
+import app.hyuabot.backend.shuttle.domain.ShuttleInitialStopRuleRequest
+import app.hyuabot.backend.shuttle.exception.InvalidShuttleInitialStopRuleException
+import app.hyuabot.backend.shuttle.exception.ShuttleInitialStopRuleNotFoundException
+import app.hyuabot.backend.shuttle.service.ShuttleInitialStopRuleService
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalTime
+import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@ExtendWith(MockitoExtension::class)
+class ShuttleInitialStopRuleServiceTest {
+    @Mock lateinit var repository: ShuttleInitialStopRuleRepository
+
+    @Mock lateinit var periodTypeRepository: ShuttlePeriodTypeRepository
+
+    @Mock lateinit var stopRepository: ShuttleStopRepository
+
+    @InjectMocks lateinit var service: ShuttleInitialStopRuleService
+
+    private val triangle =
+        listOf(
+            ShuttleGeoPoint(37.29, 126.83),
+            ShuttleGeoPoint(37.30, 126.83),
+            ShuttleGeoPoint(37.30, 126.84),
+        )
+
+    private fun request(
+        name: String = " Campus ",
+        periodType: String = "semester",
+        stopName: String = "station",
+        startTime: LocalTime? = null,
+        endTime: LocalTime? = null,
+        polygon: List<ShuttleGeoPoint> = triangle,
+    ) = ShuttleInitialStopRuleRequest(
+        name = name,
+        periodType = periodType,
+        weekday = true,
+        startTime = startTime,
+        endTime = endTime,
+        stopName = stopName,
+        priority = 100,
+        enabled = true,
+        polygon = polygon,
+    )
+
+    private fun rule(
+        seq: Int? = 1,
+        startTime: LocalTime? = null,
+        endTime: LocalTime? = null,
+    ) = ShuttleInitialStopRule(
+        seq = seq,
+        name = "Campus",
+        periodType = "semester",
+        weekday = true,
+        startTime = startTime,
+        endTime = endTime,
+        stopName = "station",
+        priority = 100,
+        enabled = true,
+        polygon = triangle,
+    )
+
+    private fun allowReferences() {
+        whenever(periodTypeRepository.existsById("semester")).thenReturn(true)
+        whenever(stopRepository.existsById("station")).thenReturn(true)
+    }
+
+    @Test
+    fun crud() {
+        val existing = rule()
+        whenever(repository.findAllByOrderByPriorityDescSeqAsc()).thenReturn(listOf(existing))
+        whenever(repository.findById(1)).thenReturn(Optional.of(existing))
+        whenever(repository.save(any<ShuttleInitialStopRule>())).thenAnswer { it.arguments[0] }
+        allowReferences()
+
+        assertEquals(listOf(existing), service.getAll())
+        assertEquals(existing, service.get(1))
+        assertEquals("Campus", service.create(request()).name)
+
+        val updated = service.update(1, request(name = " Updated "))
+        assertEquals("Updated", updated.name)
+        service.delete(1)
+        verify(repository).delete(existing)
+    }
+
+    @Test
+    fun notFound() {
+        whenever(repository.findById(404)).thenReturn(Optional.empty())
+        assertThrows<ShuttleInitialStopRuleNotFoundException> { service.get(404) }
+    }
+
+    @Test
+    fun activeRulesAndTimeRanges() {
+        val allDay = rule(seq = 1)
+        val morning = rule(seq = 2, startTime = LocalTime.of(7, 0), endTime = LocalTime.of(10, 0))
+        val overnight = rule(seq = 3, startTime = LocalTime.of(22, 0), endTime = LocalTime.of(2, 0))
+        val incomplete = rule(seq = 4, startTime = LocalTime.of(7, 0))
+        whenever(
+            repository.findByPeriodTypeInAndWeekdayInAndEnabledTrueOrderByPriorityDescSeqAsc(
+                listOf("semester"),
+                listOf(true),
+            ),
+        ).thenReturn(listOf(allDay, morning, overnight))
+
+        assertEquals(2, service.getActive(listOf("semester"), listOf(true), LocalTime.of(8, 0), false).size)
+        assertEquals(2, service.getActive(listOf("semester"), listOf(true), LocalTime.of(23, 0), false).size)
+        assertTrue(service.isActiveAt(overnight, LocalTime.of(1, 59)))
+        assertFalse(service.isActiveAt(overnight, LocalTime.of(2, 0)))
+        assertTrue(service.isActiveAt(incomplete, LocalTime.NOON))
+        assertTrue(service.getActive(emptyList(), listOf(true), LocalTime.NOON, false).isEmpty())
+        assertTrue(service.getActive(listOf("semester"), emptyList(), LocalTime.NOON, false).isEmpty())
+        assertTrue(service.getActive(listOf("semester"), listOf(true), LocalTime.NOON, true).isEmpty())
+    }
+
+    @Test
+    fun rejectsInvalidFields() {
+        assertInvalid(request(name = " "))
+        assertInvalid(request(name = "x".repeat(81)))
+        assertInvalid(request(periodType = "unknown"))
+
+        whenever(periodTypeRepository.existsById("semester")).thenReturn(true)
+        assertInvalid(request(stopName = "unknown"))
+
+        whenever(stopRepository.existsById("station")).thenReturn(true)
+        assertInvalid(request(startTime = LocalTime.NOON))
+        assertInvalid(request(startTime = LocalTime.NOON, endTime = LocalTime.NOON))
+    }
+
+    @Test
+    fun rejectsInvalidPolygons() {
+        allowReferences()
+        assertInvalid(request(polygon = triangle.take(2)))
+        assertInvalid(request(polygon = List(101) { index -> ShuttleGeoPoint(37.0 + index * 0.0001, 126.0) }))
+        assertInvalid(
+            request(
+                polygon =
+                    listOf(
+                        ShuttleGeoPoint(91.0, 126.0),
+                        ShuttleGeoPoint(37.0, 126.0),
+                        ShuttleGeoPoint(38.0, 127.0),
+                    ),
+            ),
+        )
+        assertInvalid(
+            request(
+                polygon =
+                    listOf(
+                        ShuttleGeoPoint(37.0, 126.0),
+                        ShuttleGeoPoint(37.0, 126.0),
+                        ShuttleGeoPoint(37.0, 126.0),
+                    ),
+            ),
+        )
+        assertInvalid(
+            request(
+                polygon =
+                    listOf(
+                        ShuttleGeoPoint(0.0, 0.0),
+                        ShuttleGeoPoint(2.0, 2.0),
+                        ShuttleGeoPoint(0.0, 2.0),
+                        ShuttleGeoPoint(1.0, 0.0),
+                    ),
+            ),
+        )
+    }
+
+    private fun assertInvalid(request: ShuttleInitialStopRuleRequest) {
+        assertThrows<InvalidShuttleInitialStopRuleException> { service.create(request) }
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleInitialStopRuleServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/shuttle/ShuttleInitialStopRuleServiceTest.kt
@@ -121,12 +121,30 @@ class ShuttleInitialStopRuleServiceTest {
 
         assertEquals(2, service.getActive(listOf("semester"), listOf(true), LocalTime.of(8, 0), false).size)
         assertEquals(2, service.getActive(listOf("semester"), listOf(true), LocalTime.of(23, 0), false).size)
+        assertFalse(service.isActiveAt(morning, LocalTime.of(6, 59)))
         assertTrue(service.isActiveAt(overnight, LocalTime.of(1, 59)))
         assertFalse(service.isActiveAt(overnight, LocalTime.of(2, 0)))
         assertTrue(service.isActiveAt(incomplete, LocalTime.NOON))
         assertTrue(service.getActive(emptyList(), listOf(true), LocalTime.NOON, false).isEmpty())
         assertTrue(service.getActive(listOf("semester"), emptyList(), LocalTime.NOON, false).isEmpty())
         assertTrue(service.getActive(listOf("semester"), listOf(true), LocalTime.NOON, true).isEmpty())
+    }
+
+    @Test
+    fun acceptsDistinctTimeRange() {
+        allowReferences()
+        whenever(repository.save(any<ShuttleInitialStopRule>())).thenAnswer { it.arguments[0] }
+
+        val created =
+            service.create(
+                request(
+                    startTime = LocalTime.of(7, 0),
+                    endTime = LocalTime.of(10, 0),
+                ),
+            )
+
+        assertEquals(LocalTime.of(7, 0), created.startTime)
+        assertEquals(LocalTime.of(10, 0), created.endTime)
     }
 
     @Test
@@ -146,6 +164,7 @@ class ShuttleInitialStopRuleServiceTest {
     @Test
     fun rejectsInvalidPolygons() {
         allowReferences()
+        whenever(repository.save(any<ShuttleInitialStopRule>())).thenAnswer { it.arguments[0] }
         assertInvalid(request(polygon = triangle.take(2)))
         assertInvalid(request(polygon = List(101) { index -> ShuttleGeoPoint(37.0 + index * 0.0001, 126.0) }))
         assertInvalid(
@@ -153,6 +172,16 @@ class ShuttleInitialStopRuleServiceTest {
                 polygon =
                     listOf(
                         ShuttleGeoPoint(91.0, 126.0),
+                        ShuttleGeoPoint(37.0, 126.0),
+                        ShuttleGeoPoint(38.0, 127.0),
+                    ),
+            ),
+        )
+        assertInvalid(
+            request(
+                polygon =
+                    listOf(
+                        ShuttleGeoPoint(-91.0, 126.0),
                         ShuttleGeoPoint(37.0, 126.0),
                         ShuttleGeoPoint(38.0, 127.0),
                     ),
@@ -176,6 +205,47 @@ class ShuttleInitialStopRuleServiceTest {
                         ShuttleGeoPoint(2.0, 2.0),
                         ShuttleGeoPoint(0.0, 2.0),
                         ShuttleGeoPoint(1.0, 0.0),
+                    ),
+            ),
+        )
+        assertInvalid(
+            request(
+                polygon =
+                    listOf(
+                        ShuttleGeoPoint(0.0, 0.0),
+                        ShuttleGeoPoint(1.0, 1.0),
+                        ShuttleGeoPoint(2.0, 2.0),
+                    ),
+            ),
+        )
+        assertInvalid(
+            request(
+                polygon =
+                    listOf(
+                        ShuttleGeoPoint(37.0, 181.0),
+                        ShuttleGeoPoint(38.0, 126.0),
+                        ShuttleGeoPoint(39.0, 127.0),
+                    ),
+            ),
+        )
+        assertInvalid(
+            request(
+                polygon =
+                    listOf(
+                        ShuttleGeoPoint(37.0, -181.0),
+                        ShuttleGeoPoint(38.0, 126.0),
+                        ShuttleGeoPoint(39.0, 127.0),
+                    ),
+            ),
+        )
+        service.create(
+            request(
+                polygon =
+                    listOf(
+                        ShuttleGeoPoint(0.0, 0.0),
+                        ShuttleGeoPoint(0.0, 2.0),
+                        ShuttleGeoPoint(-1.0, 3.0),
+                        ShuttleGeoPoint(1.0, 3.0),
                     ),
             ),
         )


### PR DESCRIPTION
## Summary

- Add administrator CRUD APIs for prioritized shuttle initial-stop rules.
- Validate period and stop references, paired optional time windows, coordinate ranges, polygon area, and self-intersections.
- Support all-day, daytime, and midnight-crossing rule windows in Asia/Seoul.
- Expose currently active rules through the Shuttle GraphQL payload, ordered for client-side geofence evaluation.
- Cover CRUD mapping, validation boundaries, time windows, halt behavior, entity semantics, and GraphQL output.

## Impact

Mobile clients can fetch only the rules matching the effective period, weekday/weekend timetable, and current time, then select the first containing geofence by priority. Existing shuttle queries remain compatible, and clients can keep the nearest-stop behavior as their fallback.

## Validation

- Ran `./gradlew ktlintCheck` for main and test sources.
- Ran focused initial-stop rule and shuttle GraphQL tests successfully.
- Confirmed the new production classes have full line coverage in the focused report.
- Confirmed the main and test Kotlin sources compile.
- The full local Spring suite requires the repository PostgreSQL test configuration supplied by CI; unrelated context tests fail locally before reaching application tests when that datasource is absent.
- Ran `git diff --check`.
