### PR TITLE
fix: issue persistent auth cookies so iOS PWA stays logged in

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -50,7 +50,7 @@ jobs:
           echo "spring.sql.init.mode=always" >> src/main/resources/application-test.properties
           echo "jwt.secret=secret" >> src/main/resources/application-test.properties
           echo "jwt.expiration=3600" >> src/main/resources/application-test.properties
-          echo "jwt.expiration.refresh=604800" >> src/main/resources/application-test.properties
+          echo "jwt.expiration.refresh=7" >> src/main/resources/application-test.properties
           echo "jasypt.encryptor.password=secret" >> src/main/resources/application-test.properties
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/src/main/kotlin/app/hyuabot/backend/auth/AuthController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/auth/AuthController.kt
@@ -9,6 +9,7 @@ import app.hyuabot.backend.auth.domain.ValidateInvitationRequest
 import app.hyuabot.backend.auth.exception.DuplicateEmailException
 import app.hyuabot.backend.auth.exception.InvalidInvitationException
 import app.hyuabot.backend.auth.exception.InvalidUserInputException
+import app.hyuabot.backend.security.AuthCookieProvider
 import app.hyuabot.backend.security.JWTUser
 import app.hyuabot.backend.security.effectivePermissions
 import app.hyuabot.backend.utility.ResponseBuilder
