### PR TITLE
test: Reach and enforce 100% branch coverage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,7 +126,12 @@ tasks.jacocoTestCoverageVerification {
             limit {
                 counter = "LINE"
                 value = "COVEREDRATIO"
-                minimum = "1.0".toBigDecimal() // 100% coverage
+                minimum = "1.0".toBigDecimal() // 100% line coverage
+            }
+            limit {
+                counter = "BRANCH"
+                value = "COVEREDRATIO"
+                minimum = "1.0".toBigDecimal() // 100% branch coverage
             }
         }
     }

--- a/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayAuditService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/holiday/audit/HolidayAuditService.kt
@@ -38,6 +38,7 @@ class HolidayAuditService(
                     service = "holiday",
                     message = "공식 공휴일 동기화가 36시간 이상 완료되지 않았습니다.",
                     path = publicHolidayPath(effectivePermissions),
+                    today = now.toLocalDate(),
                 )
         }
         if (AdminPermission.SHUTTLE in effectivePermissions) {
@@ -112,14 +113,14 @@ class HolidayAuditService(
         service: String,
         message: String,
         path: String,
+        today: LocalDate,
         date: LocalDate? = null,
-        today: LocalDate? = null,
     ) = HolidayAuditIssue(
         code = code,
         service = service,
         date = date,
         message = message,
-        severity = if (date != null && today != null && ChronoUnit.DAYS.between(today, date) <= CRITICAL_DAYS) "ERROR" else "WARNING",
+        severity = if (date != null && ChronoUnit.DAYS.between(today, date) <= CRITICAL_DAYS) "ERROR" else "WARNING",
         managementPath = path,
     )
 

--- a/src/test/kotlin/app/hyuabot/backend/admin/AdminUserServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/admin/AdminUserServiceTest.kt
@@ -134,6 +134,10 @@ class AdminUserServiceTest {
         assertThrows<InvalidUserInputException> { service.createUser(invalid, "creator") }
         assertThrows<InvalidUserInputException> { service.createUser(valid.copy(userID = " "), "creator") }
         assertThrows<InvalidUserInputException> { service.createUser(valid.copy(email = " "), "creator") }
+        assertThrows<InvalidUserInputException> { service.createUser(valid.copy(userID = "a".repeat(21)), "creator") }
+        assertThrows<InvalidUserInputException> { service.createUser(valid.copy(nickname = "a".repeat(21)), "creator") }
+        assertThrows<InvalidUserInputException> { service.createUser(valid.copy(email = "a".repeat(51)), "creator") }
+        assertThrows<InvalidUserInputException> { service.createUser(valid.copy(phone = "0".repeat(16)), "creator") }
     }
 
     @Test
@@ -170,6 +174,19 @@ class AdminUserServiceTest {
         assertFalse(result.active)
         assertEquals(listOf(AdminPermission.BUS), result.permissions)
         verify(userRepository).save(user)
+    }
+
+    @Test
+    fun updateUserLocatesTargetAfterNonMatchingEntry() {
+        val other = user(id = "other")
+        val target = user(id = "user")
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(other, target))
+        whenever(userRepository.save(target)).thenReturn(target)
+
+        val result = service.updateUser("user", UpdateAdminUserRequest(false, setOf(AdminPermission.BUS)))
+
+        assertFalse(result.active)
+        verify(userRepository).save(target)
     }
 
     @Test
