### PR TITLE
feat: count shuttle presence as demand until the next departure

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceService.kt
@@ -8,37 +8,28 @@ import java.time.Instant
 @Service
 class AdminShuttlePresenceService(
     private val redisTemplate: RedisTemplate<String, String>,
+    private val shuttleDemandWindowService: ShuttleDemandWindowService,
     private val watchAnalyticsClock: Clock,
 ) {
     fun getViewerCounts(): AdminShuttlePresenceResponse {
         val now = Instant.now(watchAnalyticsClock)
-        val minScore = (now.epochSecond - ACTIVE_WINDOW_SECONDS).toDouble()
-        val maxScore = Double.POSITIVE_INFINITY
-
         val stops =
-            SHUTTLE_STOP_IDS.map { stopId ->
+            ShuttleDemandWindowService.STOP_NAMES.map { stopId ->
+                val window = shuttleDemandWindowService.demandWindow(stopId, now)
                 val count =
-                    redisTemplate.opsForZSet().count("presence:shuttle:$stopId", minScore, maxScore) ?: 0L
+                    if (window == null) {
+                        0L
+                    } else {
+                        redisTemplate
+                            .opsForZSet()
+                            .count("presence:shuttle:$stopId", window.startEpoch.toDouble(), Double.POSITIVE_INFINITY) ?: 0L
+                    }
                 AdminShuttlePresenceResponse.StopViewerCount(stopId, count)
             }
-
         return AdminShuttlePresenceResponse(
             stops = stops,
             updatedAt = now,
-            activeWindowSeconds = ACTIVE_WINDOW_SECONDS,
+            activeWindowSeconds = 0L,
         )
-    }
-
-    companion object {
-        internal const val ACTIVE_WINDOW_SECONDS = 75L
-        internal val SHUTTLE_STOP_IDS =
-            listOf(
-                "dormitory_o",
-                "shuttlecock_o",
-                "station",
-                "terminal",
-                "jungang_stn",
-                "shuttlecock_i",
-            )
     }
 }

--- a/src/main/kotlin/app/hyuabot/backend/presence/ShuttleDemandWindowService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/ShuttleDemandWindowService.kt
@@ -1,0 +1,103 @@
+package app.hyuabot.backend.presence
+
+import app.hyuabot.backend.codegen.types.ShuttleLimitInput
+import app.hyuabot.backend.holiday.service.PublicHolidayService
+import app.hyuabot.backend.shuttle.domain.ShuttleTimetableKey
+import app.hyuabot.backend.shuttle.service.ShuttleHolidayService
+import app.hyuabot.backend.shuttle.service.ShuttlePeriodService
+import app.hyuabot.backend.shuttle.service.ShuttleTimetableService
+import app.hyuabot.backend.utility.LocalDateTimeBuilder
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZonedDateTime
+import java.util.concurrent.atomic.AtomicReference
+
+@Service
+class ShuttleDemandWindowService(
+    private val shuttleTimetableService: ShuttleTimetableService,
+    private val shuttleHolidayService: ShuttleHolidayService,
+    private val publicHolidayService: PublicHolidayService,
+    private val shuttlePeriodService: ShuttlePeriodService,
+) {
+    private val cache = AtomicReference<Pair<LocalDate, Map<String, List<LocalTime>>>?>(null)
+
+    data class DemandWindow(
+        val startEpoch: Long,
+        val keyTtlSeconds: Long,
+    )
+
+    fun demandWindow(
+        stopName: String,
+        now: Instant,
+    ): DemandWindow? {
+        val zoned = now.atZone(LocalDateTimeBuilder.serviceTimezone)
+        val today = zoned.toLocalDate()
+        val nowTime = zoned.toLocalTime()
+
+        val times = scheduleFor(today)[stopName] ?: return null
+        val next = times.firstOrNull { it > nowTime } ?: return null
+        val previous = times.lastOrNull { it <= nowTime }
+        val startTime = previous ?: LocalTime.MIDNIGHT
+
+        val startEpoch = ZonedDateTime.of(today, startTime, LocalDateTimeBuilder.serviceTimezone).toEpochSecond()
+        val nextEpoch = ZonedDateTime.of(today, next, LocalDateTimeBuilder.serviceTimezone).toEpochSecond()
+        return DemandWindow(
+            startEpoch = startEpoch,
+            keyTtlSeconds = (nextEpoch - now.epochSecond) + KEY_TTL_BUFFER_SECONDS,
+        )
+    }
+
+    private fun scheduleFor(date: LocalDate): Map<String, List<LocalTime>> {
+        val cached = cache.get()
+        if (cached != null && cached.first == date) {
+            return cached.second
+        }
+        val computed = computeSchedule(date)
+        cache.set(date to computed)
+        return computed
+    }
+
+    private fun computeSchedule(date: LocalDate): Map<String, List<LocalTime>> {
+        val period = shuttlePeriodService.findShuttlePeriod(date) ?: return emptyMap()
+        val holiday = shuttleHolidayService.findShuttleHoliday(date)
+        val weekdays: List<Boolean> =
+            when {
+                holiday != null -> if (holiday.type == "weekends") listOf(false) else return emptyMap()
+                publicHolidayService.findPublicHoliday(date) != null -> listOf(false)
+                else -> listOf(date.dayOfWeek.value != 6 && date.dayOfWeek.value != 7)
+            }
+        val keys =
+            STOP_NAMES
+                .map { stop ->
+                    ShuttleTimetableKey(
+                        stop = stop,
+                        periods = setOf(period.type),
+                        weekdays = weekdays.toSet(),
+                        routes = null,
+                        tags = null,
+                        destinations = null,
+                        after = null,
+                        limit = ShuttleLimitInput(order = null, destination = null),
+                    )
+                }.toSet()
+        val results = shuttleTimetableService.getShuttleTimetableBatch(keys)
+        return keys.associate { key ->
+            key.stop to (results[key]?.order?.map { it.time }?.sorted() ?: emptyList())
+        }
+    }
+
+    companion object {
+        internal val STOP_NAMES =
+            listOf(
+                "dormitory_o",
+                "shuttlecock_o",
+                "station",
+                "terminal",
+                "jungang_stn",
+                "shuttlecock_i",
+            )
+        private const val KEY_TTL_BUFFER_SECONDS = 120L
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceService.kt
@@ -15,6 +15,7 @@ class ShuttlePresenceService(
     private val redisTemplate: RedisTemplate<String, String>,
     private val meterRegistry: MeterRegistry,
     private val watchAnalyticsClock: Clock,
+    private val shuttleDemandWindowService: ShuttleDemandWindowService,
 ) {
     private val heartbeatScript =
         DefaultRedisScript<Long>().apply {
@@ -29,22 +30,6 @@ class ShuttlePresenceService(
         require(APP_VERSION_REGEX.matches(request.appVersion))
 
         val now = Instant.now(watchAnalyticsClock)
-        val nowEpoch = now.epochSecond
-        val stopKey = "presence:shuttle:${stop.value}"
-        val sessionKey = "presence:shuttle:session:$sessionId"
-        val rateKey = "presence:shuttle:rate:$sessionId"
-        val count =
-            redisTemplate.execute(
-                heartbeatScript,
-                listOf(stopKey, sessionKey, rateKey),
-                (nowEpoch - ACTIVE_WINDOW_SECONDS).toString(),
-                nowEpoch.toString(),
-                sessionId,
-                stopKey,
-                ACTIVE_WINDOW_SECONDS.toString(),
-                STOP_KEY_TTL_SECONDS.toString(),
-                MIN_HEARTBEAT_INTERVAL_SECONDS.toString(),
-            ) ?: 0L
 
         meterRegistry
             .counter(
@@ -55,19 +40,39 @@ class ShuttlePresenceService(
                 stop.value,
             ).increment()
 
-        return responseFor(count, now)
+        val window = shuttleDemandWindowService.demandWindow(stop.value, now) ?: return responseFor(0L, now, 0L)
+
+        val nowEpoch = now.epochSecond
+        val stopKey = "presence:shuttle:${stop.value}"
+        val sessionKey = "presence:shuttle:session:$sessionId"
+        val rateKey = "presence:shuttle:rate:$sessionId"
+        val count =
+            redisTemplate.execute(
+                heartbeatScript,
+                listOf(stopKey, sessionKey, rateKey),
+                window.startEpoch.toString(),
+                nowEpoch.toString(),
+                sessionId,
+                stopKey,
+                window.keyTtlSeconds.toString(),
+                window.keyTtlSeconds.toString(),
+                MIN_HEARTBEAT_INTERVAL_SECONDS.toString(),
+            ) ?: 0L
+
+        return responseFor(count, now, nowEpoch - window.startEpoch)
     }
 
     internal fun responseFor(
         count: Long,
         now: Instant,
+        activeWindowSeconds: Long,
     ): ShuttlePresenceResponse {
         val visible = count >= MINIMUM_VISIBLE_COUNT
         return ShuttlePresenceResponse(
             viewerCount = count.takeIf { visible },
             visible = visible,
             updatedAt = now,
-            activeWindowSeconds = ACTIVE_WINDOW_SECONDS,
+            activeWindowSeconds = activeWindowSeconds,
         )
     }
 
@@ -100,8 +105,6 @@ class ShuttlePresenceService(
     }
 
     companion object {
-        internal const val ACTIVE_WINDOW_SECONDS = 75L
-        private const val STOP_KEY_TTL_SECONDS = 300L
         private const val MIN_HEARTBEAT_INTERVAL_SECONDS = 5L
         private const val MINIMUM_VISIBLE_COUNT = 3L
         private val APP_VERSION_REGEX = Regex("[0-9A-Za-z][0-9A-Za-z.+_-]{0,31}")

--- a/src/test/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceServiceTest.kt
@@ -1,7 +1,6 @@
 package app.hyuabot.backend.presence
 
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.data.redis.core.RedisTemplate
@@ -12,53 +11,56 @@ import java.time.ZoneOffset
 import kotlin.test.assertEquals
 
 class AdminShuttlePresenceServiceTest {
+    private val now = Instant.parse("2026-07-21T03:00:00Z")
+    private val redisTemplate = mock<RedisTemplate<String, String>>()
+    private val zSetOps = mock<ZSetOperations<String, String>>()
+    private val demandWindowService = mock<ShuttleDemandWindowService>()
+    private val service =
+        AdminShuttlePresenceService(
+            redisTemplate,
+            demandWindowService,
+            Clock.fixed(now, ZoneOffset.UTC),
+        )
+
     @Test
-    fun `getViewerCounts returns raw counts for every stop and treats null as zero`() {
-        val now = Instant.parse("2026-07-21T03:00:00Z")
-        val clock = Clock.fixed(now, ZoneOffset.UTC)
-        val redisTemplate = mock<RedisTemplate<String, String>>()
-        val zSetOps = mock<ZSetOperations<String, String>>()
-
+    fun `returns raw demand counts per stop and zero when there is no upcoming departure`() {
         whenever(redisTemplate.opsForZSet()).thenReturn(zSetOps)
+        val window = ShuttleDemandWindowService.DemandWindow(startEpoch = 1000L, keyTtlSeconds = 300L)
 
-        val counts = listOf(5L, null, 3L, 0L, 1L, 2L)
-        var callIndex = 0
-        whenever(zSetOps.count(any<String>(), any(), any())).thenAnswer { counts[callIndex++] }
+        // dormitory_o: window present, count 5
+        whenever(demandWindowService.demandWindow("dormitory_o", now)).thenReturn(window)
+        whenever(zSetOps.count("presence:shuttle:dormitory_o", 1000.0, Double.POSITIVE_INFINITY)).thenReturn(5L)
+        // shuttlecock_o: window present, ZCOUNT null -> 0
+        whenever(demandWindowService.demandWindow("shuttlecock_o", now)).thenReturn(window)
+        whenever(zSetOps.count("presence:shuttle:shuttlecock_o", 1000.0, Double.POSITIVE_INFINITY)).thenReturn(null)
+        // station: no upcoming departure -> 0 (no ZCOUNT)
+        whenever(demandWindowService.demandWindow("station", now)).thenReturn(null)
+        // terminal: window present, count 4
+        whenever(demandWindowService.demandWindow("terminal", now)).thenReturn(window)
+        whenever(zSetOps.count("presence:shuttle:terminal", 1000.0, Double.POSITIVE_INFINITY)).thenReturn(4L)
+        // jungang_stn: no upcoming departure -> 0
+        whenever(demandWindowService.demandWindow("jungang_stn", now)).thenReturn(null)
+        // shuttlecock_i: window present, count 2
+        whenever(demandWindowService.demandWindow("shuttlecock_i", now)).thenReturn(window)
+        whenever(zSetOps.count("presence:shuttle:shuttlecock_i", 1000.0, Double.POSITIVE_INFINITY)).thenReturn(2L)
 
-        val service = AdminShuttlePresenceService(redisTemplate, clock)
         val response = service.getViewerCounts()
 
         assertEquals(now, response.updatedAt)
-        assertEquals(75L, response.activeWindowSeconds)
         assertEquals(6, response.stops.size)
 
-        val expectedStops =
+        val expected =
             listOf(
                 "dormitory_o" to 5L,
                 "shuttlecock_o" to 0L,
-                "station" to 3L,
-                "terminal" to 0L,
-                "jungang_stn" to 1L,
+                "station" to 0L,
+                "terminal" to 4L,
+                "jungang_stn" to 0L,
                 "shuttlecock_i" to 2L,
             )
-        expectedStops.forEachIndexed { index, (id, count) ->
+        expected.forEachIndexed { index, (id, count) ->
             assertEquals(id, response.stops[index].stopId)
             assertEquals(count, response.stops[index].viewerCount)
         }
-    }
-
-    @Test
-    fun `exposes the six shuttle stop ids in display order`() {
-        assertEquals(
-            listOf(
-                "dormitory_o",
-                "shuttlecock_o",
-                "station",
-                "terminal",
-                "jungang_stn",
-                "shuttlecock_i",
-            ),
-            AdminShuttlePresenceService.SHUTTLE_STOP_IDS,
-        )
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/presence/ShuttleDemandWindowServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/ShuttleDemandWindowServiceTest.kt
@@ -1,0 +1,173 @@
+package app.hyuabot.backend.presence
+
+import app.hyuabot.backend.database.entity.PublicHoliday
+import app.hyuabot.backend.database.entity.ShuttleHoliday
+import app.hyuabot.backend.database.entity.ShuttlePeriod
+import app.hyuabot.backend.holiday.service.PublicHolidayService
+import app.hyuabot.backend.shuttle.domain.ShuttleTimetableKey
+import app.hyuabot.backend.shuttle.domain.ShuttleTimetableResult
+import app.hyuabot.backend.shuttle.domain.ShuttleTimetableViewItem
+import app.hyuabot.backend.shuttle.service.ShuttleHolidayService
+import app.hyuabot.backend.shuttle.service.ShuttlePeriodService
+import app.hyuabot.backend.shuttle.service.ShuttleTimetableService
+import app.hyuabot.backend.utility.LocalDateTimeBuilder
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZonedDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ShuttleDemandWindowServiceTest {
+    private val timetableService = mock<ShuttleTimetableService>()
+    private val holidayService = mock<ShuttleHolidayService>()
+    private val publicHolidayService = mock<PublicHolidayService>()
+    private val periodService = mock<ShuttlePeriodService>()
+    private val service =
+        ShuttleDemandWindowService(
+            timetableService,
+            holidayService,
+            publicHolidayService,
+            periodService,
+        )
+
+    // 2026-07-21 is a Tuesday; 03:00Z == 12:00 Asia/Seoul.
+    private val now = Instant.parse("2026-07-21T03:00:00Z")
+    private val today = LocalDate.of(2026, 7, 21)
+
+    private fun epochOf(time: LocalTime) = ZonedDateTime.of(today, time, LocalDateTimeBuilder.serviceTimezone).toEpochSecond()
+
+    private fun item(time: LocalTime) =
+        ShuttleTimetableViewItem(
+            seq = time.toSecondOfDay(),
+            routeName = "DH",
+            routeTag = "DH",
+            period = "semester",
+            weekday = true,
+            time = time,
+            group = "STATION",
+            stops = emptyList(),
+        )
+
+    private fun periodMock(type: String = "semester"): ShuttlePeriod {
+        val period = mock<ShuttlePeriod>()
+        whenever(period.type).thenReturn(type)
+        return period
+    }
+
+    private fun holidayMock(type: String): ShuttleHoliday {
+        val holiday = mock<ShuttleHoliday>()
+        whenever(holiday.type).thenReturn(type)
+        return holiday
+    }
+
+    private fun stubSchedule(timesByStop: Map<String, List<LocalTime>>) {
+        whenever(timetableService.getShuttleTimetableBatch(any())).thenAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val keys = invocation.getArgument(0) as Set<ShuttleTimetableKey>
+            keys.associateWith { key ->
+                ShuttleTimetableResult(
+                    order = (timesByStop[key.stop] ?: emptyList()).map { item(it) },
+                    destination = emptyMap(),
+                )
+            }
+        }
+    }
+
+    private fun stubOperatingWeekday() {
+        val period = periodMock()
+        whenever(periodService.findShuttlePeriod(any())).thenReturn(period)
+        whenever(holidayService.findShuttleHoliday(any())).thenReturn(null)
+        whenever(publicHolidayService.findPublicHoliday(any())).thenReturn(null)
+    }
+
+    @Test
+    fun `computes the window from the previous departure until the next one`() {
+        stubOperatingWeekday()
+        stubSchedule(mapOf("station" to listOf(LocalTime.of(11, 0), LocalTime.of(11, 30), LocalTime.of(13, 0))))
+
+        val window = service.demandWindow("station", now)!!
+
+        assertEquals(epochOf(LocalTime.of(11, 30)), window.startEpoch)
+        assertEquals((epochOf(LocalTime.of(13, 0)) - now.epochSecond) + 120, window.keyTtlSeconds)
+    }
+
+    @Test
+    fun `uses the start of day when there is no earlier departure`() {
+        stubOperatingWeekday()
+        stubSchedule(mapOf("station" to listOf(LocalTime.of(13, 0), LocalTime.of(14, 0))))
+
+        val window = service.demandWindow("station", now)!!
+
+        assertEquals(epochOf(LocalTime.MIDNIGHT), window.startEpoch)
+    }
+
+    @Test
+    fun `returns null after the last departure of the day`() {
+        stubOperatingWeekday()
+        stubSchedule(mapOf("station" to listOf(LocalTime.of(8, 0), LocalTime.of(9, 0))))
+
+        assertNull(service.demandWindow("station", now))
+    }
+
+    @Test
+    fun `returns null when the date is in no operating period`() {
+        whenever(periodService.findShuttlePeriod(any())).thenReturn(null)
+
+        assertNull(service.demandWindow("station", now))
+    }
+
+    @Test
+    fun `runs a weekend schedule on a shuttle weekend-operation holiday`() {
+        val period = periodMock()
+        val holiday = holidayMock("weekends")
+        whenever(periodService.findShuttlePeriod(any())).thenReturn(period)
+        whenever(holidayService.findShuttleHoliday(any())).thenReturn(holiday)
+        stubSchedule(mapOf("station" to listOf(LocalTime.of(11, 0), LocalTime.of(13, 0))))
+
+        val window = service.demandWindow("station", now)!!
+
+        assertEquals(epochOf(LocalTime.of(11, 0)), window.startEpoch)
+    }
+
+    @Test
+    fun `returns null when the shuttle is halted for a holiday`() {
+        val period = periodMock()
+        val holiday = holidayMock("halt")
+        whenever(periodService.findShuttlePeriod(any())).thenReturn(period)
+        whenever(holidayService.findShuttleHoliday(any())).thenReturn(holiday)
+
+        assertNull(service.demandWindow("station", now))
+    }
+
+    @Test
+    fun `runs a weekend schedule on a public holiday`() {
+        val period = periodMock()
+        val publicHoliday = mock<PublicHoliday>()
+        whenever(periodService.findShuttlePeriod(any())).thenReturn(period)
+        whenever(holidayService.findShuttleHoliday(any())).thenReturn(null)
+        whenever(publicHolidayService.findPublicHoliday(any())).thenReturn(publicHoliday)
+        stubSchedule(mapOf("station" to listOf(LocalTime.of(11, 0), LocalTime.of(13, 0))))
+
+        val window = service.demandWindow("station", now)!!
+
+        assertEquals(epochOf(LocalTime.of(11, 0)), window.startEpoch)
+    }
+
+    @Test
+    fun `caches the daily schedule so it is computed once per date`() {
+        stubOperatingWeekday()
+        stubSchedule(mapOf("station" to listOf(LocalTime.of(11, 0), LocalTime.of(13, 0))))
+
+        service.demandWindow("station", now)
+        service.demandWindow("station", now)
+
+        verify(timetableService, times(1)).getShuttleTimetableBatch(any())
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceServiceTest.kt
@@ -20,15 +20,24 @@ class ShuttlePresenceServiceTest {
     private val now = Instant.parse("2026-07-21T03:00:00Z")
     private val redisTemplate = mock<RedisTemplate<String, String>>()
     private val meterRegistry = SimpleMeterRegistry()
+    private val demandWindowService = mock<ShuttleDemandWindowService>()
     private val service =
         ShuttlePresenceService(
             redisTemplate,
             meterRegistry,
             Clock.fixed(now, ZoneOffset.UTC),
+            demandWindowService,
         )
 
     @Test
-    fun `records a valid heartbeat and returns the active viewer count`() {
+    fun `records a valid heartbeat and returns the demand count until the next departure`() {
+        whenever(demandWindowService.demandWindow("station", now))
+            .thenReturn(
+                ShuttleDemandWindowService.DemandWindow(
+                    startEpoch = now.epochSecond - 600,
+                    keyTtlSeconds = 300,
+                ),
+            )
         whenever(
             redisTemplate.execute(
                 any<RedisScript<Long>>(),
@@ -48,6 +57,7 @@ class ShuttlePresenceServiceTest {
         assertTrue(response.visible)
         assertEquals(3, response.viewerCount)
         assertEquals(now, response.updatedAt)
+        assertEquals(600, response.activeWindowSeconds)
         assertEquals(
             1.0,
             meterRegistry
@@ -66,15 +76,37 @@ class ShuttlePresenceServiceTest {
     }
 
     @Test
+    fun `returns an empty demand when there is no upcoming departure`() {
+        whenever(demandWindowService.demandWindow("station", now)).thenReturn(null)
+
+        val response = service.heartbeat(validRequest())
+
+        assertFalse(response.visible)
+        assertNull(response.viewerCount)
+        assertEquals(0, response.activeWindowSeconds)
+        assertEquals(
+            1.0,
+            meterRegistry
+                .counter(
+                    "hyuabot.shuttle.presence.heartbeats",
+                    "platform",
+                    "android",
+                    "stop_id",
+                    "station",
+                ).count(),
+        )
+    }
+
+    @Test
     fun `hides small groups and exposes counts from three viewers`() {
-        val smallGroup = service.responseFor(2, now)
+        val smallGroup = service.responseFor(2, now, 900)
         assertFalse(smallGroup.visible)
         assertNull(smallGroup.viewerCount)
 
-        val visibleGroup = service.responseFor(3, now)
+        val visibleGroup = service.responseFor(3, now, 900)
         assertTrue(visibleGroup.visible)
         assertEquals(3, visibleGroup.viewerCount)
-        assertEquals(75, visibleGroup.activeWindowSeconds)
+        assertEquals(900, visibleGroup.activeWindowSeconds)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Redefine shuttle presence from a fixed 75-second "live viewers" window to "demand for the next departure": count the distinct sessions that signalled interest in a stop since its previous departure, resetting at each departure.
- Both the app-facing heartbeat count and the admin endpoint now use this window (the app keeps the three-viewer privacy floor; the admin dashboard shows raw counts).

## Details

- New `ShuttleDemandWindowService` computes, per stop, the window lower bound (previous departure, or start of day before the first bus) and a Redis key TTL (until shortly after the next departure). It reuses the existing operating-context rules (period, weekday/weekend, shuttle holiday `weekends`/`halt`, and public holidays) and the shuttle timetable, caching the day's schedule in memory.
- When there is no upcoming departure (service halted, no operating period, or after the last bus), demand is reported as zero.
- The heartbeat Lua script is unchanged; the service now passes the previous-departure epoch as the sorted-set prune bound and the demand window's TTL.

## Validation

- ktlint, unit tests, and 100% Jacoco line coverage via the `code-check` workflow.
- New/updated unit tests cover the window service (weekday, weekend-operation holiday, public holiday, halt, no-period, before-first-bus, after-last-bus, and schedule caching), the presence service (demand count and the no-upcoming-departure path), and the admin aggregation.
