### PR TITLE
feat: add admin shuttle presence viewer-count endpoint

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceController.kt
@@ -1,0 +1,21 @@
+package app.hyuabot.backend.presence
+
+import app.hyuabot.backend.utility.ResponseBuilder
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin/shuttle-presence")
+class AdminShuttlePresenceController(
+    private val adminShuttlePresenceService: AdminShuttlePresenceService,
+) {
+    @GetMapping
+    fun getViewerCounts(): ResponseEntity<AdminShuttlePresenceResponse> =
+        ResponseBuilder.response(
+            HttpStatus.OK,
+            adminShuttlePresenceService.getViewerCounts(),
+        )
+}

--- a/src/main/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceResponse.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceResponse.kt
@@ -1,0 +1,14 @@
+package app.hyuabot.backend.presence
+
+import java.time.Instant
+
+data class AdminShuttlePresenceResponse(
+    val stops: List<StopViewerCount>,
+    val updatedAt: Instant,
+    val activeWindowSeconds: Long,
+) {
+    data class StopViewerCount(
+        val stopId: String,
+        val viewerCount: Long,
+    )
+}

--- a/src/main/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceService.kt
@@ -1,0 +1,44 @@
+package app.hyuabot.backend.presence
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import java.time.Clock
+import java.time.Instant
+
+@Service
+class AdminShuttlePresenceService(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val watchAnalyticsClock: Clock,
+) {
+    fun getViewerCounts(): AdminShuttlePresenceResponse {
+        val now = Instant.now(watchAnalyticsClock)
+        val minScore = (now.epochSecond - ACTIVE_WINDOW_SECONDS).toDouble()
+        val maxScore = Double.POSITIVE_INFINITY
+
+        val stops =
+            SHUTTLE_STOP_IDS.map { stopId ->
+                val count =
+                    redisTemplate.opsForZSet().count("presence:shuttle:$stopId", minScore, maxScore) ?: 0L
+                AdminShuttlePresenceResponse.StopViewerCount(stopId, count)
+            }
+
+        return AdminShuttlePresenceResponse(
+            stops = stops,
+            updatedAt = now,
+            activeWindowSeconds = ACTIVE_WINDOW_SECONDS,
+        )
+    }
+
+    companion object {
+        internal const val ACTIVE_WINDOW_SECONDS = 75L
+        internal val SHUTTLE_STOP_IDS =
+            listOf(
+                "dormitory_o",
+                "shuttlecock_o",
+                "station",
+                "terminal",
+                "jungang_stn",
+                "shuttlecock_i",
+            )
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceControllerTest.kt
@@ -1,0 +1,26 @@
+package app.hyuabot.backend.presence
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class AdminShuttlePresenceControllerTest {
+    @Test
+    fun `getViewerCounts returns OK with the service response`() {
+        val sampleUpdatedAt = Instant.parse("2026-07-21T03:00:00Z")
+        val sampleStop = AdminShuttlePresenceResponse.StopViewerCount("station", 4L)
+        val sample = AdminShuttlePresenceResponse(listOf(sampleStop), sampleUpdatedAt, 75L)
+
+        val service = mock<AdminShuttlePresenceService>()
+        whenever(service.getViewerCounts()).thenReturn(sample)
+
+        val controller = AdminShuttlePresenceController(service)
+        val response = controller.getViewerCounts()
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(sample, response.body)
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceServiceTest.kt
@@ -1,0 +1,49 @@
+package app.hyuabot.backend.presence
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ZSetOperations
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.assertEquals
+
+class AdminShuttlePresenceServiceTest {
+    @Test
+    fun `getViewerCounts returns raw counts for every stop and treats null as zero`() {
+        val now = Instant.parse("2026-07-21T03:00:00Z")
+        val clock = Clock.fixed(now, ZoneOffset.UTC)
+        val redisTemplate = mock<RedisTemplate<String, String>>()
+        val zSetOps = mock<ZSetOperations<String, String>>()
+
+        whenever(redisTemplate.opsForZSet()).thenReturn(zSetOps)
+
+        val counts = listOf(5L, null, 3L, 0L, 1L, 2L)
+        var callIndex = 0
+        whenever(zSetOps.count(any<String>(), any(), any())).thenAnswer { counts[callIndex++] }
+
+        val service = AdminShuttlePresenceService(redisTemplate, clock)
+        val response = service.getViewerCounts()
+
+        assertEquals(now, response.updatedAt)
+        assertEquals(75L, response.activeWindowSeconds)
+        assertEquals(6, response.stops.size)
+
+        val expectedStops =
+            listOf(
+                "dormitory_o" to 5L,
+                "shuttlecock_o" to 0L,
+                "station" to 3L,
+                "terminal" to 0L,
+                "jungang_stn" to 1L,
+                "shuttlecock_i" to 2L,
+            )
+        expectedStops.forEachIndexed { index, (id, count) ->
+            assertEquals(id, response.stops[index].stopId)
+            assertEquals(count, response.stops[index].viewerCount)
+        }
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceServiceTest.kt
@@ -46,4 +46,19 @@ class AdminShuttlePresenceServiceTest {
             assertEquals(count, response.stops[index].viewerCount)
         }
     }
+
+    @Test
+    fun `exposes the six shuttle stop ids in display order`() {
+        assertEquals(
+            listOf(
+                "dormitory_o",
+                "shuttlecock_o",
+                "station",
+                "terminal",
+                "jungang_stn",
+                "shuttlecock_i",
+            ),
+            AdminShuttlePresenceService.SHUTTLE_STOP_IDS,
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- Add a read-only admin endpoint `GET /api/v1/admin/shuttle-presence` that returns the current active viewer count for all six shuttle stops.
- Aggregate counts with a side-effect-free Redis `ZCOUNT` over each `presence:shuttle:{stopId}` sorted set, counting only sessions whose heartbeat falls within the 75-second active window.
- Expose raw counts (no privacy masking) since the endpoint is restricted to administrators.

## Details

- The path is under `/api/v1/admin/**`, so it is already gated to `SUPER_ADMIN` by `SecurityConfig`; no security change is required.
- The heartbeat write path (`ShuttlePresenceService`) is untouched; this is a separate read-only service.

## Validation

- ktlint, unit tests, and 100% Jacoco line coverage via the `code-check` workflow.
- New unit tests cover the service (including the null-count fallback) and the controller.
