### PR TITLE
feat: Add inquiry chat REST API for users and admins

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/database/entity/InquiryMessage.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/entity/InquiryMessage.kt
@@ -1,0 +1,41 @@
+package app.hyuabot.backend.database.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.Hibernate
+import java.time.ZonedDateTime
+import java.util.UUID
+
+@Entity(name = "inquiry_message")
+@Table(name = "inquiry_message")
+class InquiryMessage(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+    @Column(name = "thread_id", columnDefinition = "uuid", nullable = false)
+    var threadId: UUID,
+    @Column(name = "sender_type", length = 8, nullable = false)
+    var senderType: String,
+    @Column(name = "sender_admin_user_id", length = 20)
+    var senderAdminUserId: String? = null,
+    @Column(name = "body", columnDefinition = "TEXT", nullable = false)
+    var body: String,
+    @Column(name = "read_at", columnDefinition = "timestamptz")
+    var readAt: ZonedDateTime? = null,
+    @Column(name = "created_at", columnDefinition = "timestamptz", nullable = false)
+    var createdAt: ZonedDateTime,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+        other as InquiryMessage
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id?.hashCode() ?: 0
+}

--- a/src/main/kotlin/app/hyuabot/backend/database/entity/InquiryThread.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/entity/InquiryThread.kt
@@ -1,0 +1,50 @@
+package app.hyuabot.backend.database.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.Hibernate
+import java.time.ZonedDateTime
+import java.util.UUID
+
+@Entity(name = "inquiry_thread")
+@Table(name = "inquiry_thread")
+class InquiryThread(
+    @Id
+    @Column(name = "id", columnDefinition = "uuid")
+    val id: UUID,
+    @Column(name = "installation_id", columnDefinition = "uuid", nullable = false)
+    var installationId: UUID,
+    @Column(name = "platform", length = 16, nullable = false)
+    var platform: String,
+    @Column(name = "app_version", length = 32)
+    var appVersion: String? = null,
+    @Column(name = "status", length = 16, nullable = false)
+    var status: String = "OPEN",
+    @Column(name = "subject", length = 200)
+    var subject: String? = null,
+    @Column(name = "contact_email", length = 255)
+    var contactEmail: String? = null,
+    @Column(name = "entry_screen", length = 64)
+    var entryScreen: String? = null,
+    @Column(name = "entry_screen_name", length = 120)
+    var entryScreenName: String? = null,
+    @Column(name = "assigned_admin_user_id", length = 20)
+    var assignedAdminUserId: String? = null,
+    @Column(name = "last_message_at", columnDefinition = "timestamptz")
+    var lastMessageAt: ZonedDateTime? = null,
+    @Column(name = "created_at", columnDefinition = "timestamptz", nullable = false)
+    var createdAt: ZonedDateTime,
+    @Column(name = "updated_at", columnDefinition = "timestamptz", nullable = false)
+    var updatedAt: ZonedDateTime,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+        other as InquiryThread
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+}

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/InquiryMessageRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/InquiryMessageRepository.kt
@@ -1,0 +1,19 @@
+package app.hyuabot.backend.database.repository
+
+import app.hyuabot.backend.database.entity.InquiryMessage
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface InquiryMessageRepository : JpaRepository<InquiryMessage, Long> {
+    fun findByThreadIdOrderByCreatedAtAsc(threadId: UUID): List<InquiryMessage>
+
+    fun findByThreadIdAndIdGreaterThanOrderByCreatedAtAsc(
+        threadId: UUID,
+        id: Long,
+    ): List<InquiryMessage>
+
+    fun findByThreadIdAndSenderTypeAndReadAtIsNull(
+        threadId: UUID,
+        senderType: String,
+    ): List<InquiryMessage>
+}

