### PR TITLE
fix: Persist shuttle initial-stop polygons

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,7 @@ spring.jpa.properties.hibernate.default_batch_fetch_size=30
 spring.jpa.properties.hibernate.jdbc.batch_size=30
 spring.jpa.properties.hibernate.order_inserts=true
 spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.type.json_format_mapper=jackson3
 spring.jpa.open-in-view=false
 # Log
 logging.level.app.hyuabot.backend=DEBUG

--- a/src/test/kotlin/app/hyuabot/backend/database/repository/ShuttleRepositoryTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/database/repository/ShuttleRepositoryTest.kt
@@ -1,6 +1,7 @@
 package app.hyuabot.backend.database.repository
 
 import app.hyuabot.backend.database.entity.ShuttleHoliday
+import app.hyuabot.backend.database.entity.ShuttleInitialStopRule
 import app.hyuabot.backend.database.entity.ShuttlePeriod
 import app.hyuabot.backend.database.entity.ShuttlePeriodType
 import app.hyuabot.backend.database.entity.ShuttleRoute
@@ -8,6 +9,7 @@ import app.hyuabot.backend.database.entity.ShuttleRouteStop
 import app.hyuabot.backend.database.entity.ShuttleStop
 import app.hyuabot.backend.database.entity.ShuttleTimetable
 import app.hyuabot.backend.database.entity.ShuttleTimetableView
+import app.hyuabot.backend.shuttle.domain.ShuttleGeoPoint
 import jakarta.persistence.EntityManager
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -44,6 +46,8 @@ class ShuttleRepositoryTest {
     @Autowired lateinit var timetableRepository: ShuttleTimetableRepository
 
     @Autowired lateinit var timetableViewRepository: ShuttleTimetableViewRepository
+
+    @Autowired lateinit var initialStopRuleRepository: ShuttleInitialStopRuleRepository
 
     @Autowired lateinit var entityManager: EntityManager
 
@@ -209,6 +213,7 @@ class ShuttleRepositoryTest {
 
     @AfterEach
     fun tearDown() {
+        initialStopRuleRepository.deleteAll()
         timetableRepository.deleteAll()
         routeStopRepository.deleteAll()
         routeRepository.deleteAll()
@@ -216,6 +221,36 @@ class ShuttleRepositoryTest {
         periodRepository.deleteAll()
         periodTypeRepository.deleteAll()
         holidayRepository.deleteAll()
+    }
+
+    @Test
+    @DisplayName("초기 정류장 다각형 JSON 저장 및 조회")
+    fun testInitialStopRulePolygonJsonRoundTrip() {
+        val polygon =
+            listOf(
+                ShuttleGeoPoint(37.291, 126.831),
+                ShuttleGeoPoint(37.292, 126.832),
+                ShuttleGeoPoint(37.290, 126.833),
+            )
+        val saved =
+            initialStopRuleRepository.saveAndFlush(
+                ShuttleInitialStopRule(
+                    name = "ERICA 평일 오전",
+                    periodType = "semester",
+                    weekday = true,
+                    startTime = LocalTime.of(7, 0),
+                    endTime = LocalTime.of(10, 0),
+                    stopName = "dormitory_o",
+                    priority = 100,
+                    enabled = true,
+                    polygon = polygon,
+                ),
+            )
+
+        entityManager.clear()
+
+        val restored = initialStopRuleRepository.findById(requireNotNull(saved.seq)).orElseThrow()
+        assertEquals(polygon, restored.polygon)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Explicitly select Hibernate's Jackson 3 JSON format mapper for PostgreSQL `jsonb` values.
- Add a PostgreSQL repository regression test that saves, clears the persistence context, and reloads an initial-stop polygon.

## Root Cause

The runtime contains both Jackson 2 and Jackson 3. Hibernate 7.4 selected Jackson 2 first, but the application provides Kotlin value-object support through the Jackson 3 Kotlin module. Hibernate's JSON deep-copy step therefore failed while handling `List<ShuttleGeoPoint>` and surfaced as `InvalidDataAccessApiUsageException` with HTTP 500.

## Impact

Administrators can create and update shuttle initial-stop geofences without a server error. No database schema or API contract changes are required.

## Validation

- `./gradlew ktlintCheck`
- Focused shuttle initial-stop entity and service tests
- `git diff --check`
- Full PostgreSQL-backed test suite and JSON round-trip regression test
- JaCoCo coverage verification: 100% overall project coverage