@@ -304,6 +321,19 @@ class AdminUserServiceTest {
         assertEquals(AdminUserStatus.DELETED, AdminUserResponse.from(target).status)
         verify(refreshTokenRepository).deleteAllByUserID("user")
         verifyNoInteractions(invitationService)
+    }
+
+    @Test
+    fun deleteUserLocatesTargetAfterNonMatchingEntry() {
+        val other = user(id = "other")
+        val target = user(id = "user")
+        whenever(userRepository.findAllForPermissionUpdate()).thenReturn(listOf(other, target))
+        whenever(invitationRepository.findAllActiveRelatedForUpdate("user")).thenReturn(emptyList())
+
+        service.deleteUser("user", "admin")
+
+        assertFalse(target.active)
+        verify(refreshTokenRepository).deleteAllByUserID("user")
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/adminoverview/AdminOverviewServiceTest.kt
@@ -302,6 +302,19 @@ class AdminOverviewServiceTest {
         assertNull(service.getOverview(setOf(AdminPermission.BUS), current).weatherForecast)
     }
 
+    @Test
+    fun `subway permission alone audits holidays and flags jobs that failed without ever succeeding`() {
+        val now = Instant.now()
+        whenever(prometheusClient.getCronJobRuns()).thenReturn(
+            mapOf("subway-realtime-cron-job" to CronJobRun(null, now.minusSeconds(60).toString())),
+        )
+
+        val result = service.getOverview(setOf(AdminPermission.SUBWAY))
+
+        assertEquals("ERROR", result.services.first { it.id == "subway" }.status)
+        assertNotNull(result.services.first { it.id == "holiday-configuration" })
+    }
+
     private fun invitation(expiresAt: ZonedDateTime) =
         AdminUserInvitation(
             uuid = UUID.randomUUID(),

--- a/src/test/kotlin/app/hyuabot/backend/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/auth/AuthServiceTest.kt
@@ -163,6 +163,15 @@ class AuthServiceTest {
         assertThrows<InvalidUserInputException> {
             authService.updateProfile("testUser", UpdateProfileRequest("User", " ", ""))
         }
+        assertThrows<InvalidUserInputException> {
+            authService.updateProfile("testUser", UpdateProfileRequest("a".repeat(21), "test@example.com", ""))
+        }
+        assertThrows<InvalidUserInputException> {
+            authService.updateProfile("testUser", UpdateProfileRequest("User", "a".repeat(51), ""))
+        }
+        assertThrows<InvalidUserInputException> {
+            authService.updateProfile("testUser", UpdateProfileRequest("User", "test@example.com", "0".repeat(16)))
+        }
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/database/entity/InquiryMessageTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/database/entity/InquiryMessageTest.kt
@@ -60,4 +60,25 @@ class InquiryMessageTest {
         val entity = InquiryMessage::class.java.getDeclaredConstructor().newInstance()
         assertNotNull(entity)
     }
+
+    @Test
+    fun mutableProperties() {
+        val now = ZonedDateTime.now()
+        val other = UUID.fromString("22222222-2222-2222-2222-222222222222")
+        val entity = create()
+        entity.id = 99L
+        entity.threadId = other
+        entity.senderType = "ADMIN"
+        entity.senderAdminUserId = "admin"
+        entity.body = "답변"
+        entity.readAt = now
+        entity.createdAt = now
+        assertEquals(99L, entity.id)
+        assertEquals(other, entity.threadId)
+        assertEquals("ADMIN", entity.senderType)
+        assertEquals("admin", entity.senderAdminUserId)
+        assertEquals("답변", entity.body)
+        assertEquals(now, entity.readAt)
+        assertEquals(now, entity.createdAt)
+    }
 }

--- a/src/test/kotlin/app/hyuabot/backend/database/entity/InquiryThreadTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/database/entity/InquiryThreadTest.kt
@@ -73,4 +73,34 @@ class InquiryThreadTest {
         val entity = InquiryThread::class.java.getDeclaredConstructor().newInstance()
         assertNotNull(entity)
     }
+
+    @Test
+    fun mutableProperties() {
+        val now = ZonedDateTime.now()
+        val entity = create()
+        entity.installationId = otherId
+        entity.platform = "AOS"
+        entity.appVersion = "2.0.0"
+        entity.status = "PENDING"
+        entity.subject = "제목"
+        entity.contactEmail = "a@b.com"
+        entity.entryScreen = "cafeteria"
+        entity.entryScreenName = "학식"
+        entity.assignedAdminUserId = "admin"
+        entity.lastMessageAt = now
+        entity.createdAt = now
+        entity.updatedAt = now
+        assertEquals(otherId, entity.installationId)
+        assertEquals("AOS", entity.platform)
+        assertEquals("2.0.0", entity.appVersion)
+        assertEquals("PENDING", entity.status)
+        assertEquals("제목", entity.subject)
+        assertEquals("a@b.com", entity.contactEmail)
+        assertEquals("cafeteria", entity.entryScreen)
+        assertEquals("학식", entity.entryScreenName)
+        assertEquals("admin", entity.assignedAdminUserId)
+        assertEquals(now, entity.lastMessageAt)
+        assertEquals(now, entity.createdAt)
+        assertEquals(now, entity.updatedAt)
+    }
 }

--- a/src/test/kotlin/app/hyuabot/backend/holiday/HolidayAuditServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/holiday/HolidayAuditServiceTest.kt
@@ -158,6 +158,57 @@ class HolidayAuditServiceTest {
     }
 
     @Test
+    fun `bus permission flags a stale but previously successful sync`() {
+        val syncState =
+            HolidaySyncState(
+                source = "KASI",
+                lastAttemptAt = now.minusHours(40),
+                lastSuccessAt = now.minusHours(40),
+                rangeStart = now.toLocalDate(),
+                rangeEnd = now.toLocalDate().plusYears(1),
+                lastError = null,
+            )
+        whenever(syncStateRepository.findBySource("KASI")).thenReturn(syncState)
+
+        val result = service().audit(setOf(AdminPermission.BUS), now)
+
+        assertEquals("PUBLIC_HOLIDAY_SYNC_STALE", result.issues.single().code)
+        assertEquals("/bus/holiday", result.issues.single().managementPath)
+    }
+
+    @Test
+    fun `weekend timetable present clears the shuttle weekend issue`() {
+        val date = now.toLocalDate().plusDays(5)
+        val syncState =
+            HolidaySyncState(
+                source = "KASI",
+                lastAttemptAt = now.minusHours(1),
+                lastSuccessAt = now.minusHours(1),
+                rangeStart = now.toLocalDate(),
+                rangeEnd = now.toLocalDate().plusYears(1),
+                lastError = null,
+            )
+        whenever(syncStateRepository.findBySource("KASI")).thenReturn(syncState)
+        whenever(shuttleHolidayRepository.findAll()).thenReturn(emptyList())
+        whenever(publicHolidayRepository.findOfficialHolidaysBetween(any(), any(), any(), any())).thenReturn(
+            listOf(PublicHoliday(1, date, "광복절", "solar")),
+        )
+        whenever(shuttleHolidayRepository.findByDateAndCalendarType(date, "solar")).thenReturn(
+            ShuttleHoliday(1, date, "weekends", "solar"),
+        )
+        whenever(shuttlePeriodService.findShuttlePeriod(date)).thenReturn(
+            app.hyuabot.backend.database.entity
+                .ShuttlePeriod(1, "semester", now.minusDays(1), now.plusDays(30), null),
+        )
+        whenever(shuttleTimetableRepository.existsByPeriodTypeAndWeekday("semester", false)).thenReturn(true)
+
+        val result = service().audit(setOf(AdminPermission.SHUTTLE), now)
+
+        assertTrue(result.issues.isEmpty())
+        verify(shuttleTimetableRepository).existsByPeriodTypeAndWeekday("semester", false)
+    }
+
+    @Test
     fun `permissions limit audit scope and select available management path`() {
         whenever(syncStateRepository.findBySource("KASI")).thenReturn(null)
         val subway = service().audit(setOf(AdminPermission.SUBWAY), now)

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryAdminControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryAdminControllerTest.kt
@@ -68,6 +68,50 @@ class InquiryAdminControllerTest {
             createdAt = ZonedDateTime.now(),
         )
 
+    private fun threadWithLastMessage() =
+        InquiryThread(
+            id = threadId,
+            installationId = installationId,
+            platform = "iOS",
+            status = "OPEN",
+            lastMessageAt = ZonedDateTime.now(),
+            createdAt = ZonedDateTime.now(),
+            updatedAt = ZonedDateTime.now(),
+        )
+
+    private fun readMessage() =
+        InquiryMessage(
+            id = 2L,
+            threadId = threadId,
+            senderType = "USER",
+            body = "문의",
+            readAt = ZonedDateTime.now(),
+            createdAt = ZonedDateTime.now(),
+        )
+
+    @Test
+    @DisplayName("스레드 단건 조회 - 마지막 메시지 시각 포함")
+    @WithCustomMockUser(username = "adminUser")
+    fun testGetThreadWithLastMessage() {
+        doReturn(threadWithLastMessage()).whenever(service).adminGetThread(threadId)
+        mockMvc
+            .perform(get("/api/v1/inquiry/admin/threads/$threadId"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.lastMessageAt").isNotEmpty)
+    }
+
+    @Test
+    @DisplayName("메시지 목록 조회 - 읽은 메시지 포함")
+    @WithCustomMockUser(username = "adminUser")
+    fun testGetMessagesWithReadMessage() {
+        doReturn(thread()).whenever(service).adminGetThread(threadId)
+        doReturn(listOf(readMessage())).whenever(service).getMessagesForAdmin(threadId)
+        mockMvc
+            .perform(get("/api/v1/inquiry/admin/threads/$threadId/messages"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.result[0].readAt").isNotEmpty)
+    }
+
     @Test
     @DisplayName("스레드 목록 조회 - 배정된 것만")
     @WithCustomMockUser(username = "adminUser")

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryControllerTest.kt
@@ -66,6 +66,61 @@ class InquiryControllerTest {
 
     private fun installationHeader() = installationId.toString()
 
+    private fun threadWithLastMessage() =
+        InquiryThread(
+            id = threadId,
+            installationId = installationId,
+            platform = "iOS",
+            status = "OPEN",
+            lastMessageAt = ZonedDateTime.now(),
+            createdAt = ZonedDateTime.now(),
+            updatedAt = ZonedDateTime.now(),
+        )
+
+    private fun readMessage() =
+        InquiryMessage(
+            id = 2L,
+            threadId = threadId,
+            senderType = "ADMIN",
+            body = "답변",
+            readAt = ZonedDateTime.now(),
+            createdAt = ZonedDateTime.now(),
+        )
+
+    @Test
+    @DisplayName("문의 스레드 생성 - 플랫폼 헤더/마지막 메시지 시각 포함")
+    fun testOpenThreadWithPlatformHeader() {
+        doReturn(threadWithLastMessage()).whenever(service).openOrGetActiveThread(
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+        )
+        mockMvc
+            .perform(
+                post("/api/v1/inquiry/threads")
+                    .header("X-Installation-Id", installationHeader())
+                    .header("X-App-Platform", "iOS")
+                    .header("X-App-Version", "1.0.0")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(OpenThreadRequest(subject = "제목"))),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.lastMessageAt").isNotEmpty)
+    }
+
+    @Test
+    @DisplayName("문의 메시지 목록 조회 - 읽은 메시지 포함")
+    fun testGetMessagesWithReadMessage() {
+        doReturn(listOf(readMessage())).whenever(service).getMessages(anyOrNull(), anyOrNull(), anyOrNull())
+        mockMvc
+            .perform(get("/api/v1/inquiry/threads/$threadId/messages").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.result[0].readAt").isNotEmpty)
+    }
+
     @Test
     @DisplayName("문의 스레드 생성 - 성공")
     fun testOpenThread() {

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryDtoTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryDtoTest.kt
@@ -1,0 +1,28 @@
+package app.hyuabot.backend.inquiry
+
+import app.hyuabot.backend.inquiry.domain.PatchThreadRequest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class InquiryDtoTest {
+    @Test
+    fun patchThreadRequest() {
+        val request = PatchThreadRequest(status = "PENDING", assignedAdminUserId = "admin")
+        assertEquals("PENDING", request.status)
+        assertEquals("admin", request.assignedAdminUserId)
+        assertEquals("PENDING", request.component1())
+        assertEquals("admin", request.component2())
+        assertEquals("other", request.copy(assignedAdminUserId = "other").assignedAdminUserId)
+        assertEquals(request, request.copy())
+        assertEquals(request.hashCode(), request.copy().hashCode())
+        assertTrue(request.toString().contains("PENDING"))
+
+        val defaults = PatchThreadRequest()
+        assertNull(defaults.status)
+        assertNull(defaults.assignedAdminUserId)
+        assertNotEquals(request, defaults)
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryServiceTest.kt
@@ -146,6 +146,22 @@ class InquiryServiceTest {
     }
 
     @Test
+    @DisplayName("openOrGetActiveThread - entryScreen 변경 + 이름 null -> 라우트 id로 시스템 메시지")
+    fun testOpenExistingThreadDifferentEntryScreenWithoutName() {
+        val existing = thread(entryScreen = "home", entryScreenName = "홈")
+        whenever(
+            threadRepository.findFirstByInstallationIdAndStatusInOrderByCreatedAtDesc(installationId, InquiryService.ACTIVE_STATUSES),
+        ).thenReturn(existing)
+        service.openOrGetActiveThread(installationId, "iOS", null, null, null, "cafeteria", null)
+        assertNull(existing.entryScreenName)
+        verify(messageRepository).save(
+            argThat<InquiryMessage> {
+                senderType == "SYSTEM" && body == InquiryService.entryScreenSystemMessage("cafeteria")
+            },
+        )
+    }
+
+    @Test
     @DisplayName("getActiveThread - 값 반환")
     fun testGetActiveThread() {
         val existing = thread()

--- a/src/test/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceResponseTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/AdminShuttlePresenceResponseTest.kt
@@ -1,0 +1,39 @@
+package app.hyuabot.backend.presence
+
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class AdminShuttlePresenceResponseTest {
+    @Test
+    fun dataClass() {
+        val now = Instant.now()
+        val response =
+            AdminShuttlePresenceResponse(
+                stops = listOf(AdminShuttlePresenceResponse.StopViewerCount(stopId = "stop", viewerCount = 3L)),
+                updatedAt = now,
+                activeWindowSeconds = 60L,
+            )
+        assertEquals(1, response.stops.size)
+        assertEquals(now, response.updatedAt)
+        assertEquals(60L, response.activeWindowSeconds)
+        assertEquals(now, response.component2())
+        assertEquals(60L, response.component3())
+        assertEquals(response, response.copy())
+        assertEquals(response.hashCode(), response.copy().hashCode())
+        assertTrue(response.toString().contains("60"))
+        assertNotEquals(response, response.copy(activeWindowSeconds = 30L))
+
+        val stop = response.stops[0]
+        assertEquals("stop", stop.stopId)
+        assertEquals(3L, stop.viewerCount)
+        assertEquals("stop", stop.component1())
+        assertEquals(3L, stop.component2())
+        assertEquals(stop, stop.copy())
+        assertEquals(stop.hashCode(), stop.copy().hashCode())
+        assertTrue(stop.toString().contains("stop"))
+        assertNotEquals(stop, stop.copy(viewerCount = 9L))
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/presence/ShuttleDemandWindowServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/ShuttleDemandWindowServiceTest.kt
@@ -22,6 +22,7 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZonedDateTime
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class ShuttleDemandWindowServiceTest {
@@ -169,5 +170,47 @@ class ShuttleDemandWindowServiceTest {
         service.demandWindow("station", now)
 
         verify(timetableService, times(1)).getShuttleTimetableBatch(any())
+    }
+
+    @Test
+    fun `recomputes the schedule when the date changes`() {
+        stubOperatingWeekday()
+        stubSchedule(mapOf("station" to listOf(LocalTime.of(11, 0), LocalTime.of(13, 0))))
+
+        service.demandWindow("station", now)
+        // 2026-07-22 is a different date, so the cached entry must be discarded.
+        service.demandWindow("station", Instant.parse("2026-07-22T03:00:00Z"))
+
+        verify(timetableService, times(2)).getShuttleTimetableBatch(any())
+    }
+
+    @Test
+    fun `runs a weekend schedule on a saturday`() {
+        stubOperatingWeekday()
+        stubSchedule(mapOf("station" to listOf(LocalTime.of(11, 0), LocalTime.of(13, 0))))
+
+        // 2026-07-25 is a Saturday (dayOfWeek value 6).
+        val window = service.demandWindow("station", Instant.parse("2026-07-25T03:00:00Z"))
+
+        assertNotNull(window)
+    }
+
+    @Test
+    fun `runs a weekend schedule on a sunday`() {
+        stubOperatingWeekday()
+        stubSchedule(mapOf("station" to listOf(LocalTime.of(11, 0), LocalTime.of(13, 0))))
+
+        // 2026-07-26 is a Sunday (dayOfWeek value 7).
+        val window = service.demandWindow("station", Instant.parse("2026-07-26T03:00:00Z"))
+
+        assertNotNull(window)
+    }
+
+    @Test
+    fun `returns null when the timetable batch has no entry for the stop`() {
+        stubOperatingWeekday()
+        whenever(timetableService.getShuttleTimetableBatch(any())).thenReturn(emptyMap())
+
+        assertNull(service.demandWindow("station", now))
     }
 }

--- a/src/test/kotlin/app/hyuabot/backend/timetableimport/SubwayTimetableImportServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/timetableimport/SubwayTimetableImportServiceTest.kt
@@ -143,6 +143,25 @@ class SubwayTimetableImportServiceTest {
         verify(store).release("subway", "preview")
     }
 
+    @Test
+    fun `preview updates a row when only the terminal station changes`() {
+        val current = listOf(entity("A", "S", "T1", "05:00:00"))
+        val request =
+            SubwayTimetableImportRequest(
+                stationIDs = listOf("A"),
+                entries = listOf(entry("A", "S", "T2", "05:00:00")),
+            )
+        whenever(stationRepository.findByIdIn(any())).thenReturn(stations("A", "S", "T1", "T2"))
+        whenever(timetableRepository.findByStationIDIn(listOf("A"))).thenReturn(current)
+        whenever(store.save(any(), any())).thenReturn(StoredTimetableImport("preview", ZonedDateTime.now().plusMinutes(15)))
+
+        val result = service.preview(request)
+
+        assertEquals(0, result.createCount)
+        assertEquals(1, result.updateCount)
+        assertEquals(0, result.deleteCount)
+    }
+
     private fun entry(
         station: String,
         start: String,


### PR DESCRIPTION
## Summary

- Bring the backend to 100% branch coverage (previously 100% line, ~98.5% branch) and enforce it going forward.
- Add tests covering the remaining uncovered branches across `ShuttleDemandWindowService`, `AuthService`, `AdminOverviewService`, `SubwayTimetableImportService`, `AdminUserService`, `HolidayAuditService`, and the new inquiry controllers/service (null-safe `?.`/`?:`, compound `||`/`&&` short-circuits, `when` arms).
- Remove one unreachable branch in `HolidayAuditService.issue()`: `today` was nullable but every caller that passes `date` also passes `today`, so `today != null` could never be false. Make `today` non-null (the sync-stale caller now passes `now.toLocalDate()`); behavior is unchanged.
- Add a `BRANCH` `COVEREDRATIO` = 1.0 rule to `jacocoTestCoverageVerification` alongside the existing `LINE` rule.

## Validation

- `./gradlew ktlintCheck`
- `./gradlew test`
- `./gradlew jacocoTestCoverageVerification` — BUNDLE LINE 10242/10242, BRANCH 1893/1893 (100% line and branch)