--- a/src/main/kotlin/app/hyuabot/backend/database/repository/InquiryThreadRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/InquiryThreadRepository.kt
@@ -1,0 +1,19 @@
+package app.hyuabot.backend.database.repository
+
+import app.hyuabot.backend.database.entity.InquiryThread
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface InquiryThreadRepository : JpaRepository<InquiryThread, UUID> {
+    fun findFirstByInstallationIdAndStatusInOrderByCreatedAtDesc(
+        installationId: UUID,
+        status: Collection<String>,
+    ): InquiryThread?
+
+    fun findByStatusInOrderByLastMessageAtDesc(status: Collection<String>): List<InquiryThread>
+
+    fun findByAssignedAdminUserIdAndStatusInOrderByLastMessageAtDesc(
+        adminUserId: String,
+        status: Collection<String>,
+    ): List<InquiryThread>
+}

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/InquiryService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/InquiryService.kt
@@ -1,0 +1,219 @@
+package app.hyuabot.backend.inquiry
+
+import app.hyuabot.backend.database.entity.InquiryMessage
+import app.hyuabot.backend.database.entity.InquiryThread
+import app.hyuabot.backend.database.repository.InquiryMessageRepository
+import app.hyuabot.backend.database.repository.InquiryThreadRepository
+import app.hyuabot.backend.inquiry.exception.EmptyInquiryMessageException
+import app.hyuabot.backend.inquiry.exception.InquiryThreadForbiddenException
+import app.hyuabot.backend.inquiry.exception.InquiryThreadNotFoundException
+import app.hyuabot.backend.inquiry.exception.InvalidInquiryStatusException
+import app.hyuabot.backend.utility.LocalDateTimeBuilder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.ZonedDateTime
+import java.util.UUID
+
+@Service
+class InquiryService(
+    private val threadRepository: InquiryThreadRepository,
+    private val messageRepository: InquiryMessageRepository,
+) {
+    private fun now(): ZonedDateTime = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
+
+    private fun getThreadOrThrow(threadId: UUID): InquiryThread =
+        threadRepository.findById(threadId).orElseThrow { InquiryThreadNotFoundException() }
+
+    private fun getOwnedThreadOrThrow(
+        threadId: UUID,
+        installationId: UUID,
+    ): InquiryThread {
+        val thread = getThreadOrThrow(threadId)
+        if (thread.installationId != installationId) {
+            throw InquiryThreadForbiddenException()
+        }
+        return thread
+    }
+
+    @Transactional
+    fun openOrGetActiveThread(
+        installationId: UUID,
+        platform: String,
+        appVersion: String?,
+        subject: String?,
+        contactEmail: String?,
+        entryScreen: String?,
+        entryScreenName: String?,
+    ): InquiryThread {
+        val timestamp = now()
+        threadRepository
+            .findFirstByInstallationIdAndStatusInOrderByCreatedAtDesc(installationId, ACTIVE_STATUSES)
+            ?.let { existing ->
+                // 다른 화면에서 다시 문의를 시작하면 진입 화면을 갱신하고 타임라인에 SYSTEM 메시지를 남긴다.
+                if (entryScreen != null && entryScreen != existing.entryScreen) {
+                    existing.entryScreen = entryScreen
+                    existing.entryScreenName = entryScreenName
+                    existing.updatedAt = timestamp
+                    threadRepository.save(existing)
+                    messageRepository.save(
+                        InquiryMessage(
+                            threadId = existing.id,
+                            senderType = "SYSTEM",
+                            body = entryScreenSystemMessage(entryScreenName ?: entryScreen),
+                            createdAt = timestamp,
+                        ),
+                    )
+                }
+                return existing
+            }
+        return threadRepository.save(
+            InquiryThread(
+                id = UUID.randomUUID(),
+                installationId = installationId,
+                platform = platform,
+                appVersion = appVersion,
+                status = "OPEN",
+                subject = subject,
+                contactEmail = contactEmail,
+                entryScreen = entryScreen,
+                entryScreenName = entryScreenName,
+                assignedAdminUserId = null,
+                lastMessageAt = null,
+                createdAt = timestamp,
+                updatedAt = timestamp,
+            ),
+        )
+    }
+
+    fun getActiveThread(installationId: UUID): InquiryThread? =
+        threadRepository.findFirstByInstallationIdAndStatusInOrderByCreatedAtDesc(installationId, ACTIVE_STATUSES)
+
+    fun getMessages(
+        threadId: UUID,
+        installationId: UUID,
+        after: Long?,
+    ): List<InquiryMessage> {
+        getOwnedThreadOrThrow(threadId, installationId)
+        return if (after != null) {
+            messageRepository.findByThreadIdAndIdGreaterThanOrderByCreatedAtAsc(threadId, after)
+        } else {
+            messageRepository.findByThreadIdOrderByCreatedAtAsc(threadId)
+        }
+    }
+
+    @Transactional
+    fun sendUserMessage(
+        threadId: UUID,
+        installationId: UUID,
+        body: String,
+    ): InquiryMessage {
+        if (body.isBlank()) {
+            throw EmptyInquiryMessageException()
+        }
+        val thread = getOwnedThreadOrThrow(threadId, installationId)
+        val timestamp = now()
+        val message =
+            messageRepository.save(
+                InquiryMessage(
+                    threadId = threadId,
+                    senderType = "USER",
+                    body = body,
+                    createdAt = timestamp,
+                ),
+            )
+        thread.lastMessageAt = timestamp
+        thread.updatedAt = timestamp
+        threadRepository.save(thread)
+        return message
+    }
+
+    @Transactional
+    fun markReadByUser(
+        threadId: UUID,
+        installationId: UUID,
+    ) {
+        getOwnedThreadOrThrow(threadId, installationId)
+        val timestamp = now()
+        messageRepository.findByThreadIdAndSenderTypeAndReadAtIsNull(threadId, "ADMIN").forEach {
+            it.readAt = timestamp
+        }
+    }
+
+    fun adminListThreads(assignedAdminUserId: String?): List<InquiryThread> =
+        if (assignedAdminUserId != null) {
+            threadRepository.findByAssignedAdminUserIdAndStatusInOrderByLastMessageAtDesc(assignedAdminUserId, ACTIVE_STATUSES)
+        } else {
+            threadRepository.findByStatusInOrderByLastMessageAtDesc(ACTIVE_STATUSES)
+        }
+
+    fun adminGetThread(threadId: UUID): InquiryThread = getThreadOrThrow(threadId)
+
+    fun getMessagesForAdmin(threadId: UUID): List<InquiryMessage> = messageRepository.findByThreadIdOrderByCreatedAtAsc(threadId)
+
+    @Transactional
+    fun adminReply(
+        threadId: UUID,
+        adminUserId: String,
+        body: String,
+    ): InquiryMessage {
+        if (body.isBlank()) {
+            throw EmptyInquiryMessageException()
+        }
+        val thread = getThreadOrThrow(threadId)
+        val timestamp = now()
+        val message =
+            messageRepository.save(
+                InquiryMessage(
+                    threadId = threadId,
+                    senderType = "ADMIN",
+                    senderAdminUserId = adminUserId,
+                    body = body,
+                    createdAt = timestamp,
+                ),
+            )
+        thread.lastMessageAt = timestamp
+        thread.updatedAt = timestamp
+        threadRepository.save(thread)
+        return message
+    }
+
+    @Transactional
+    fun adminMarkRead(threadId: UUID) {
+        getThreadOrThrow(threadId)
+        val timestamp = now()
+        messageRepository.findByThreadIdAndSenderTypeAndReadAtIsNull(threadId, "USER").forEach {
+            it.readAt = timestamp
+        }
+    }
+
+    @Transactional
+    fun adminUpdateThread(
+        threadId: UUID,
+        status: String?,
+        assignedAdminUserId: String?,
+    ): InquiryThread {
+        val thread = getThreadOrThrow(threadId)
+        if (status != null) {
+            if (!ACTIVE_STATUSES.contains(status)) {
+                throw InvalidInquiryStatusException()
+            }
+            thread.status = status
+        }
+        if (assignedAdminUserId != null) {
+            thread.assignedAdminUserId = assignedAdminUserId
+        }
+        thread.updatedAt = now()
+        return threadRepository.save(thread)
+    }
+
+    fun adminCloseThread(threadId: UUID) {
+        val thread = getThreadOrThrow(threadId)
+        threadRepository.delete(thread)
+    }
+
+    companion object {
+        val ACTIVE_STATUSES = listOf("OPEN", "PENDING")
+
+        fun entryScreenSystemMessage(screen: String): String = "사용자가 '$screen' 화면에서 문의를 시작했습니다."
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/controller/InquiryAdminController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/controller/InquiryAdminController.kt
@@ -1,0 +1,237 @@
+package app.hyuabot.backend.inquiry.controller
+
+import app.hyuabot.backend.database.entity.InquiryMessage
+import app.hyuabot.backend.database.entity.InquiryThread
+import app.hyuabot.backend.inquiry.InquiryService
+import app.hyuabot.backend.inquiry.domain.AdminThreadListResponse
+import app.hyuabot.backend.inquiry.domain.AdminThreadResponse
+import app.hyuabot.backend.inquiry.domain.MessageListResponse
+import app.hyuabot.backend.inquiry.domain.MessageResponse
+import app.hyuabot.backend.inquiry.domain.PatchThreadRequest
+import app.hyuabot.backend.inquiry.domain.SendMessageRequest
+import app.hyuabot.backend.inquiry.exception.EmptyInquiryMessageException
+import app.hyuabot.backend.inquiry.exception.InquiryThreadNotFoundException
+import app.hyuabot.backend.inquiry.exception.InvalidInquiryStatusException
+import app.hyuabot.backend.utility.ResponseBuilder
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RequestMapping("/api/v1/inquiry/admin")
+@RestController
+@Tag(name = "InquiryAdmin", description = "문의 채팅(관리자) 관련 API")
+class InquiryAdminController {
+    @Autowired private lateinit var service: InquiryService
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    private fun currentAdminUserId(): String = SecurityContextHolder.getContext().authentication!!.name
+
+    @GetMapping("/threads")
+    @Operation(summary = "문의 스레드 목록 조회", description = "assigned=true이면 내게 배정된 스레드만, 아니면 활성 스레드 전체를 조회합니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "문의 스레드 목록 조회 성공",
+        content = [Content(schema = Schema(implementation = AdminThreadListResponse::class))],
+    )
+    fun listThreads(
+        @RequestParam(value = "assigned", required = false, defaultValue = "false") assigned: Boolean,
+    ): ResponseEntity<*> =
+        try {
+            val threads =
+                if (assigned) {
+                    service.adminListThreads(currentAdminUserId())
+                } else {
+                    service.adminListThreads(null)
+                }
+            ResponseBuilder.response(
+                HttpStatus.OK,
+                AdminThreadListResponse(threads.map { toAdminThreadResponse(it) }),
+            )
+        } catch (e: Exception) {
+            logger.error("Failed to list inquiry threads", e)
+            ResponseBuilder.response(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ResponseBuilder.Message("INTERNAL_SERVER_ERROR"),
+            )
+        }
+
+    @GetMapping("/threads/{id}")
+    @Operation(summary = "문의 스레드 단건 조회", description = "문의 스레드를 단건 조회합니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "문의 스레드 단건 조회 성공",
+        content = [Content(schema = Schema(implementation = AdminThreadResponse::class))],
+    )
+    fun getThread(
+        @PathVariable id: UUID,
+    ): ResponseEntity<*> =
+        try {
+            ResponseBuilder.response(HttpStatus.OK, toAdminThreadResponse(service.adminGetThread(id)))
+        } catch (_: InquiryThreadNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("THREAD_NOT_FOUND"))
+        } catch (e: Exception) {
+            logger.error("Failed to get inquiry thread", e)
+            ResponseBuilder.response(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ResponseBuilder.Message("INTERNAL_SERVER_ERROR"),
+            )
+        }
+
+    @GetMapping("/threads/{id}/messages")
+    @Operation(summary = "문의 메시지 목록 조회", description = "스레드의 메시지를 조회합니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "문의 메시지 목록 조회 성공",
+        content = [Content(schema = Schema(implementation = MessageListResponse::class))],
+    )
+    fun getMessages(
+        @PathVariable id: UUID,
+    ): ResponseEntity<*> =
+        try {
+            service.adminGetThread(id)
+            val messages = service.getMessagesForAdmin(id)
+            ResponseBuilder.response(
+                HttpStatus.OK,
+                MessageListResponse(messages.map { toMessageResponse(it) }),
+            )
+        } catch (_: InquiryThreadNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("THREAD_NOT_FOUND"))
+        } catch (e: Exception) {
+            logger.error("Failed to get inquiry messages", e)
+            ResponseBuilder.response(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ResponseBuilder.Message("INTERNAL_SERVER_ERROR"),
+            )
+        }
+
+    @PostMapping("/threads/{id}/messages")
+    @Operation(summary = "문의 답변 전송", description = "스레드에 관리자 답변을 전송합니다.")
+    @ApiResponse(
+        responseCode = "201",
+        description = "문의 답변 전송 성공",
+        content = [Content(schema = Schema(implementation = MessageResponse::class))],
+    )
+    fun reply(
+        @PathVariable id: UUID,
+        @RequestBody request: SendMessageRequest,
+    ): ResponseEntity<*> =
+        try {
+            val message = service.adminReply(id, currentAdminUserId(), request.body)
+            ResponseBuilder.response(HttpStatus.CREATED, toMessageResponse(message))
+        } catch (_: InquiryThreadNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("THREAD_NOT_FOUND"))
+        } catch (_: EmptyInquiryMessageException) {
+            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("EMPTY_MESSAGE"))
+        } catch (e: Exception) {
+            logger.error("Failed to send inquiry reply", e)
+            ResponseBuilder.response(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ResponseBuilder.Message("INTERNAL_SERVER_ERROR"),
+            )
+        }
+
+    @PostMapping("/threads/{id}/read")
+    @Operation(summary = "문의 메시지 읽음 처리", description = "사용자가 보낸 메시지를 읽음 처리합니다.")
+    @ApiResponse(responseCode = "204", description = "문의 메시지 읽음 처리 성공")
+    fun markRead(
+        @PathVariable id: UUID,
+    ): ResponseEntity<*> =
+        try {
+            service.adminMarkRead(id)
+            ResponseBuilder.response(HttpStatus.NO_CONTENT, null)
+        } catch (_: InquiryThreadNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("THREAD_NOT_FOUND"))
+        } catch (e: Exception) {
+            logger.error("Failed to mark inquiry messages read", e)
+            ResponseBuilder.response(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ResponseBuilder.Message("INTERNAL_SERVER_ERROR"),
+            )
+        }
+
+    @PatchMapping("/threads/{id}")
+    @Operation(summary = "문의 스레드 수정", description = "스레드의 상태 또는 배정 관리자를 수정합니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "문의 스레드 수정 성공",
+        content = [Content(schema = Schema(implementation = AdminThreadResponse::class))],
+    )
+    fun updateThread(
+        @PathVariable id: UUID,
+        @RequestBody request: PatchThreadRequest,
+    ): ResponseEntity<*> =
+        try {
+            val thread = service.adminUpdateThread(id, request.status, request.assignedAdminUserId)
+            ResponseBuilder.response(HttpStatus.OK, toAdminThreadResponse(thread))
+        } catch (_: InquiryThreadNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("THREAD_NOT_FOUND"))
+        } catch (_: InvalidInquiryStatusException) {
+            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("INVALID_STATUS"))
+        } catch (e: Exception) {
+            logger.error("Failed to update inquiry thread", e)
+            ResponseBuilder.response(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ResponseBuilder.Message("INTERNAL_SERVER_ERROR"),
+            )
+        }
+
+    @DeleteMapping("/threads/{id}")
+    @Operation(summary = "문의 스레드 종료", description = "문의 스레드를 종료(삭제)합니다.")
+    @ApiResponse(responseCode = "204", description = "문의 스레드 종료 성공")
+    fun closeThread(
+        @PathVariable id: UUID,
+    ): ResponseEntity<*> =
+        try {
+            service.adminCloseThread(id)
+            ResponseBuilder.response(HttpStatus.NO_CONTENT, null)
+        } catch (_: InquiryThreadNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("THREAD_NOT_FOUND"))
+        } catch (e: Exception) {
+            logger.error("Failed to close inquiry thread", e)
+            ResponseBuilder.response(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ResponseBuilder.Message("INTERNAL_SERVER_ERROR"),
+            )
+        }
+
+    private fun toAdminThreadResponse(thread: InquiryThread): AdminThreadResponse =
+        AdminThreadResponse(
+            id = thread.id.toString(),
+            installationId = thread.installationId.toString(),
+            platform = thread.platform,
+            status = thread.status,
+            subject = thread.subject,
+            contactEmail = thread.contactEmail,
+            assignedAdminUserId = thread.assignedAdminUserId,
+            entryScreen = thread.entryScreen,
+            entryScreenName = thread.entryScreenName,
+            lastMessageAt = thread.lastMessageAt?.toString(),
+            createdAt = thread.createdAt.toString(),
+        )
+
+    private fun toMessageResponse(message: InquiryMessage): MessageResponse =
+        MessageResponse(
+            id = message.id!!,
+            senderType = message.senderType,
+            body = message.body,
+            readAt = message.readAt?.toString(),
+            createdAt = message.createdAt.toString(),
+        )
+}

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/controller/InquiryController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/controller/InquiryController.kt
@@ -1,0 +1,197 @@
+package app.hyuabot.backend.inquiry.controller
+
+import app.hyuabot.backend.database.entity.InquiryMessage
+import app.hyuabot.backend.database.entity.InquiryThread
+import app.hyuabot.backend.inquiry.InquiryService
+import app.hyuabot.backend.inquiry.domain.MessageListResponse
+import app.hyuabot.backend.inquiry.domain.MessageResponse
+import app.hyuabot.backend.inquiry.domain.OpenThreadRequest
+import app.hyuabot.backend.inquiry.domain.SendMessageRequest
+import app.hyuabot.backend.inquiry.domain.ThreadResponse
+import app.hyuabot.backend.inquiry.exception.EmptyInquiryMessageException
+import app.hyuabot.backend.inquiry.exception.InquiryThreadForbiddenException
+import app.hyuabot.backend.inquiry.exception.InquiryThreadNotFoundException
+import app.hyuabot.backend.utility.ResponseBuilder
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RequestMapping("/api/v1/inquiry")
+@RestController
+@Tag(name = "Inquiry", description = "문의 채팅(사용자) 관련 API")
+class InquiryController {
+    @Autowired private lateinit var service: InquiryService
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @PostMapping("/threads")
+    @Operation(summary = "문의 스레드 생성", description = "활성 스레드가 있으면 반환하고, 없으면 새로 생성합니다.")
+    @ApiResponse(
+        responseCode = "201",
+        description = "문의 스레드 생성 성공",
+        content = [Content(schema = Schema(implementation = ThreadResponse::class))],
+    )
+    fun openThread(
+        @RequestHeader("X-Installation-Id") installationId: UUID,
+        @RequestHeader(value = "X-App-Platform", required = false) platform: String?,
+        @RequestHeader(value = "X-App-Version", required = false) appVersion: String?,
+        @RequestBody request: OpenThreadRequest,
+    ): ResponseEntity<*> =
+        try {
+            val thread =
+                service.openOrGetActiveThread(
+                    installationId = installationId,
+                    platform = platform ?: "UNKNOWN",
+                    appVersion = appVersion,
+                    subject = request.subject,
+                    contactEmail = request.contactEmail,
+                    entryScreen = request.entryScreen,
+                    entryScreenName = request.entryScreenName,
+                )
+            ResponseBuilder.response(HttpStatus.CREATED, toThreadResponse(thread))
+        } catch (e: Exception) {
+            logger.error("Failed to open inquiry thread", e)
+            ResponseBuilder.response(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ResponseBuilder.Message("INTERNAL_SERVER_ERROR"),
+            )
+        }
+
+    @GetMapping("/threads/me")
+    @Operation(summary = "내 활성 문의 스레드 조회", description = "활성 스레드가 있으면 반환하고, 없으면 204를 반환합니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "활성 문의 스레드 조회 성공",
+        content = [Content(schema = Schema(implementation = ThreadResponse::class))],
+    )
+    fun getMyThread(
+        @RequestHeader("X-Installation-Id") installationId: UUID,
+    ): ResponseEntity<*> =
+        try {
+            service.getActiveThread(installationId)?.let {
+                ResponseBuilder.response(HttpStatus.OK, toThreadResponse(it))
+            } ?: ResponseBuilder.response(HttpStatus.NO_CONTENT, null)
+        } catch (e: Exception) {
+            logger.error("Failed to get active inquiry thread", e)
+            ResponseBuilder.response(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ResponseBuilder.Message("INTERNAL_SERVER_ERROR"),
+            )
+        }
+
+    @GetMapping("/threads/{id}/messages")
+    @Operation(summary = "문의 메시지 목록 조회", description = "스레드의 메시지를 조회합니다. after 이후의 메시지만 조회할 수 있습니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "문의 메시지 목록 조회 성공",
+        content = [Content(schema = Schema(implementation = MessageListResponse::class))],
+    )
+    fun getMessages(
+        @RequestHeader("X-Installation-Id") installationId: UUID,
+        @PathVariable id: UUID,
+        @RequestParam(value = "after", required = false) after: Long?,
+    ): ResponseEntity<*> =
+        try {
+            val messages = service.getMessages(id, installationId, after)
+            ResponseBuilder.response(
+                HttpStatus.OK,
+                MessageListResponse(messages.map { toMessageResponse(it) }),
+            )
+        } catch (_: InquiryThreadForbiddenException) {
+            ResponseBuilder.response(HttpStatus.FORBIDDEN, ResponseBuilder.Message("FORBIDDEN"))
+        } catch (_: InquiryThreadNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("THREAD_NOT_FOUND"))
+        } catch (e: Exception) {
+            logger.error("Failed to get inquiry messages", e)
+            ResponseBuilder.response(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ResponseBuilder.Message("INTERNAL_SERVER_ERROR"),
+            )
+        }
+
+    @PostMapping("/threads/{id}/messages")
+    @Operation(summary = "문의 메시지 전송", description = "스레드에 사용자 메시지를 전송합니다.")
+    @ApiResponse(
+        responseCode = "201",
+        description = "문의 메시지 전송 성공",
+        content = [Content(schema = Schema(implementation = MessageResponse::class))],
+    )
+    fun sendMessage(
+        @RequestHeader("X-Installation-Id") installationId: UUID,
+        @PathVariable id: UUID,
+        @RequestBody request: SendMessageRequest,
+    ): ResponseEntity<*> =
+        try {
+            val message = service.sendUserMessage(id, installationId, request.body)
+            ResponseBuilder.response(HttpStatus.CREATED, toMessageResponse(message))
+        } catch (_: InquiryThreadForbiddenException) {
+            ResponseBuilder.response(HttpStatus.FORBIDDEN, ResponseBuilder.Message("FORBIDDEN"))
+        } catch (_: InquiryThreadNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("THREAD_NOT_FOUND"))
+        } catch (_: EmptyInquiryMessageException) {
+            ResponseBuilder.response(HttpStatus.BAD_REQUEST, ResponseBuilder.Message("EMPTY_MESSAGE"))
+        } catch (e: Exception) {
+            logger.error("Failed to send inquiry message", e)
+            ResponseBuilder.response(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ResponseBuilder.Message("INTERNAL_SERVER_ERROR"),
+            )
+        }
+
+    @PostMapping("/threads/{id}/read")
+    @Operation(summary = "문의 메시지 읽음 처리", description = "관리자가 보낸 메시지를 읽음 처리합니다.")
+    @ApiResponse(responseCode = "204", description = "문의 메시지 읽음 처리 성공")
+    fun markRead(
+        @RequestHeader("X-Installation-Id") installationId: UUID,
+        @PathVariable id: UUID,
+    ): ResponseEntity<*> =
+        try {
+            service.markReadByUser(id, installationId)
+            ResponseBuilder.response(HttpStatus.NO_CONTENT, null)
+        } catch (_: InquiryThreadForbiddenException) {
+            ResponseBuilder.response(HttpStatus.FORBIDDEN, ResponseBuilder.Message("FORBIDDEN"))
+        } catch (_: InquiryThreadNotFoundException) {
+            ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("THREAD_NOT_FOUND"))
+        } catch (e: Exception) {
+            logger.error("Failed to mark inquiry messages read", e)
+            ResponseBuilder.response(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ResponseBuilder.Message("INTERNAL_SERVER_ERROR"),
+            )
+        }
+
+    private fun toThreadResponse(thread: InquiryThread): ThreadResponse =
+        ThreadResponse(
+            id = thread.id.toString(),
+            status = thread.status,
+            subject = thread.subject,
+            contactEmail = thread.contactEmail,
+            entryScreen = thread.entryScreen,
+            entryScreenName = thread.entryScreenName,
+            lastMessageAt = thread.lastMessageAt?.toString(),
+            createdAt = thread.createdAt.toString(),
+        )
+
+    private fun toMessageResponse(message: InquiryMessage): MessageResponse =
+        MessageResponse(
+            id = message.id!!,
+            senderType = message.senderType,
+            body = message.body,
+            readAt = message.readAt?.toString(),
+            createdAt = message.createdAt.toString(),
+        )
+}

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/domain/InquiryDto.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/domain/InquiryDto.kt
@@ -1,0 +1,93 @@
+package app.hyuabot.backend.inquiry.domain
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class OpenThreadRequest(
+    @get:Schema(description = "문의 제목", example = "버스 도착 정보 오류")
+    val subject: String? = null,
+    @get:Schema(description = "답변 받을 이메일", example = "user@example.com")
+    val contactEmail: String? = null,
+    @get:Schema(description = "문의를 시작한 화면 라우트 id", example = "shuttle.realtime")
+    val entryScreen: String? = null,
+    @get:Schema(description = "문의를 시작한 화면 표시명", example = "셔틀 실시간")
+    val entryScreenName: String? = null,
+)
+
+data class SendMessageRequest(
+    @get:Schema(description = "메시지 본문", example = "안녕하세요, 문의드립니다.")
+    val body: String,
+)
+
+data class MessageResponse(
+    @get:Schema(description = "메시지 ID", example = "1")
+    val id: Long,
+    @get:Schema(description = "발신자 유형", example = "USER")
+    val senderType: String,
+    @get:Schema(description = "메시지 본문", example = "안녕하세요, 문의드립니다.")
+    val body: String,
+    @get:Schema(description = "읽은 시각(ISO-8601)", example = "2026-07-29T12:00:00+09:00")
+    val readAt: String?,
+    @get:Schema(description = "생성 시각(ISO-8601)", example = "2026-07-29T12:00:00+09:00")
+    val createdAt: String,
+)
+
+data class MessageListResponse(
+    @get:Schema(description = "메시지 목록")
+    val result: List<MessageResponse>,
+)
+
+data class ThreadResponse(
+    @get:Schema(description = "스레드 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    val id: String,
+    @get:Schema(description = "스레드 상태", example = "OPEN")
+    val status: String,
+    @get:Schema(description = "문의 제목", example = "버스 도착 정보 오류")
+    val subject: String?,
+    @get:Schema(description = "답변 받을 이메일", example = "user@example.com")
+    val contactEmail: String?,
+    @get:Schema(description = "문의를 시작한 화면 라우트 id", example = "shuttle.realtime")
+    val entryScreen: String?,
+    @get:Schema(description = "문의를 시작한 화면 표시명", example = "셔틀 실시간")
+    val entryScreenName: String?,
+    @get:Schema(description = "마지막 메시지 시각(ISO-8601)", example = "2026-07-29T12:00:00+09:00")
+    val lastMessageAt: String?,
+    @get:Schema(description = "생성 시각(ISO-8601)", example = "2026-07-29T12:00:00+09:00")
+    val createdAt: String,
+)
+
+data class AdminThreadResponse(
+    @get:Schema(description = "스레드 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    val id: String,
+    @get:Schema(description = "설치 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    val installationId: String,
+    @get:Schema(description = "플랫폼", example = "iOS")
+    val platform: String,
+    @get:Schema(description = "스레드 상태", example = "OPEN")
+    val status: String,
+    @get:Schema(description = "문의 제목", example = "버스 도착 정보 오류")
+    val subject: String?,
+    @get:Schema(description = "답변 받을 이메일", example = "user@example.com")
+    val contactEmail: String?,
+    @get:Schema(description = "배정된 관리자 ID", example = "admin")
+    val assignedAdminUserId: String?,
+    @get:Schema(description = "문의를 시작한 화면 라우트 id", example = "shuttle.realtime")
+    val entryScreen: String?,
+    @get:Schema(description = "문의를 시작한 화면 표시명", example = "셔틀 실시간")
+    val entryScreenName: String?,
+    @get:Schema(description = "마지막 메시지 시각(ISO-8601)", example = "2026-07-29T12:00:00+09:00")
+    val lastMessageAt: String?,
+    @get:Schema(description = "생성 시각(ISO-8601)", example = "2026-07-29T12:00:00+09:00")
+    val createdAt: String,
+)
+
+data class AdminThreadListResponse(
+    @get:Schema(description = "스레드 목록")
+    val result: List<AdminThreadResponse>,
+)
+
+data class PatchThreadRequest(
+    @get:Schema(description = "변경할 상태(OPEN/PENDING)", example = "PENDING")
+    val status: String? = null,
+    @get:Schema(description = "배정할 관리자 ID", example = "admin")
+    val assignedAdminUserId: String? = null,
+)

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/exception/EmptyInquiryMessageException.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/exception/EmptyInquiryMessageException.kt
@@ -1,0 +1,3 @@
+package app.hyuabot.backend.inquiry.exception
+
+class EmptyInquiryMessageException : RuntimeException()

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/exception/InquiryThreadForbiddenException.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/exception/InquiryThreadForbiddenException.kt
@@ -1,0 +1,3 @@
+package app.hyuabot.backend.inquiry.exception
+
+class InquiryThreadForbiddenException : RuntimeException()

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/exception/InquiryThreadNotFoundException.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/exception/InquiryThreadNotFoundException.kt
@@ -1,0 +1,3 @@
+package app.hyuabot.backend.inquiry.exception
+
+class InquiryThreadNotFoundException : RuntimeException()

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/exception/InvalidInquiryStatusException.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/exception/InvalidInquiryStatusException.kt
@@ -1,0 +1,3 @@
+package app.hyuabot.backend.inquiry.exception
+
+class InvalidInquiryStatusException : RuntimeException()

--- a/src/main/kotlin/app/hyuabot/backend/security/AdminPermission.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/AdminPermission.kt
@@ -10,6 +10,7 @@ enum class AdminPermission {
     CONTACT,
     CALENDAR,
     NOTICE,
+    INQUIRY,
     ;
 
     companion object {

--- a/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
+++ b/src/main/kotlin/app/hyuabot/backend/security/SecurityConfig.kt
@@ -64,6 +64,10 @@ class SecurityConfig(
                         "/actuator/health/**",
                         "/actuator/prometheus",
                     ).permitAll()
+                    .requestMatchers("/api/v1/inquiry/admin/**")
+                    .hasAuthority(AdminPermission.INQUIRY.name)
+                    .requestMatchers("/api/v1/inquiry/**")
+                    .permitAll()
                     .requestMatchers("/api/v1/admin/**")
                     .hasAuthority(AdminPermission.SUPER_ADMIN.name)
                     .requestMatchers("/api/v1/building/**")

--- a/src/test/kotlin/app/hyuabot/backend/database/entity/InquiryMessageTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/database/entity/InquiryMessageTest.kt
@@ -1,0 +1,63 @@
+package app.hyuabot.backend.database.entity
+
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class InquiryMessageTest {
+    private val threadId: UUID = UUID.fromString("11111111-1111-1111-1111-111111111111")
+
+    private fun create(id: Long? = 1L) =
+        InquiryMessage(
+            id = id,
+            threadId = threadId,
+            senderType = "USER",
+            body = "hello",
+            createdAt = ZonedDateTime.now(),
+        )
+
+    @Test
+    fun equalsAndHashCode() {
+        val a = create()
+        val nullValue: Any? = null
+        assertTrue(a == a)
+        assertFalse(a.equals(nullValue))
+        assertFalse(a.equals(Any()))
+        assertEquals(a, create())
+        assertEquals(a.hashCode(), create().hashCode())
+        assertFalse(a == create(id = 2L))
+        assertEquals(0, create(id = null).hashCode())
+    }
+
+    @Test
+    fun fieldAccess() {
+        val now = ZonedDateTime.now()
+        val entity =
+            InquiryMessage(
+                id = 1L,
+                threadId = threadId,
+                senderType = "ADMIN",
+                senderAdminUserId = "admin",
+                body = "hello",
+                readAt = now,
+                createdAt = now,
+            )
+        assertEquals(1L, entity.id)
+        assertEquals(threadId, entity.threadId)
+        assertEquals("ADMIN", entity.senderType)
+        assertEquals("admin", entity.senderAdminUserId)
+        assertEquals("hello", entity.body)
+        assertEquals(now, entity.readAt)
+        assertEquals(now, entity.createdAt)
+    }
+
+    @Test
+    fun noArgConstructor() {
+        val entity = InquiryMessage::class.java.getDeclaredConstructor().newInstance()
+        assertNotNull(entity)
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/database/entity/InquiryThreadTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/database/entity/InquiryThreadTest.kt
@@ -1,0 +1,76 @@
+package app.hyuabot.backend.database.entity
+
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class InquiryThreadTest {
+    private val fixedId: UUID = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val otherId: UUID = UUID.fromString("22222222-2222-2222-2222-222222222222")
+
+    private fun create(id: UUID = fixedId) =
+        InquiryThread(
+            id = id,
+            installationId = UUID.fromString("33333333-3333-3333-3333-333333333333"),
+            platform = "iOS",
+            createdAt = ZonedDateTime.now(),
+            updatedAt = ZonedDateTime.now(),
+        )
+
+    @Test
+    fun equalsAndHashCode() {
+        val a = create()
+        val nullValue: Any? = null
+        assertTrue(a == a)
+        assertFalse(a.equals(nullValue))
+        assertFalse(a.equals(Any()))
+        assertEquals(a, create())
+        assertEquals(a.hashCode(), create().hashCode())
+        assertFalse(a == create(id = otherId))
+    }
+
+    @Test
+    fun fieldAccess() {
+        val now = ZonedDateTime.now()
+        val installation = UUID.fromString("33333333-3333-3333-3333-333333333333")
+        val entity =
+            InquiryThread(
+                id = fixedId,
+                installationId = installation,
+                platform = "iOS",
+                appVersion = "1.0.0",
+                status = "PENDING",
+                subject = "제목",
+                contactEmail = "a@b.com",
+                entryScreen = "shuttle",
+                entryScreenName = "셔틀",
+                assignedAdminUserId = "admin",
+                lastMessageAt = now,
+                createdAt = now,
+                updatedAt = now,
+            )
+        assertEquals(fixedId, entity.id)
+        assertEquals(installation, entity.installationId)
+        assertEquals("iOS", entity.platform)
+        assertEquals("1.0.0", entity.appVersion)
+        assertEquals("PENDING", entity.status)
+        assertEquals("제목", entity.subject)
+        assertEquals("a@b.com", entity.contactEmail)
+        assertEquals("shuttle", entity.entryScreen)
+        assertEquals("셔틀", entity.entryScreenName)
+        assertEquals("admin", entity.assignedAdminUserId)
+        assertEquals(now, entity.lastMessageAt)
+        assertEquals(now, entity.createdAt)
+        assertEquals(now, entity.updatedAt)
+    }
+
+    @Test
+    fun noArgConstructor() {
+        val entity = InquiryThread::class.java.getDeclaredConstructor().newInstance()
+        assertNotNull(entity)
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryAdminControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryAdminControllerTest.kt
@@ -1,0 +1,349 @@
+package app.hyuabot.backend.inquiry
+
+import app.hyuabot.backend.database.entity.InquiryMessage
+import app.hyuabot.backend.database.entity.InquiryThread
+import app.hyuabot.backend.inquiry.domain.PatchThreadRequest
+import app.hyuabot.backend.inquiry.domain.SendMessageRequest
+import app.hyuabot.backend.inquiry.exception.EmptyInquiryMessageException
+import app.hyuabot.backend.inquiry.exception.InquiryThreadNotFoundException
+import app.hyuabot.backend.inquiry.exception.InvalidInquiryStatusException
+import app.hyuabot.backend.security.WithCustomMockUser
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import tools.jackson.databind.ObjectMapper
+import java.time.ZonedDateTime
+import java.util.UUID
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class InquiryAdminControllerTest {
+    @MockitoBean
+    private lateinit var service: InquiryService
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    private val installationId: UUID = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val threadId: UUID = UUID.fromString("22222222-2222-2222-2222-222222222222")
+
+    private fun thread() =
+        InquiryThread(
+            id = threadId,
+            installationId = installationId,
+            platform = "iOS",
+            status = "OPEN",
+            createdAt = ZonedDateTime.now(),
+            updatedAt = ZonedDateTime.now(),
+        )
+
+    private fun message() =
+        InquiryMessage(
+            id = 1L,
+            threadId = threadId,
+            senderType = "USER",
+            body = "문의",
+            createdAt = ZonedDateTime.now(),
+        )
+
+    @Test
+    @DisplayName("스레드 목록 조회 - 배정된 것만")
+    @WithCustomMockUser(username = "adminUser")
+    fun testListThreadsAssigned() {
+        doReturn(listOf(thread())).whenever(service).adminListThreads("adminUser")
+        mockMvc
+            .perform(get("/api/v1/inquiry/admin/threads?assigned=true"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.result.length()").value(1))
+            .andExpect(jsonPath("$.result[0].id").value(threadId.toString()))
+        verify(service).adminListThreads("adminUser")
+    }
+
+    @Test
+    @DisplayName("스레드 목록 조회 - 전체")
+    @WithCustomMockUser(username = "adminUser")
+    fun testListThreadsAll() {
+        doReturn(listOf(thread())).whenever(service).adminListThreads(null)
+        mockMvc
+            .perform(get("/api/v1/inquiry/admin/threads"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.result.length()").value(1))
+        verify(service).adminListThreads(null)
+    }
+
+    @Test
+    @DisplayName("스레드 목록 조회 - 기타 예외")
+    @WithCustomMockUser(username = "adminUser")
+    fun testListThreadsError() {
+        doThrow(RuntimeException("error")).whenever(service).adminListThreads(anyOrNull())
+        mockMvc
+            .perform(get("/api/v1/inquiry/admin/threads"))
+            .andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("스레드 단건 조회 - 200")
+    @WithCustomMockUser(username = "adminUser")
+    fun testGetThread() {
+        doReturn(thread()).whenever(service).adminGetThread(any())
+        mockMvc
+            .perform(get("/api/v1/inquiry/admin/threads/$threadId"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(threadId.toString()))
+            .andExpect(jsonPath("$.installationId").value(installationId.toString()))
+    }
+
+    @Test
+    @DisplayName("스레드 단건 조회 - 404")
+    @WithCustomMockUser(username = "adminUser")
+    fun testGetThreadNotFound() {
+        doThrow(InquiryThreadNotFoundException()).whenever(service).adminGetThread(any())
+        mockMvc
+            .perform(get("/api/v1/inquiry/admin/threads/$threadId"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("THREAD_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("스레드 단건 조회 - 기타 예외")
+    @WithCustomMockUser(username = "adminUser")
+    fun testGetThreadError() {
+        doThrow(RuntimeException("error")).whenever(service).adminGetThread(any())
+        mockMvc
+            .perform(get("/api/v1/inquiry/admin/threads/$threadId"))
+            .andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("메시지 목록 조회 - 200")
+    @WithCustomMockUser(username = "adminUser")
+    fun testGetMessages() {
+        doReturn(thread()).whenever(service).adminGetThread(any())
+        doReturn(listOf(message())).whenever(service).getMessagesForAdmin(any())
+        mockMvc
+            .perform(get("/api/v1/inquiry/admin/threads/$threadId/messages"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.result.length()").value(1))
+            .andExpect(jsonPath("$.result[0].senderType").value("USER"))
+    }
+
+    @Test
+    @DisplayName("메시지 목록 조회 - 404")
+    @WithCustomMockUser(username = "adminUser")
+    fun testGetMessagesNotFound() {
+        doThrow(InquiryThreadNotFoundException()).whenever(service).adminGetThread(any())
+        mockMvc
+            .perform(get("/api/v1/inquiry/admin/threads/$threadId/messages"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("THREAD_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("메시지 목록 조회 - 기타 예외")
+    @WithCustomMockUser(username = "adminUser")
+    fun testGetMessagesError() {
+        doThrow(RuntimeException("error")).whenever(service).adminGetThread(any())
+        mockMvc
+            .perform(get("/api/v1/inquiry/admin/threads/$threadId/messages"))
+            .andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("답변 전송 - 201")
+    @WithCustomMockUser(username = "adminUser")
+    fun testReply() {
+        doReturn(message()).whenever(service).adminReply(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                post("/api/v1/inquiry/admin/threads/$threadId/messages")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(SendMessageRequest(body = "답변드립니다"))),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").value(1))
+    }
+
+    @Test
+    @DisplayName("답변 전송 - 404")
+    @WithCustomMockUser(username = "adminUser")
+    fun testReplyNotFound() {
+        doThrow(InquiryThreadNotFoundException()).whenever(service).adminReply(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                post("/api/v1/inquiry/admin/threads/$threadId/messages")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(SendMessageRequest(body = "hi"))),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("THREAD_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("답변 전송 - 400 빈 메시지")
+    @WithCustomMockUser(username = "adminUser")
+    fun testReplyEmpty() {
+        doThrow(EmptyInquiryMessageException()).whenever(service).adminReply(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                post("/api/v1/inquiry/admin/threads/$threadId/messages")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(SendMessageRequest(body = " "))),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").value("EMPTY_MESSAGE"))
+    }
+
+    @Test
+    @DisplayName("답변 전송 - 기타 예외")
+    @WithCustomMockUser(username = "adminUser")
+    fun testReplyError() {
+        doThrow(RuntimeException("error")).whenever(service).adminReply(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                post("/api/v1/inquiry/admin/threads/$threadId/messages")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(SendMessageRequest(body = "hi"))),
+            ).andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("읽음 처리 - 204")
+    @WithCustomMockUser(username = "adminUser")
+    fun testMarkRead() {
+        mockMvc
+            .perform(post("/api/v1/inquiry/admin/threads/$threadId/read"))
+            .andExpect(status().isNoContent)
+    }
+
+    @Test
+    @DisplayName("읽음 처리 - 404")
+    @WithCustomMockUser(username = "adminUser")
+    fun testMarkReadNotFound() {
+        doThrow(InquiryThreadNotFoundException()).whenever(service).adminMarkRead(any())
+        mockMvc
+            .perform(post("/api/v1/inquiry/admin/threads/$threadId/read"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("THREAD_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("읽음 처리 - 기타 예외")
+    @WithCustomMockUser(username = "adminUser")
+    fun testMarkReadError() {
+        doThrow(RuntimeException("error")).whenever(service).adminMarkRead(any())
+        mockMvc
+            .perform(post("/api/v1/inquiry/admin/threads/$threadId/read"))
+            .andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("스레드 수정 - 200")
+    @WithCustomMockUser(username = "adminUser")
+    fun testUpdateThread() {
+        doReturn(thread()).whenever(service).adminUpdateThread(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                patch("/api/v1/inquiry/admin/threads/$threadId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(PatchThreadRequest(status = "PENDING"))),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(threadId.toString()))
+    }
+
+    @Test
+    @DisplayName("스레드 수정 - 404")
+    @WithCustomMockUser(username = "adminUser")
+    fun testUpdateThreadNotFound() {
+        doThrow(InquiryThreadNotFoundException()).whenever(service).adminUpdateThread(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                patch("/api/v1/inquiry/admin/threads/$threadId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(PatchThreadRequest(status = "PENDING"))),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("THREAD_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("스레드 수정 - 400 무효 상태")
+    @WithCustomMockUser(username = "adminUser")
+    fun testUpdateThreadInvalidStatus() {
+        doThrow(InvalidInquiryStatusException()).whenever(service).adminUpdateThread(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                patch("/api/v1/inquiry/admin/threads/$threadId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(PatchThreadRequest(status = "CLOSED"))),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").value("INVALID_STATUS"))
+    }
+
+    @Test
+    @DisplayName("스레드 수정 - 기타 예외")
+    @WithCustomMockUser(username = "adminUser")
+    fun testUpdateThreadError() {
+        doThrow(RuntimeException("error")).whenever(service).adminUpdateThread(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                patch("/api/v1/inquiry/admin/threads/$threadId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(PatchThreadRequest(status = "PENDING"))),
+            ).andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("스레드 종료 - 204")
+    @WithCustomMockUser(username = "adminUser")
+    fun testCloseThread() {
+        mockMvc
+            .perform(delete("/api/v1/inquiry/admin/threads/$threadId"))
+            .andExpect(status().isNoContent)
+    }
+
+    @Test
+    @DisplayName("스레드 종료 - 404")
+    @WithCustomMockUser(username = "adminUser")
+    fun testCloseThreadNotFound() {
+        doThrow(InquiryThreadNotFoundException()).whenever(service).adminCloseThread(any())
+        mockMvc
+            .perform(delete("/api/v1/inquiry/admin/threads/$threadId"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("THREAD_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("스레드 종료 - 기타 예외")
+    @WithCustomMockUser(username = "adminUser")
+    fun testCloseThreadError() {
+        doThrow(RuntimeException("error")).whenever(service).adminCloseThread(any())
+        mockMvc
+            .perform(delete("/api/v1/inquiry/admin/threads/$threadId"))
+            .andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryControllerTest.kt
@@ -70,7 +70,13 @@ class InquiryControllerTest {
     @DisplayName("문의 스레드 생성 - 성공")
     fun testOpenThread() {
         doReturn(thread()).whenever(service).openOrGetActiveThread(
-            anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
         )
         mockMvc
             .perform(
@@ -87,7 +93,13 @@ class InquiryControllerTest {
     @DisplayName("문의 스레드 생성 - 기타 예외")
     fun testOpenThreadError() {
         doThrow(RuntimeException("error")).whenever(service).openOrGetActiveThread(
-            anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
         )
         mockMvc
             .perform(

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryControllerTest.kt
@@ -1,0 +1,282 @@
+package app.hyuabot.backend.inquiry
+
+import app.hyuabot.backend.database.entity.InquiryMessage
+import app.hyuabot.backend.database.entity.InquiryThread
+import app.hyuabot.backend.inquiry.domain.OpenThreadRequest
+import app.hyuabot.backend.inquiry.domain.SendMessageRequest
+import app.hyuabot.backend.inquiry.exception.EmptyInquiryMessageException
+import app.hyuabot.backend.inquiry.exception.InquiryThreadForbiddenException
+import app.hyuabot.backend.inquiry.exception.InquiryThreadNotFoundException
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import tools.jackson.databind.ObjectMapper
+import java.time.ZonedDateTime
+import java.util.UUID
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class InquiryControllerTest {
+    @MockitoBean
+    private lateinit var service: InquiryService
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    private val installationId: UUID = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val threadId: UUID = UUID.fromString("22222222-2222-2222-2222-222222222222")
+
+    private fun thread() =
+        InquiryThread(
+            id = threadId,
+            installationId = installationId,
+            platform = "iOS",
+            status = "OPEN",
+            createdAt = ZonedDateTime.now(),
+            updatedAt = ZonedDateTime.now(),
+        )
+
+    private fun message() =
+        InquiryMessage(
+            id = 1L,
+            threadId = threadId,
+            senderType = "ADMIN",
+            body = "답변",
+            createdAt = ZonedDateTime.now(),
+        )
+
+    private fun installationHeader() = installationId.toString()
+
+    @Test
+    @DisplayName("문의 스레드 생성 - 성공")
+    fun testOpenThread() {
+        doReturn(thread()).whenever(service).openOrGetActiveThread(
+            anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(),
+        )
+        mockMvc
+            .perform(
+                post("/api/v1/inquiry/threads")
+                    .header("X-Installation-Id", installationHeader())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(OpenThreadRequest(subject = "제목"))),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").value(threadId.toString()))
+            .andExpect(jsonPath("$.status").value("OPEN"))
+    }
+
+    @Test
+    @DisplayName("문의 스레드 생성 - 기타 예외")
+    fun testOpenThreadError() {
+        doThrow(RuntimeException("error")).whenever(service).openOrGetActiveThread(
+            anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(),
+        )
+        mockMvc
+            .perform(
+                post("/api/v1/inquiry/threads")
+                    .header("X-Installation-Id", installationHeader())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(OpenThreadRequest())),
+            ).andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("내 활성 스레드 조회 - 200")
+    fun testGetMyThread() {
+        doReturn(thread()).whenever(service).getActiveThread(any())
+        mockMvc
+            .perform(get("/api/v1/inquiry/threads/me").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(threadId.toString()))
+    }
+
+    @Test
+    @DisplayName("내 활성 스레드 조회 - 204")
+    fun testGetMyThreadNoContent() {
+        doReturn(null).whenever(service).getActiveThread(any())
+        mockMvc
+            .perform(get("/api/v1/inquiry/threads/me").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isNoContent)
+    }
+
+    @Test
+    @DisplayName("내 활성 스레드 조회 - 기타 예외")
+    fun testGetMyThreadError() {
+        doThrow(RuntimeException("error")).whenever(service).getActiveThread(any())
+        mockMvc
+            .perform(get("/api/v1/inquiry/threads/me").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("문의 메시지 목록 조회 - 200")
+    fun testGetMessages() {
+        doReturn(listOf(message())).whenever(service).getMessages(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(get("/api/v1/inquiry/threads/$threadId/messages").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.result.length()").value(1))
+            .andExpect(jsonPath("$.result[0].id").value(1))
+            .andExpect(jsonPath("$.result[0].senderType").value("ADMIN"))
+            .andExpect(jsonPath("$.result[0].body").value("답변"))
+    }
+
+    @Test
+    @DisplayName("문의 메시지 목록 조회 - 403")
+    fun testGetMessagesForbidden() {
+        doThrow(InquiryThreadForbiddenException()).whenever(service).getMessages(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(get("/api/v1/inquiry/threads/$threadId/messages").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.message").value("FORBIDDEN"))
+    }
+
+    @Test
+    @DisplayName("문의 메시지 목록 조회 - 404")
+    fun testGetMessagesNotFound() {
+        doThrow(InquiryThreadNotFoundException()).whenever(service).getMessages(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(get("/api/v1/inquiry/threads/$threadId/messages").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("THREAD_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("문의 메시지 목록 조회 - 기타 예외")
+    fun testGetMessagesError() {
+        doThrow(RuntimeException("error")).whenever(service).getMessages(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(get("/api/v1/inquiry/threads/$threadId/messages").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("문의 메시지 전송 - 201")
+    fun testSendMessage() {
+        doReturn(message()).whenever(service).sendUserMessage(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                post("/api/v1/inquiry/threads/$threadId/messages")
+                    .header("X-Installation-Id", installationHeader())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(SendMessageRequest(body = "안녕하세요"))),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.body").value("답변"))
+    }
+
+    @Test
+    @DisplayName("문의 메시지 전송 - 403")
+    fun testSendMessageForbidden() {
+        doThrow(InquiryThreadForbiddenException()).whenever(service).sendUserMessage(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                post("/api/v1/inquiry/threads/$threadId/messages")
+                    .header("X-Installation-Id", installationHeader())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(SendMessageRequest(body = "hi"))),
+            ).andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.message").value("FORBIDDEN"))
+    }
+
+    @Test
+    @DisplayName("문의 메시지 전송 - 404")
+    fun testSendMessageNotFound() {
+        doThrow(InquiryThreadNotFoundException()).whenever(service).sendUserMessage(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                post("/api/v1/inquiry/threads/$threadId/messages")
+                    .header("X-Installation-Id", installationHeader())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(SendMessageRequest(body = "hi"))),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("THREAD_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("문의 메시지 전송 - 400 빈 메시지")
+    fun testSendMessageEmpty() {
+        doThrow(EmptyInquiryMessageException()).whenever(service).sendUserMessage(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                post("/api/v1/inquiry/threads/$threadId/messages")
+                    .header("X-Installation-Id", installationHeader())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(SendMessageRequest(body = " "))),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").value("EMPTY_MESSAGE"))
+    }
+
+    @Test
+    @DisplayName("문의 메시지 전송 - 기타 예외")
+    fun testSendMessageError() {
+        doThrow(RuntimeException("error")).whenever(service).sendUserMessage(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(
+                post("/api/v1/inquiry/threads/$threadId/messages")
+                    .header("X-Installation-Id", installationHeader())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(SendMessageRequest(body = "hi"))),
+            ).andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("문의 메시지 읽음 처리 - 204")
+    fun testMarkRead() {
+        mockMvc
+            .perform(post("/api/v1/inquiry/threads/$threadId/read").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isNoContent)
+    }
+
+    @Test
+    @DisplayName("문의 메시지 읽음 처리 - 403")
+    fun testMarkReadForbidden() {
+        doThrow(InquiryThreadForbiddenException()).whenever(service).markReadByUser(anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(post("/api/v1/inquiry/threads/$threadId/read").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.message").value("FORBIDDEN"))
+    }
+
+    @Test
+    @DisplayName("문의 메시지 읽음 처리 - 404")
+    fun testMarkReadNotFound() {
+        doThrow(InquiryThreadNotFoundException()).whenever(service).markReadByUser(anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(post("/api/v1/inquiry/threads/$threadId/read").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("THREAD_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("문의 메시지 읽음 처리 - 기타 예외")
+    fun testMarkReadError() {
+        doThrow(RuntimeException("error")).whenever(service).markReadByUser(anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(post("/api/v1/inquiry/threads/$threadId/read").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryServiceTest.kt
@@ -1,0 +1,387 @@
+package app.hyuabot.backend.inquiry
+
+import app.hyuabot.backend.database.entity.InquiryMessage
+import app.hyuabot.backend.database.entity.InquiryThread
+import app.hyuabot.backend.database.repository.InquiryMessageRepository
+import app.hyuabot.backend.database.repository.InquiryThreadRepository
+import app.hyuabot.backend.inquiry.exception.EmptyInquiryMessageException
+import app.hyuabot.backend.inquiry.exception.InquiryThreadForbiddenException
+import app.hyuabot.backend.inquiry.exception.InquiryThreadNotFoundException
+import app.hyuabot.backend.inquiry.exception.InvalidInquiryStatusException
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.ZonedDateTime
+import java.util.Optional
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+@ExtendWith(MockitoExtension::class)
+class InquiryServiceTest {
+    @Mock
+    lateinit var threadRepository: InquiryThreadRepository
+
+    @Mock
+    lateinit var messageRepository: InquiryMessageRepository
+
+    @InjectMocks
+    lateinit var service: InquiryService
+
+    private val installationId: UUID = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val otherInstallationId: UUID = UUID.fromString("99999999-9999-9999-9999-999999999999")
+    private val threadId: UUID = UUID.fromString("22222222-2222-2222-2222-222222222222")
+
+    private fun thread(
+        id: UUID = threadId,
+        installation: UUID = installationId,
+        entryScreen: String? = null,
+        entryScreenName: String? = null,
+        status: String = "OPEN",
+        assignedAdminUserId: String? = null,
+    ) = InquiryThread(
+        id = id,
+        installationId = installation,
+        platform = "iOS",
+        status = status,
+        entryScreen = entryScreen,
+        entryScreenName = entryScreenName,
+        assignedAdminUserId = assignedAdminUserId,
+        createdAt = ZonedDateTime.now(),
+        updatedAt = ZonedDateTime.now(),
+    )
+
+    private fun message(
+        id: Long? = 1L,
+        senderType: String = "USER",
+        readAt: ZonedDateTime? = null,
+    ) = InquiryMessage(
+        id = id,
+        threadId = threadId,
+        senderType = senderType,
+        body = "body",
+        readAt = readAt,
+        createdAt = ZonedDateTime.now(),
+    )
+
+    @Test
+    @DisplayName("openOrGetActiveThread - 활성 스레드 없음 -> 신규 생성")
+    fun testOpenNewThread() {
+        whenever(
+            threadRepository.findFirstByInstallationIdAndStatusInOrderByCreatedAtDesc(installationId, InquiryService.ACTIVE_STATUSES),
+        ).thenReturn(null)
+        whenever(threadRepository.save(any<InquiryThread>())).thenAnswer { it.arguments[0] as InquiryThread }
+        val result =
+            service.openOrGetActiveThread(
+                installationId = installationId,
+                platform = "iOS",
+                appVersion = "1.0.0",
+                subject = "제목",
+                contactEmail = "a@b.com",
+                entryScreen = "shuttle.realtime",
+                entryScreenName = "셔틀 실시간",
+            )
+        assertEquals(installationId, result.installationId)
+        assertEquals("iOS", result.platform)
+        assertEquals("OPEN", result.status)
+        verify(threadRepository).save(any<InquiryThread>())
+    }
+
+    @Test
+    @DisplayName("openOrGetActiveThread - 활성 스레드 존재 + entryScreen null -> 기존 반환")
+    fun testOpenExistingThreadNoEntryScreen() {
+        val existing = thread(entryScreen = "home")
+        whenever(
+            threadRepository.findFirstByInstallationIdAndStatusInOrderByCreatedAtDesc(installationId, InquiryService.ACTIVE_STATUSES),
+        ).thenReturn(existing)
+        val result =
+            service.openOrGetActiveThread(installationId, "iOS", null, null, null, null, null)
+        assertSame(existing, result)
+        verify(messageRepository, never()).save(any())
+        verify(threadRepository, never()).save(any())
+    }
+
+    @Test
+    @DisplayName("openOrGetActiveThread - 활성 스레드 존재 + entryScreen 동일 -> 시스템 메시지 없음")
+    fun testOpenExistingThreadSameEntryScreen() {
+        val existing = thread(entryScreen = "home")
+        whenever(
+            threadRepository.findFirstByInstallationIdAndStatusInOrderByCreatedAtDesc(installationId, InquiryService.ACTIVE_STATUSES),
+        ).thenReturn(existing)
+        val result =
+            service.openOrGetActiveThread(installationId, "iOS", null, null, null, "home", "홈")
+        assertSame(existing, result)
+        verify(messageRepository, never()).save(any())
+    }
+
+    @Test
+    @DisplayName("openOrGetActiveThread - 활성 스레드 존재 + entryScreen 변경 -> 시스템 메시지 저장")
+    fun testOpenExistingThreadDifferentEntryScreen() {
+        val existing = thread(entryScreen = "home", entryScreenName = "홈")
+        whenever(
+            threadRepository.findFirstByInstallationIdAndStatusInOrderByCreatedAtDesc(installationId, InquiryService.ACTIVE_STATUSES),
+        ).thenReturn(existing)
+        val result =
+            service.openOrGetActiveThread(installationId, "iOS", null, null, null, "shuttle", "셔틀")
+        assertSame(existing, result)
+        assertEquals("shuttle", existing.entryScreen)
+        assertEquals("셔틀", existing.entryScreenName)
+        verify(threadRepository).save(existing)
+        verify(messageRepository).save(
+            argThat<InquiryMessage> {
+                senderType == "SYSTEM" && body == InquiryService.entryScreenSystemMessage("셔틀")
+            },
+        )
+    }
+
+    @Test
+    @DisplayName("getActiveThread - 값 반환")
+    fun testGetActiveThread() {
+        val existing = thread()
+        whenever(
+            threadRepository.findFirstByInstallationIdAndStatusInOrderByCreatedAtDesc(installationId, InquiryService.ACTIVE_STATUSES),
+        ).thenReturn(existing)
+        assertSame(existing, service.getActiveThread(installationId))
+    }
+
+    @Test
+    @DisplayName("getActiveThread - null 반환")
+    fun testGetActiveThreadNull() {
+        whenever(
+            threadRepository.findFirstByInstallationIdAndStatusInOrderByCreatedAtDesc(installationId, InquiryService.ACTIVE_STATUSES),
+        ).thenReturn(null)
+        assertNull(service.getActiveThread(installationId))
+    }
+
+    @Test
+    @DisplayName("getMessages - after null")
+    fun testGetMessagesWithoutAfter() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(thread()))
+        val messages = listOf(message())
+        whenever(messageRepository.findByThreadIdOrderByCreatedAtAsc(threadId)).thenReturn(messages)
+        assertEquals(messages, service.getMessages(threadId, installationId, null))
+    }
+
+    @Test
+    @DisplayName("getMessages - after 지정")
+    fun testGetMessagesWithAfter() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(thread()))
+        val messages = listOf(message(id = 5L))
+        whenever(messageRepository.findByThreadIdAndIdGreaterThanOrderByCreatedAtAsc(threadId, 3L)).thenReturn(messages)
+        assertEquals(messages, service.getMessages(threadId, installationId, 3L))
+    }
+
+    @Test
+    @DisplayName("getMessages - 소유자가 아님")
+    fun testGetMessagesForbidden() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(thread(installation = otherInstallationId)))
+        assertThrows<InquiryThreadForbiddenException> { service.getMessages(threadId, installationId, null) }
+    }
+
+    @Test
+    @DisplayName("getMessages - 스레드 없음")
+    fun testGetMessagesNotFound() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.empty())
+        assertThrows<InquiryThreadNotFoundException> { service.getMessages(threadId, installationId, null) }
+    }
+
+    @Test
+    @DisplayName("sendUserMessage - 본문 공백")
+    fun testSendUserMessageBlank() {
+        assertThrows<EmptyInquiryMessageException> { service.sendUserMessage(threadId, installationId, "  ") }
+        verify(messageRepository, never()).save(any())
+        verify(threadRepository, never()).findById(any())
+    }
+
+    @Test
+    @DisplayName("sendUserMessage - 정상 전송")
+    fun testSendUserMessage() {
+        val target = thread()
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(target))
+        whenever(messageRepository.save(any<InquiryMessage>())).thenAnswer { it.arguments[0] as InquiryMessage }
+        val result = service.sendUserMessage(threadId, installationId, "안녕하세요")
+        assertEquals("USER", result.senderType)
+        assertEquals("안녕하세요", result.body)
+        assertNotNull(target.lastMessageAt)
+        verify(threadRepository).save(target)
+    }
+
+    @Test
+    @DisplayName("sendUserMessage - 소유자가 아님")
+    fun testSendUserMessageForbidden() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(thread(installation = otherInstallationId)))
+        assertThrows<InquiryThreadForbiddenException> { service.sendUserMessage(threadId, installationId, "hi") }
+    }
+
+    @Test
+    @DisplayName("markReadByUser - ADMIN 미읽음 읽음 처리")
+    fun testMarkReadByUser() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(thread()))
+        val unread = message(senderType = "ADMIN")
+        whenever(messageRepository.findByThreadIdAndSenderTypeAndReadAtIsNull(threadId, "ADMIN")).thenReturn(listOf(unread))
+        service.markReadByUser(threadId, installationId)
+        assertNotNull(unread.readAt)
+    }
+
+    @Test
+    @DisplayName("markReadByUser - 소유자가 아님")
+    fun testMarkReadByUserForbidden() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(thread(installation = otherInstallationId)))
+        assertThrows<InquiryThreadForbiddenException> { service.markReadByUser(threadId, installationId) }
+    }
+
+    @Test
+    @DisplayName("adminListThreads - 배정 관리자 지정")
+    fun testAdminListThreadsAssigned() {
+        val threads = listOf(thread())
+        whenever(
+            threadRepository.findByAssignedAdminUserIdAndStatusInOrderByLastMessageAtDesc("adminUser", InquiryService.ACTIVE_STATUSES),
+        ).thenReturn(threads)
+        assertEquals(threads, service.adminListThreads("adminUser"))
+    }
+
+    @Test
+    @DisplayName("adminListThreads - 전체")
+    fun testAdminListThreadsAll() {
+        val threads = listOf(thread())
+        whenever(threadRepository.findByStatusInOrderByLastMessageAtDesc(InquiryService.ACTIVE_STATUSES)).thenReturn(threads)
+        assertEquals(threads, service.adminListThreads(null))
+    }
+
+    @Test
+    @DisplayName("adminGetThread - 존재")
+    fun testAdminGetThread() {
+        val target = thread()
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(target))
+        assertSame(target, service.adminGetThread(threadId))
+    }
+
+    @Test
+    @DisplayName("adminGetThread - 없음")
+    fun testAdminGetThreadNotFound() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.empty())
+        assertThrows<InquiryThreadNotFoundException> { service.adminGetThread(threadId) }
+    }
+
+    @Test
+    @DisplayName("getMessagesForAdmin - 목록 반환")
+    fun testGetMessagesForAdmin() {
+        val messages = listOf(message())
+        whenever(messageRepository.findByThreadIdOrderByCreatedAtAsc(threadId)).thenReturn(messages)
+        assertEquals(messages, service.getMessagesForAdmin(threadId))
+    }
+
+    @Test
+    @DisplayName("adminReply - 본문 공백")
+    fun testAdminReplyBlank() {
+        assertThrows<EmptyInquiryMessageException> { service.adminReply(threadId, "adminUser", " ") }
+        verify(messageRepository, never()).save(any())
+    }
+
+    @Test
+    @DisplayName("adminReply - 정상 답변")
+    fun testAdminReply() {
+        val target = thread()
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(target))
+        whenever(messageRepository.save(any<InquiryMessage>())).thenAnswer { it.arguments[0] as InquiryMessage }
+        val result = service.adminReply(threadId, "adminUser", "답변입니다")
+        assertEquals("ADMIN", result.senderType)
+        assertEquals("adminUser", result.senderAdminUserId)
+        assertEquals("답변입니다", result.body)
+        verify(threadRepository).save(target)
+    }
+
+    @Test
+    @DisplayName("adminReply - 스레드 없음")
+    fun testAdminReplyNotFound() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.empty())
+        assertThrows<InquiryThreadNotFoundException> { service.adminReply(threadId, "adminUser", "hi") }
+    }
+
+    @Test
+    @DisplayName("adminMarkRead - USER 미읽음 읽음 처리")
+    fun testAdminMarkRead() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(thread()))
+        val unread = message(senderType = "USER")
+        whenever(messageRepository.findByThreadIdAndSenderTypeAndReadAtIsNull(threadId, "USER")).thenReturn(listOf(unread))
+        service.adminMarkRead(threadId)
+        assertNotNull(unread.readAt)
+    }
+
+    @Test
+    @DisplayName("adminMarkRead - 스레드 없음")
+    fun testAdminMarkReadNotFound() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.empty())
+        assertThrows<InquiryThreadNotFoundException> { service.adminMarkRead(threadId) }
+    }
+
+    @Test
+    @DisplayName("adminUpdateThread - 변경 없음")
+    fun testAdminUpdateThreadNoChange() {
+        val target = thread()
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(target))
+        whenever(threadRepository.save(any<InquiryThread>())).thenAnswer { it.arguments[0] as InquiryThread }
+        val result = service.adminUpdateThread(threadId, null, null)
+        assertSame(target, result)
+    }
+
+    @Test
+    @DisplayName("adminUpdateThread - 유효 상태")
+    fun testAdminUpdateThreadValidStatus() {
+        val target = thread()
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(target))
+        whenever(threadRepository.save(any<InquiryThread>())).thenAnswer { it.arguments[0] as InquiryThread }
+        val result = service.adminUpdateThread(threadId, "PENDING", null)
+        assertEquals("PENDING", result.status)
+    }
+
+    @Test
+    @DisplayName("adminUpdateThread - 무효 상태")
+    fun testAdminUpdateThreadInvalidStatus() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(thread()))
+        assertThrows<InvalidInquiryStatusException> { service.adminUpdateThread(threadId, "CLOSED", null) }
+    }
+
+    @Test
+    @DisplayName("adminUpdateThread - 배정 관리자 지정")
+    fun testAdminUpdateThreadAssign() {
+        val target = thread()
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(target))
+        whenever(threadRepository.save(any<InquiryThread>())).thenAnswer { it.arguments[0] as InquiryThread }
+        val result = service.adminUpdateThread(threadId, null, "adminUser")
+        assertEquals("adminUser", result.assignedAdminUserId)
+    }
+
+    @Test
+    @DisplayName("adminCloseThread - 존재 시 삭제")
+    fun testAdminCloseThread() {
+        val target = thread()
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(target))
+        service.adminCloseThread(threadId)
+        verify(threadRepository).delete(target)
+    }
+
+    @Test
+    @DisplayName("adminCloseThread - 스레드 없음")
+    fun testAdminCloseThreadNotFound() {
+        whenever(threadRepository.findById(threadId)).thenReturn(Optional.empty())
+        assertThrows<InquiryThreadNotFoundException> { service.adminCloseThread(threadId) }
+    }
+
+    @Test
+    @DisplayName("companion - entryScreenSystemMessage")
+    fun testEntryScreenSystemMessage() {
+        assertEquals("사용자가 '셔틀' 화면에서 문의를 시작했습니다.", InquiryService.entryScreenSystemMessage("셔틀"))
+    }
+}


### PR DESCRIPTION
## Summary

- Add the inquiry chat domain that will replace the KakaoTalk open-chat link with an in-app support chat.
- Entities/repositories: `InquiryThread`, `InquiryMessage` (`inquiry_thread` / `inquiry_message`).
- User REST API (`/api/v1/inquiry/**`, anonymous via the `X-Installation-Id` header): open or reuse the single active thread, list messages (cursor by `after`), send a message, mark admin messages as read.
- Admin REST API (`/api/v1/inquiry/admin/**`, `INQUIRY` authority): list/get threads, reply, mark user messages read, update status/assignee, and close (hard delete).
- Capture the entry screen (`entryScreen` / `entryScreenName`) the inquiry was started from; when the active thread is reopened from a different screen, append a `SYSTEM` message so admins can see the context in the timeline.
- Add the `INQUIRY` admin permission and register the new routes in `SecurityConfig` (admin path matched before the anonymous user path).

## Notes

- The `inquiry_thread` / `inquiry_message` tables are applied out-of-band, consistent with the existing manual migration convention. `assigned_admin_user_id` / `sender_admin_user_id` reference `admin_user(user_id)`.
- One active thread per installation (DB partial unique index); closing a thread hard-deletes it and its messages cascade.
- Read receipts are bidirectional (`read_at` + user/admin read endpoints).
- SSE realtime delivery, push notifications, and screenshot attachments (MinIO) are planned as follow-up phases.

## Validation

- `./gradlew ktlintCheck`
- `./gradlew test`
- `./gradlew jacocoTestCoverageVerification` (100% project line coverage)