@@ -25,7 +26,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.core.context.SecurityContextHolder
@@ -47,6 +47,8 @@ class AuthController {
     @Autowired private lateinit var authService: AuthService
 
     @Autowired private lateinit var invitationService: UserInvitationService
+
+    @Autowired private lateinit var authCookieProvider: AuthCookieProvider
     private val logger = LoggerFactory.getLogger(javaClass)
 
     @PostMapping("/account-setup/validate")
@@ -136,22 +138,8 @@ class AuthController {
     ): ResponseEntity<ResponseBuilder.Message> {
         try {
             authService.login(payload.username, payload.password).let {
-                val accessTokenCookie =
-                    ResponseCookie
-                        .from("access_token", it.accessToken)
-                        .httpOnly(true)
-                        .secure(true)
-                        .sameSite("None")
-                        .path("/")
-                        .build()
-                val refreshTokenCookie =
-                    ResponseCookie
-                        .from("refresh_token", it.refreshToken)
-                        .httpOnly(true)
-                        .secure(true)
-                        .sameSite("None")
-                        .path("/")
-                        .build()
+                val accessTokenCookie = authCookieProvider.accessTokenCookie(it.accessToken)
+                val refreshTokenCookie = authCookieProvider.refreshTokenCookie(it.refreshToken)
                 return ResponseBuilder
                     .response(
                         HttpStatus.CREATED,
@@ -219,14 +207,7 @@ class AuthController {
         val refreshToken = request.cookies.first { it.name == "refresh_token" }.value
         try {
             val newAccessToken = authService.refreshToken(refreshToken)
-            val accessTokenCookie =
-                ResponseCookie
-                    .from("access_token", newAccessToken)
-                    .httpOnly(true)
-                    .secure(true)
-                    .sameSite("None")
-                    .path("/")
-                    .build()
+            val accessTokenCookie = authCookieProvider.accessTokenCookie(newAccessToken)
             return ResponseBuilder.response(
                 HttpStatus.OK,
                 "TOKEN_REFRESH_SUCCESS",
@@ -295,29 +276,11 @@ class AuthController {
         }
         val userID = principal.username
         val userInfo = authService.getUserInfo(userID)
-        val expireAccessToken =
-            ResponseCookie
-                .from("access_token", "")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
-                .path("/")
-                .maxAge(0)
-                .build()
-        val expireRefreshToken =
-            ResponseCookie
-                .from("refresh_token", "")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
-                .path("/")
-                .maxAge(0)
-                .build()
         authService.logout(userInfo, request).let {
             return ResponseBuilder.response(
                 HttpStatus.OK,
                 "LOGOUT_SUCCESS",
-                cookies = listOf(expireAccessToken, expireRefreshToken),
+                cookies = authCookieProvider.expiredAuthCookies(),
             )
         }
     }
@@ -423,7 +386,7 @@ class AuthController {
             ResponseBuilder.response(
                 HttpStatus.OK,
                 "PASSWORD_CHANGED",
-                cookies = expiredAuthCookies(),
+                cookies = authCookieProvider.expiredAuthCookies(),
             )
         } catch (_: BadCredentialsException) {
             ResponseBuilder.response(HttpStatus.BAD_REQUEST, "CURRENT_PASSWORD_MISMATCH")
@@ -442,16 +405,4 @@ class AuthController {
             active = user.active,
             permissions = user.permissions.effectivePermissions().sortedBy { it.ordinal },
         )
-
-    private fun expiredAuthCookies() =
-        listOf("access_token", "refresh_token").map { name ->
-            ResponseCookie
-                .from(name, "")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
-                .path("/")
-                .maxAge(0)
-                .build()
-        }
 }

--- a/src/main/kotlin/app/hyuabot/backend/security/AuthCookieProvider.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/AuthCookieProvider.kt
@@ -1,0 +1,48 @@
+package app.hyuabot.backend.security
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseCookie
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+// 인증 토큰 쿠키 생성기.
+// iOS 홈 화면 PWA(standalone 모드)는 세션 쿠키를 앱 종료/메모리 회수 시 삭제하므로,
+// refresh token 유효기간과 동일한 Max-Age 를 부여해 영속 쿠키로 발급한다.
+@Component
+class AuthCookieProvider(
+    @param:Value("\${jwt.expiration.refresh}") private val refreshExpirationDays: Long,
+) {
+    fun accessTokenCookie(value: String): ResponseCookie = persistentCookie(ACCESS_TOKEN, value)
+
+    fun refreshTokenCookie(value: String): ResponseCookie = persistentCookie(REFRESH_TOKEN, value)
+
+    fun expiredAuthCookies(): List<ResponseCookie> = listOf(expiredCookie(ACCESS_TOKEN), expiredCookie(REFRESH_TOKEN))
+
+    private fun persistentCookie(
+        name: String,
+        value: String,
+    ): ResponseCookie =
+        baseCookie(name, value)
+            .maxAge(Duration.ofDays(refreshExpirationDays))
+            .build()
+
+    private fun expiredCookie(name: String): ResponseCookie =
+        baseCookie(name, "")
+            .maxAge(0)
+            .build()
+
+    private fun baseCookie(
+        name: String,
+        value: String,
+    ) = ResponseCookie
+        .from(name, value)
+        .httpOnly(true)
+        .secure(true)
+        .sameSite("None")
+        .path("/")
+
+    companion object {
+        private const val ACCESS_TOKEN = "access_token"
+        private const val REFRESH_TOKEN = "refresh_token"
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/security/JWTAuthenticationFilter.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/JWTAuthenticationFilter.kt
@@ -15,6 +15,7 @@ import org.springframework.web.filter.OncePerRequestFilter
 class JWTAuthenticationFilter(
     private val tokenProvider: JWTTokenProvider,
     private val redisTemplate: RedisTemplate<String, String>,
+    private val authCookieProvider: AuthCookieProvider,
 ) : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -53,7 +54,7 @@ class JWTAuthenticationFilter(
         val context = SecurityContextHolder.createEmptyContext()
         context.authentication = authentication
         SecurityContextHolder.setContext(context)
-        response.addHeader("Set-Cookie", "access_token=$token; Path=/; HttpOnly; SameSite=None; Secure")
+        response.addHeader("Set-Cookie", authCookieProvider.accessTokenCookie(token).toString())
     } catch (e: Exception) {
         request.setAttribute("error", e.message)
     }

--- a/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
@@ -18,6 +18,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 class SecurityConfig(
     private val tokenProvider: JWTTokenProvider,
     private val redisTemplate: RedisTemplate<String, String>,
+    private val authCookieProvider: AuthCookieProvider,
 ) {
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain =
@@ -97,7 +98,7 @@ class SecurityConfig(
                     .anyRequest()
                     .denyAll()
             }.addFilterBefore(
-                JWTAuthenticationFilter(tokenProvider, redisTemplate),
+                JWTAuthenticationFilter(tokenProvider, redisTemplate, authCookieProvider),
                 UsernamePasswordAuthenticationFilter::class.java,
             ).build()
 

--- a/src/test/kotlin/app/hyuabot/backend/security/AuthCookieProviderTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/security/AuthCookieProviderTest.kt
@@ -1,0 +1,44 @@
+package app.hyuabot.backend.security
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AuthCookieProviderTest {
+    private val refreshExpirationDays = 7L
+    private val provider = AuthCookieProvider(refreshExpirationDays)
+
+    @Test
+    @DisplayName("access token 쿠키는 refresh 유효기간과 동일한 Max-Age 를 가진 영속 쿠키로 발급된다")
+    fun accessTokenCookieIsPersistent() {
+        val cookie = provider.accessTokenCookie("access-value")
+        assertEquals("access_token", cookie.name)
+        assertEquals("access-value", cookie.value)
+        assertEquals(Duration.ofDays(refreshExpirationDays), cookie.maxAge)
+        assertTrue(cookie.isHttpOnly)
+        assertTrue(cookie.isSecure)
+        assertEquals("None", cookie.sameSite)
+        assertEquals("/", cookie.path)
+    }
+
+    @Test
+    @DisplayName("refresh token 쿠키는 refresh 유효기간과 동일한 Max-Age 를 가진 영속 쿠키로 발급된다")
+    fun refreshTokenCookieIsPersistent() {
+        val cookie = provider.refreshTokenCookie("refresh-value")
+        assertEquals("refresh_token", cookie.name)
+        assertEquals("refresh-value", cookie.value)
+        assertEquals(Duration.ofDays(refreshExpirationDays), cookie.maxAge)
+    }
+
+    @Test
+    @DisplayName("만료 쿠키는 access/refresh 두 개가 Max-Age 0 으로 발급된다")
+    fun expiredAuthCookiesHaveZeroMaxAge() {
+        val cookies = provider.expiredAuthCookies()
+        assertEquals(2, cookies.size)
+        assertEquals(listOf("access_token", "refresh_token"), cookies.map { it.name })
+        assertTrue(cookies.all { it.maxAge == Duration.ZERO })
+        assertTrue(cookies.all { it.value.isEmpty() })
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/security/JWTAuthenticationFilterTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/security/JWTAuthenticationFilterTest.kt
@@ -38,7 +38,7 @@ class JWTAuthenticationFilterTest {
 
     @BeforeEach
     fun setup() {
-        jwtAuthenticationFilter = JWTAuthenticationFilter(jwtTokenProvider, redisTemplate)
+        jwtAuthenticationFilter = JWTAuthenticationFilter(jwtTokenProvider, redisTemplate, AuthCookieProvider(7))
         SecurityContextHolder.clearContext()
     }
 


### PR DESCRIPTION
## Summary

- Introduce `AuthCookieProvider` to centralize auth cookie creation and issue `access_token` / `refresh_token` cookies with a `Max-Age` equal to the refresh token lifetime.
- Route login, token refresh, logout, password change, and the authentication filter through the shared provider.
- Correct the refresh-expiration test fixture to days (`7`), matching the production `JWT_REFRESH_EXPIRATION_DAYS` semantics.

## Root Cause

The `access_token` and `refresh_token` cookies were emitted without a `Max-Age`/`Expires` attribute, making them session cookies. iOS home-screen PWAs (standalone mode) purge session cookies whenever the app is backgrounded or evicted from memory, so on every relaunch the dashboard had no cookies. `getUserInfo()` returned 401, the refresh attempt found no `refresh_token`, and the client redirected to `/login` — appearing as a repeated logout.

## Impact

The admin dashboard added to the iOS home screen stays authenticated across app relaunches. Cookies now persist for the refresh window and are still refreshed and invalidated exactly as before. No API contract or database schema changes.

## Validation

- `./gradlew ktlintCheck`
- `./gradlew test`
- JaCoCo coverage verification: 100% overall project coverage (`./gradlew jacocoTestCoverageVerification`)
