### PR TITLE
feat: Stream inquiry updates over SSE with Redis pub/sub

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/config/RedisConfig.kt
+++ b/src/main/kotlin/app/hyuabot/backend/config/RedisConfig.kt
@@ -1,10 +1,14 @@
 package app.hyuabot.backend.config
 
+import app.hyuabot.backend.inquiry.sse.InquiryEventListener
+import app.hyuabot.backend.inquiry.sse.InquiryEventPublisher
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
 @Configuration
@@ -22,5 +26,12 @@ class RedisConfig(
             keySerializer = StringRedisSerializer()
             valueSerializer = StringRedisSerializer()
             hashKeySerializer = StringRedisSerializer()
+        }
+
+    @Bean
+    fun redisMessageListenerContainer(inquiryEventListener: InquiryEventListener): RedisMessageListenerContainer =
+        RedisMessageListenerContainer().apply {
+            setConnectionFactory(redisConnectionFactory())
+            addMessageListener(inquiryEventListener, ChannelTopic(InquiryEventPublisher.CHANNEL))
         }
 }

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/InquiryService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/InquiryService.kt
@@ -4,10 +4,13 @@ import app.hyuabot.backend.database.entity.InquiryMessage
 import app.hyuabot.backend.database.entity.InquiryThread
 import app.hyuabot.backend.database.repository.InquiryMessageRepository
 import app.hyuabot.backend.database.repository.InquiryThreadRepository
+import app.hyuabot.backend.inquiry.domain.InquiryEvent
+import app.hyuabot.backend.inquiry.domain.toMessageResponse
 import app.hyuabot.backend.inquiry.exception.EmptyInquiryMessageException
 import app.hyuabot.backend.inquiry.exception.InquiryThreadForbiddenException
 import app.hyuabot.backend.inquiry.exception.InquiryThreadNotFoundException
 import app.hyuabot.backend.inquiry.exception.InvalidInquiryStatusException
+import app.hyuabot.backend.inquiry.sse.InquiryEventPublisher
 import app.hyuabot.backend.utility.LocalDateTimeBuilder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -18,6 +21,7 @@ import java.util.UUID
 class InquiryService(
     private val threadRepository: InquiryThreadRepository,
     private val messageRepository: InquiryMessageRepository,
+    private val eventPublisher: InquiryEventPublisher,
 ) {
     private fun now(): ZonedDateTime = ZonedDateTime.now(LocalDateTimeBuilder.serviceTimezone)
 
@@ -55,14 +59,16 @@ class InquiryService(
                     existing.entryScreenName = entryScreenName
                     existing.updatedAt = timestamp
                     threadRepository.save(existing)
-                    messageRepository.save(
-                        InquiryMessage(
-                            threadId = existing.id,
-                            senderType = "SYSTEM",
-                            body = entryScreenSystemMessage(entryScreenName ?: entryScreen),
-                            createdAt = timestamp,
-                        ),
-                    )
+                    val systemMessage =
+                        messageRepository.save(
+                            InquiryMessage(
+                                threadId = existing.id,
+                                senderType = "SYSTEM",
+                                body = entryScreenSystemMessage(entryScreenName ?: entryScreen),
+                                createdAt = timestamp,
+                            ),
+                        )
+                    publishMessage(existing.id, existing.installationId, systemMessage)
                 }
                 return existing
             }
@@ -124,6 +130,7 @@ class InquiryService(
         thread.lastMessageAt = timestamp
         thread.updatedAt = timestamp
         threadRepository.save(thread)
+        publishMessage(threadId, thread.installationId, message)
         return message
     }
 
@@ -132,11 +139,12 @@ class InquiryService(
         threadId: UUID,
         installationId: UUID,
     ) {
-        getOwnedThreadOrThrow(threadId, installationId)
+        val thread = getOwnedThreadOrThrow(threadId, installationId)
         val timestamp = now()
         messageRepository.findByThreadIdAndSenderTypeAndReadAtIsNull(threadId, "ADMIN").forEach {
             it.readAt = timestamp
         }
+        publishRead(threadId, thread.installationId, "USER")
     }
 
     fun adminListThreads(assignedAdminUserId: String?): List<InquiryThread> =
@@ -174,16 +182,18 @@ class InquiryService(
         thread.lastMessageAt = timestamp
         thread.updatedAt = timestamp
         threadRepository.save(thread)
+        publishMessage(threadId, thread.installationId, message)
         return message
     }
 
     @Transactional
     fun adminMarkRead(threadId: UUID) {
-        getThreadOrThrow(threadId)
+        val thread = getThreadOrThrow(threadId)
         val timestamp = now()
         messageRepository.findByThreadIdAndSenderTypeAndReadAtIsNull(threadId, "USER").forEach {
             it.readAt = timestamp
         }
+        publishRead(threadId, thread.installationId, "ADMIN")
     }
 
     @Transactional
@@ -203,12 +213,61 @@ class InquiryService(
             thread.assignedAdminUserId = assignedAdminUserId
         }
         thread.updatedAt = now()
-        return threadRepository.save(thread)
+        val saved = threadRepository.save(thread)
+        publishThread(saved.id, saved.installationId, saved.status)
+        return saved
     }
 
     fun adminCloseThread(threadId: UUID) {
         val thread = getThreadOrThrow(threadId)
+        val installationId = thread.installationId
         threadRepository.delete(thread)
+        publishThread(thread.id, installationId, "CLOSED")
+    }
+
+    private fun publishMessage(
+        threadId: UUID,
+        installationId: UUID,
+        message: InquiryMessage,
+    ) {
+        eventPublisher.publish(
+            InquiryEvent(
+                kind = "message",
+                threadId = threadId.toString(),
+                installationId = installationId.toString(),
+                message = message.toMessageResponse(),
+            ),
+        )
+    }
+
+    private fun publishRead(
+        threadId: UUID,
+        installationId: UUID,
+        reader: String,
+    ) {
+        eventPublisher.publish(
+            InquiryEvent(
+                kind = "read",
+                threadId = threadId.toString(),
+                installationId = installationId.toString(),
+                reader = reader,
+            ),
+        )
+    }
+
+    private fun publishThread(
+        threadId: UUID,
+        installationId: UUID,
+        status: String,
+    ) {
+        eventPublisher.publish(
+            InquiryEvent(
+                kind = "thread",
+                threadId = threadId.toString(),
+                installationId = installationId.toString(),
+                status = status,
+            ),
+        )
     }
 
     companion object {

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/controller/InquiryAdminController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/controller/InquiryAdminController.kt
@@ -1,6 +1,5 @@
 package app.hyuabot.backend.inquiry.controller
 
-import app.hyuabot.backend.database.entity.InquiryMessage
 import app.hyuabot.backend.database.entity.InquiryThread
 import app.hyuabot.backend.inquiry.InquiryService
 import app.hyuabot.backend.inquiry.domain.AdminThreadListResponse
@@ -9,9 +8,11 @@ import app.hyuabot.backend.inquiry.domain.MessageListResponse
 import app.hyuabot.backend.inquiry.domain.MessageResponse
 import app.hyuabot.backend.inquiry.domain.PatchThreadRequest
 import app.hyuabot.backend.inquiry.domain.SendMessageRequest
+import app.hyuabot.backend.inquiry.domain.toMessageResponse
 import app.hyuabot.backend.inquiry.exception.EmptyInquiryMessageException
 import app.hyuabot.backend.inquiry.exception.InquiryThreadNotFoundException
 import app.hyuabot.backend.inquiry.exception.InvalidInquiryStatusException
+import app.hyuabot.backend.inquiry.sse.InquirySseRegistry
 import app.hyuabot.backend.utility.ResponseBuilder
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -21,6 +22,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -32,6 +34,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.util.UUID
 
 @RequestMapping("/api/v1/inquiry/admin")
@@ -39,9 +42,16 @@ import java.util.UUID
 @Tag(name = "InquiryAdmin", description = "문의 채팅(관리자) 관련 API")
 class InquiryAdminController {
     @Autowired private lateinit var service: InquiryService
+
+    @Autowired private lateinit var registry: InquirySseRegistry
     private val logger = LoggerFactory.getLogger(javaClass)
 
     private fun currentAdminUserId(): String = SecurityContextHolder.getContext().authentication!!.name
+
+    @GetMapping("/stream", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    @Operation(summary = "문의 실시간 스트림(관리자)", description = "모든 문의 이벤트를 SSE로 수신합니다.")
+    @ApiResponse(responseCode = "200", description = "SSE 연결 성공")
+    fun stream(): SseEmitter = registry.registerForAdmin()
 
     @GetMapping("/threads")
     @Operation(summary = "문의 스레드 목록 조회", description = "assigned=true이면 내게 배정된 스레드만, 아니면 활성 스레드 전체를 조회합니다.")
@@ -109,7 +119,7 @@ class InquiryAdminController {
             val messages = service.getMessagesForAdmin(id)
             ResponseBuilder.response(
                 HttpStatus.OK,
-                MessageListResponse(messages.map { toMessageResponse(it) }),
+                MessageListResponse(messages.map { it.toMessageResponse() }),
             )
         } catch (_: InquiryThreadNotFoundException) {
             ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("THREAD_NOT_FOUND"))
@@ -134,7 +144,7 @@ class InquiryAdminController {
     ): ResponseEntity<*> =
         try {
             val message = service.adminReply(id, currentAdminUserId(), request.body)
-            ResponseBuilder.response(HttpStatus.CREATED, toMessageResponse(message))
+            ResponseBuilder.response(HttpStatus.CREATED, message.toMessageResponse())
         } catch (_: InquiryThreadNotFoundException) {
             ResponseBuilder.response(HttpStatus.NOT_FOUND, ResponseBuilder.Message("THREAD_NOT_FOUND"))
         } catch (_: EmptyInquiryMessageException) {
@@ -224,14 +234,5 @@ class InquiryAdminController {
             entryScreenName = thread.entryScreenName,
             lastMessageAt = thread.lastMessageAt?.toString(),
             createdAt = thread.createdAt.toString(),
-        )
-
-    private fun toMessageResponse(message: InquiryMessage): MessageResponse =
-        MessageResponse(
-            id = message.id!!,
-            senderType = message.senderType,
-            body = message.body,
-            readAt = message.readAt?.toString(),
-            createdAt = message.createdAt.toString(),
         )
 }

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/controller/InquiryController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/controller/InquiryController.kt
@@ -1,6 +1,5 @@
 package app.hyuabot.backend.inquiry.controller
 
-import app.hyuabot.backend.database.entity.InquiryMessage
 import app.hyuabot.backend.database.entity.InquiryThread
 import app.hyuabot.backend.inquiry.InquiryService
 import app.hyuabot.backend.inquiry.domain.MessageListResponse
@@ -8,9 +7,11 @@ import app.hyuabot.backend.inquiry.domain.MessageResponse
 import app.hyuabot.backend.inquiry.domain.OpenThreadRequest
 import app.hyuabot.backend.inquiry.domain.SendMessageRequest
 import app.hyuabot.backend.inquiry.domain.ThreadResponse
+import app.hyuabot.backend.inquiry.domain.toMessageResponse
 import app.hyuabot.backend.inquiry.exception.EmptyInquiryMessageException
 import app.hyuabot.backend.inquiry.exception.InquiryThreadForbiddenException
 import app.hyuabot.backend.inquiry.exception.InquiryThreadNotFoundException
+import app.hyuabot.backend.inquiry.sse.InquirySseRegistry
 import app.hyuabot.backend.utility.ResponseBuilder
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -20,6 +21,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -29,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.util.UUID
 
 @RequestMapping("/api/v1/inquiry")
@@ -36,7 +39,16 @@ import java.util.UUID
 @Tag(name = "Inquiry", description = "문의 채팅(사용자) 관련 API")
 class InquiryController {
     @Autowired private lateinit var service: InquiryService
+
+    @Autowired private lateinit var registry: InquirySseRegistry
     private val logger = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping("/stream", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    @Operation(summary = "문의 실시간 스트림(사용자)", description = "설치 ID에 대한 문의 이벤트를 SSE로 수신합니다.")
+    @ApiResponse(responseCode = "200", description = "SSE 연결 성공")
+    fun stream(
+        @RequestHeader("X-Installation-Id") installationId: UUID,
+    ): SseEmitter = registry.registerForInstallation(installationId.toString())
 
     @PostMapping("/threads")
     @Operation(summary = "문의 스레드 생성", description = "활성 스레드가 있으면 반환하고, 없으면 새로 생성합니다.")
@@ -109,7 +121,7 @@ class InquiryController {
             val messages = service.getMessages(id, installationId, after)
             ResponseBuilder.response(
                 HttpStatus.OK,
-                MessageListResponse(messages.map { toMessageResponse(it) }),
+                MessageListResponse(messages.map { it.toMessageResponse() }),
             )
         } catch (_: InquiryThreadForbiddenException) {
             ResponseBuilder.response(HttpStatus.FORBIDDEN, ResponseBuilder.Message("FORBIDDEN"))
@@ -137,7 +149,7 @@ class InquiryController {
     ): ResponseEntity<*> =
         try {
             val message = service.sendUserMessage(id, installationId, request.body)
-            ResponseBuilder.response(HttpStatus.CREATED, toMessageResponse(message))
+            ResponseBuilder.response(HttpStatus.CREATED, message.toMessageResponse())
         } catch (_: InquiryThreadForbiddenException) {
             ResponseBuilder.response(HttpStatus.FORBIDDEN, ResponseBuilder.Message("FORBIDDEN"))
         } catch (_: InquiryThreadNotFoundException) {
@@ -184,14 +196,5 @@ class InquiryController {
             entryScreenName = thread.entryScreenName,
             lastMessageAt = thread.lastMessageAt?.toString(),
             createdAt = thread.createdAt.toString(),
-        )
-
-    private fun toMessageResponse(message: InquiryMessage): MessageResponse =
-        MessageResponse(
-            id = message.id!!,
-            senderType = message.senderType,
-            body = message.body,
-            readAt = message.readAt?.toString(),
-            createdAt = message.createdAt.toString(),
         )
 }

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/domain/InquiryEvent.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/domain/InquiryEvent.kt
@@ -1,0 +1,21 @@
+package app.hyuabot.backend.inquiry.domain
+
+import app.hyuabot.backend.database.entity.InquiryMessage
+
+data class InquiryEvent(
+    val kind: String,
+    val threadId: String,
+    val installationId: String,
+    val message: MessageResponse? = null,
+    val reader: String? = null,
+    val status: String? = null,
+)
+
+fun InquiryMessage.toMessageResponse(): MessageResponse =
+    MessageResponse(
+        id = id!!,
+        senderType = senderType,
+        body = body,
+        readAt = readAt?.toString(),
+        createdAt = createdAt.toString(),
+    )

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/sse/InquiryEventListener.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/sse/InquiryEventListener.kt
@@ -1,0 +1,28 @@
+package app.hyuabot.backend.inquiry.sse
+
+import app.hyuabot.backend.inquiry.domain.InquiryEvent
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+@Component
+class InquiryEventListener(
+    private val registry: InquirySseRegistry,
+    private val objectMapper: ObjectMapper,
+) : MessageListener {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun onMessage(
+        message: Message,
+        pattern: ByteArray?,
+    ) {
+        try {
+            val event = objectMapper.readValue(message.body, InquiryEvent::class.java)
+            registry.dispatch(event)
+        } catch (e: Exception) {
+            logger.warn("Failed to handle inquiry event", e)
+        }
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/sse/InquiryEventPublisher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/sse/InquiryEventPublisher.kt
@@ -1,0 +1,20 @@
+package app.hyuabot.backend.inquiry.sse
+
+import app.hyuabot.backend.inquiry.domain.InquiryEvent
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+@Component
+class InquiryEventPublisher(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+) {
+    fun publish(event: InquiryEvent) {
+        redisTemplate.convertAndSend(CHANNEL, objectMapper.writeValueAsString(event))
+    }
+
+    companion object {
+        const val CHANNEL = "inquiry:events"
+    }
+}

--- a/src/main/kotlin/app/hyuabot/backend/inquiry/sse/InquirySseRegistry.kt
+++ b/src/main/kotlin/app/hyuabot/backend/inquiry/sse/InquirySseRegistry.kt
@@ -1,0 +1,78 @@
+package app.hyuabot.backend.inquiry.sse
+
+import app.hyuabot.backend.inquiry.domain.InquiryEvent
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import tools.jackson.databind.ObjectMapper
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+@Component
+open class InquirySseRegistry(
+    private val objectMapper: ObjectMapper,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    val installationEmitters = ConcurrentHashMap<String, CopyOnWriteArrayList<SseEmitter>>()
+    val adminEmitters = CopyOnWriteArrayList<SseEmitter>()
+
+    internal open fun createEmitter(timeoutMs: Long): SseEmitter = SseEmitter(timeoutMs)
+
+    fun registerForInstallation(
+        installationId: String,
+        timeoutMs: Long = DEFAULT_TIMEOUT,
+    ): SseEmitter {
+        val emitter = createEmitter(timeoutMs)
+        val emitters = installationEmitters.computeIfAbsent(installationId) { CopyOnWriteArrayList() }
+        emitters.add(emitter)
+        emitter.onCompletion { emitters.remove(emitter) }
+        emitter.onTimeout { emitters.remove(emitter) }
+        emitter.onError { emitters.remove(emitter) }
+        sendInit(emitter)
+        return emitter
+    }
+
+    fun registerForAdmin(timeoutMs: Long = DEFAULT_TIMEOUT): SseEmitter {
+        val emitter = createEmitter(timeoutMs)
+        adminEmitters.add(emitter)
+        emitter.onCompletion { adminEmitters.remove(emitter) }
+        emitter.onTimeout { adminEmitters.remove(emitter) }
+        emitter.onError { adminEmitters.remove(emitter) }
+        sendInit(emitter)
+        return emitter
+    }
+
+    fun dispatch(event: InquiryEvent) {
+        val json = objectMapper.writeValueAsString(event)
+        installationEmitters[event.installationId]?.let { emitters ->
+            emitters.forEach { sendTo(emitters, it, event.kind, json) }
+        }
+        adminEmitters.forEach { sendTo(adminEmitters, it, event.kind, json) }
+    }
+
+    private fun sendInit(emitter: SseEmitter) {
+        try {
+            emitter.send(SseEmitter.event().name("init").data("connected"))
+        } catch (e: Exception) {
+            logger.warn("Failed to send init SSE event", e)
+        }
+    }
+
+    private fun sendTo(
+        emitters: CopyOnWriteArrayList<SseEmitter>,
+        emitter: SseEmitter,
+        name: String,
+        json: String,
+    ) {
+        try {
+            emitter.send(SseEmitter.event().name(name).data(json))
+        } catch (e: Exception) {
+            emitters.remove(emitter)
+            emitter.completeWithError(e)
+        }
+    }
+
+    companion object {
+        const val DEFAULT_TIMEOUT = 1800_000L
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryAdminControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryAdminControllerTest.kt
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delet
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import tools.jackson.databind.ObjectMapper
@@ -358,6 +359,16 @@ class InquiryAdminControllerTest {
                     .content(objectMapper.writeValueAsString(PatchThreadRequest(status = "PENDING"))),
             ).andExpect(status().isInternalServerError)
             .andExpect(jsonPath("$.message").value("INTERNAL_SERVER_ERROR"))
+    }
+
+    @Test
+    @DisplayName("문의 실시간 스트림(관리자) - 200 SSE 연결")
+    @WithCustomMockUser(username = "adminUser")
+    fun testStream() {
+        mockMvc
+            .perform(get("/api/v1/inquiry/admin/stream"))
+            .andExpect(status().isOk)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM))
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryControllerTest.kt
@@ -23,6 +23,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import tools.jackson.databind.ObjectMapper
@@ -335,6 +336,15 @@ class InquiryControllerTest {
             .perform(post("/api/v1/inquiry/threads/$threadId/read").header("X-Installation-Id", installationHeader()))
             .andExpect(status().isNotFound)
             .andExpect(jsonPath("$.message").value("THREAD_NOT_FOUND"))
+    }
+
+    @Test
+    @DisplayName("문의 실시간 스트림 - 200 SSE 연결")
+    fun testStream() {
+        mockMvc
+            .perform(get("/api/v1/inquiry/stream").header("X-Installation-Id", installationHeader()))
+            .andExpect(status().isOk)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM))
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryDtoTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryDtoTest.kt
@@ -1,5 +1,7 @@
 package app.hyuabot.backend.inquiry
 
+import app.hyuabot.backend.inquiry.domain.InquiryEvent
+import app.hyuabot.backend.inquiry.domain.MessageResponse
 import app.hyuabot.backend.inquiry.domain.PatchThreadRequest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -8,6 +10,49 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class InquiryDtoTest {
+    @Test
+    fun inquiryEvent() {
+        val message =
+            MessageResponse(
+                id = 1L,
+                senderType = "USER",
+                body = "hi",
+                readAt = null,
+                createdAt = "2026-07-29T12:00:00+09:00",
+            )
+        val event =
+            InquiryEvent(
+                kind = "message",
+                threadId = "thread",
+                installationId = "install",
+                message = message,
+                reader = "USER",
+                status = "OPEN",
+            )
+        assertEquals("message", event.kind)
+        assertEquals("thread", event.threadId)
+        assertEquals("install", event.installationId)
+        assertEquals(message, event.message)
+        assertEquals("USER", event.reader)
+        assertEquals("OPEN", event.status)
+        assertEquals("message", event.component1())
+        assertEquals("thread", event.component2())
+        assertEquals("install", event.component3())
+        assertEquals(message, event.component4())
+        assertEquals("USER", event.component5())
+        assertEquals("OPEN", event.component6())
+        assertEquals(event, event.copy())
+        assertEquals(event.hashCode(), event.copy().hashCode())
+        assertEquals("thread2", event.copy(threadId = "thread2").threadId)
+        assertTrue(event.toString().contains("message"))
+
+        val defaults = InquiryEvent(kind = "read", threadId = "t", installationId = "i")
+        assertNull(defaults.message)
+        assertNull(defaults.reader)
+        assertNull(defaults.status)
+        assertNotEquals(event, defaults)
+    }
+
     @Test
     fun patchThreadRequest() {
         val request = PatchThreadRequest(status = "PENDING", assignedAdminUserId = "admin")

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryEventListenerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryEventListenerTest.kt
@@ -1,0 +1,46 @@
+package app.hyuabot.backend.inquiry
+
+import app.hyuabot.backend.inquiry.domain.InquiryEvent
+import app.hyuabot.backend.inquiry.sse.InquiryEventListener
+import app.hyuabot.backend.inquiry.sse.InquirySseRegistry
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.connection.Message
+import tools.jackson.databind.ObjectMapper
+
+class InquiryEventListenerTest {
+    private val registry = mock<InquirySseRegistry>()
+    private val objectMapper = ObjectMapper()
+    private val listener = InquiryEventListener(registry, objectMapper)
+
+    @Test
+    @DisplayName("onMessage - 정상 JSON -> dispatch 호출")
+    fun testOnMessageValid() {
+        val event =
+            InquiryEvent(
+                kind = "thread",
+                threadId = "t",
+                installationId = "i",
+                status = "OPEN",
+            )
+        val message = mock<Message>()
+        whenever(message.body).thenReturn(objectMapper.writeValueAsBytes(event))
+        listener.onMessage(message, null)
+        verify(registry).dispatch(argThat { kind == "thread" && status == "OPEN" })
+    }
+
+    @Test
+    @DisplayName("onMessage - 잘못된 JSON -> 예외 무시, dispatch 미호출")
+    fun testOnMessageInvalid() {
+        val message = mock<Message>()
+        whenever(message.body).thenReturn("not-json".toByteArray())
+        listener.onMessage(message, null)
+        verify(registry, never()).dispatch(any())
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryEventPublisherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryEventPublisherTest.kt
@@ -1,0 +1,33 @@
+package app.hyuabot.backend.inquiry
+
+import app.hyuabot.backend.inquiry.domain.InquiryEvent
+import app.hyuabot.backend.inquiry.sse.InquiryEventPublisher
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.springframework.data.redis.core.RedisTemplate
+import tools.jackson.databind.ObjectMapper
+
+class InquiryEventPublisherTest {
+    private val redisTemplate = mock<RedisTemplate<String, String>>()
+    private val objectMapper = ObjectMapper()
+    private val publisher = InquiryEventPublisher(redisTemplate, objectMapper)
+
+    @Test
+    @DisplayName("publish - Redis 채널로 이벤트 직렬화 전송")
+    fun testPublish() {
+        val event =
+            InquiryEvent(
+                kind = "read",
+                threadId = "22222222-2222-2222-2222-222222222222",
+                installationId = "11111111-1111-1111-1111-111111111111",
+                reader = "USER",
+            )
+        publisher.publish(event)
+        verify(redisTemplate).convertAndSend(
+            InquiryEventPublisher.CHANNEL,
+            objectMapper.writeValueAsString(event),
+        )
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquiryServiceTest.kt
@@ -4,10 +4,12 @@ import app.hyuabot.backend.database.entity.InquiryMessage
 import app.hyuabot.backend.database.entity.InquiryThread
 import app.hyuabot.backend.database.repository.InquiryMessageRepository
 import app.hyuabot.backend.database.repository.InquiryThreadRepository
+import app.hyuabot.backend.inquiry.domain.InquiryEvent
 import app.hyuabot.backend.inquiry.exception.EmptyInquiryMessageException
 import app.hyuabot.backend.inquiry.exception.InquiryThreadForbiddenException
 import app.hyuabot.backend.inquiry.exception.InquiryThreadNotFoundException
 import app.hyuabot.backend.inquiry.exception.InvalidInquiryStatusException
+import app.hyuabot.backend.inquiry.sse.InquiryEventPublisher
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -35,6 +37,9 @@ class InquiryServiceTest {
 
     @Mock
     lateinit var messageRepository: InquiryMessageRepository
+
+    @Mock
+    lateinit var eventPublisher: InquiryEventPublisher
 
     @InjectMocks
     lateinit var service: InquiryService
@@ -132,6 +137,7 @@ class InquiryServiceTest {
         whenever(
             threadRepository.findFirstByInstallationIdAndStatusInOrderByCreatedAtDesc(installationId, InquiryService.ACTIVE_STATUSES),
         ).thenReturn(existing)
+        whenever(messageRepository.save(any<InquiryMessage>())).thenAnswer { (it.arguments[0] as InquiryMessage).apply { id = 10L } }
         val result =
             service.openOrGetActiveThread(installationId, "iOS", null, null, null, "shuttle", "셔틀")
         assertSame(existing, result)
@@ -143,6 +149,12 @@ class InquiryServiceTest {
                 senderType == "SYSTEM" && body == InquiryService.entryScreenSystemMessage("셔틀")
             },
         )
+        verify(eventPublisher).publish(
+            argThat<InquiryEvent> {
+                kind == "message" &&
+                    installationId == this@InquiryServiceTest.installationId.toString()
+            },
+        )
     }
 
     @Test
@@ -152,6 +164,7 @@ class InquiryServiceTest {
         whenever(
             threadRepository.findFirstByInstallationIdAndStatusInOrderByCreatedAtDesc(installationId, InquiryService.ACTIVE_STATUSES),
         ).thenReturn(existing)
+        whenever(messageRepository.save(any<InquiryMessage>())).thenAnswer { (it.arguments[0] as InquiryMessage).apply { id = 11L } }
         service.openOrGetActiveThread(installationId, "iOS", null, null, null, "cafeteria", null)
         assertNull(existing.entryScreenName)
         verify(messageRepository).save(
@@ -225,12 +238,13 @@ class InquiryServiceTest {
     fun testSendUserMessage() {
         val target = thread()
         whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(target))
-        whenever(messageRepository.save(any<InquiryMessage>())).thenAnswer { it.arguments[0] as InquiryMessage }
+        whenever(messageRepository.save(any<InquiryMessage>())).thenAnswer { (it.arguments[0] as InquiryMessage).apply { id = 1L } }
         val result = service.sendUserMessage(threadId, installationId, "안녕하세요")
         assertEquals("USER", result.senderType)
         assertEquals("안녕하세요", result.body)
         assertNotNull(target.lastMessageAt)
         verify(threadRepository).save(target)
+        verify(eventPublisher).publish(argThat<InquiryEvent> { kind == "message" && message?.senderType == "USER" })
     }
 
     @Test
@@ -248,6 +262,7 @@ class InquiryServiceTest {
         whenever(messageRepository.findByThreadIdAndSenderTypeAndReadAtIsNull(threadId, "ADMIN")).thenReturn(listOf(unread))
         service.markReadByUser(threadId, installationId)
         assertNotNull(unread.readAt)
+        verify(eventPublisher).publish(argThat<InquiryEvent> { kind == "read" && reader == "USER" })
     }
 
     @Test
@@ -310,12 +325,13 @@ class InquiryServiceTest {
     fun testAdminReply() {
         val target = thread()
         whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(target))
-        whenever(messageRepository.save(any<InquiryMessage>())).thenAnswer { it.arguments[0] as InquiryMessage }
+        whenever(messageRepository.save(any<InquiryMessage>())).thenAnswer { (it.arguments[0] as InquiryMessage).apply { id = 1L } }
         val result = service.adminReply(threadId, "adminUser", "답변입니다")
         assertEquals("ADMIN", result.senderType)
         assertEquals("adminUser", result.senderAdminUserId)
         assertEquals("답변입니다", result.body)
         verify(threadRepository).save(target)
+        verify(eventPublisher).publish(argThat<InquiryEvent> { kind == "message" && message?.senderType == "ADMIN" })
     }
 
     @Test
@@ -333,6 +349,7 @@ class InquiryServiceTest {
         whenever(messageRepository.findByThreadIdAndSenderTypeAndReadAtIsNull(threadId, "USER")).thenReturn(listOf(unread))
         service.adminMarkRead(threadId)
         assertNotNull(unread.readAt)
+        verify(eventPublisher).publish(argThat<InquiryEvent> { kind == "read" && reader == "ADMIN" })
     }
 
     @Test
@@ -360,6 +377,7 @@ class InquiryServiceTest {
         whenever(threadRepository.save(any<InquiryThread>())).thenAnswer { it.arguments[0] as InquiryThread }
         val result = service.adminUpdateThread(threadId, "PENDING", null)
         assertEquals("PENDING", result.status)
+        verify(eventPublisher).publish(argThat<InquiryEvent> { kind == "thread" && status == "PENDING" })
     }
 
     @Test
@@ -386,6 +404,7 @@ class InquiryServiceTest {
         whenever(threadRepository.findById(threadId)).thenReturn(Optional.of(target))
         service.adminCloseThread(threadId)
         verify(threadRepository).delete(target)
+        verify(eventPublisher).publish(argThat<InquiryEvent> { kind == "thread" && status == "CLOSED" })
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/inquiry/InquirySseRegistryTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/inquiry/InquirySseRegistryTest.kt
@@ -1,0 +1,124 @@
+package app.hyuabot.backend.inquiry
+
+import app.hyuabot.backend.inquiry.domain.InquiryEvent
+import app.hyuabot.backend.inquiry.sse.InquirySseRegistry
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import tools.jackson.databind.ObjectMapper
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.function.Consumer
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class InquirySseRegistryTest {
+    private fun registryWithEmitter(emitter: SseEmitter) =
+        object : InquirySseRegistry(ObjectMapper()) {
+            override fun createEmitter(timeoutMs: Long): SseEmitter = emitter
+        }
+
+    @Test
+    @DisplayName("registerForInstallation - 등록 및 콜백에서 제거")
+    fun testRegisterForInstallation() {
+        val emitter = mock<SseEmitter>()
+        val registry = registryWithEmitter(emitter)
+        val result = registry.registerForInstallation("inst")
+        assertSame(emitter, result)
+        assertEquals(1, registry.installationEmitters["inst"]!!.size)
+        verify(emitter).send(any<SseEmitter.SseEventBuilder>())
+
+        val completion = argumentCaptor<Runnable>()
+        verify(emitter).onCompletion(completion.capture())
+        val timeout = argumentCaptor<Runnable>()
+        verify(emitter).onTimeout(timeout.capture())
+        val error = argumentCaptor<Consumer<Throwable>>()
+        verify(emitter).onError(error.capture())
+
+        completion.firstValue.run()
+        timeout.firstValue.run()
+        error.firstValue.accept(RuntimeException("boom"))
+        assertTrue(registry.installationEmitters["inst"]!!.isEmpty())
+    }
+
+    @Test
+    @DisplayName("registerForAdmin - 등록 및 콜백에서 제거")
+    fun testRegisterForAdmin() {
+        val emitter = mock<SseEmitter>()
+        val registry = registryWithEmitter(emitter)
+        val result = registry.registerForAdmin()
+        assertSame(emitter, result)
+        assertEquals(1, registry.adminEmitters.size)
+        verify(emitter).send(any<SseEmitter.SseEventBuilder>())
+
+        val completion = argumentCaptor<Runnable>()
+        verify(emitter).onCompletion(completion.capture())
+        val timeout = argumentCaptor<Runnable>()
+        verify(emitter).onTimeout(timeout.capture())
+        val error = argumentCaptor<Consumer<Throwable>>()
+        verify(emitter).onError(error.capture())
+
+        completion.firstValue.run()
+        timeout.firstValue.run()
+        error.firstValue.accept(RuntimeException("boom"))
+        assertTrue(registry.adminEmitters.isEmpty())
+    }
+
+    @Test
+    @DisplayName("register - 초기 이벤트 전송 실패는 무시")
+    fun testRegisterSendInitFailureIsCaught() {
+        val emitter = mock<SseEmitter>()
+        doThrow(RuntimeException("boom")).whenever(emitter).send(any<SseEmitter.SseEventBuilder>())
+        val registry = registryWithEmitter(emitter)
+        registry.registerForAdmin()
+        assertEquals(1, registry.adminEmitters.size)
+    }
+
+    @Test
+    @DisplayName("createEmitter - 실제 SseEmitter 생성")
+    fun testCreateRealEmitter() {
+        val registry = InquirySseRegistry(ObjectMapper())
+        val emitter = registry.registerForInstallation("real")
+        assertNotNull(emitter)
+        assertEquals(1, registry.installationEmitters["real"]!!.size)
+    }
+
+    @Test
+    @DisplayName("dispatch - 설치/관리자 전송 및 미등록 설치 분기")
+    fun testDispatchSuccessAndUnknownInstallation() {
+        val registry = InquirySseRegistry(ObjectMapper())
+        val instEmitter = mock<SseEmitter>()
+        registry.installationEmitters["inst"] = CopyOnWriteArrayList<SseEmitter>().apply { add(instEmitter) }
+        val adminEmitter = mock<SseEmitter>()
+        registry.adminEmitters.add(adminEmitter)
+
+        registry.dispatch(InquiryEvent(kind = "message", threadId = "t", installationId = "inst"))
+        verify(instEmitter).send(any<SseEmitter.SseEventBuilder>())
+        verify(adminEmitter).send(any<SseEmitter.SseEventBuilder>())
+
+        registry.dispatch(InquiryEvent(kind = "read", threadId = "t", installationId = "unknown", reader = "ADMIN"))
+        verify(instEmitter).send(any<SseEmitter.SseEventBuilder>())
+        verify(adminEmitter, times(2)).send(any<SseEmitter.SseEventBuilder>())
+    }
+
+    @Test
+    @DisplayName("dispatch - 전송 실패 시 emitter 제거")
+    fun testDispatchRemovesFailingEmitter() {
+        val registry = InquirySseRegistry(ObjectMapper())
+        val failing = mock<SseEmitter>()
+        doThrow(RuntimeException("x")).whenever(failing).send(any<SseEmitter.SseEventBuilder>())
+        registry.adminEmitters.add(failing)
+
+        registry.dispatch(InquiryEvent(kind = "thread", threadId = "t", installationId = "i", status = "CLOSED"))
+        verify(failing).completeWithError(any())
+        assertTrue(registry.adminEmitters.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

- Deliver real-time inquiry updates over Server-Sent Events, replacing the admin/app polling with a push stream.
- User stream `GET /api/v1/inquiry/stream` (anonymous, keyed by the `X-Installation-Id` header) and admin stream `GET /api/v1/inquiry/admin/stream` (`INQUIRY` authority) return an `SseEmitter`.
- `InquiryService` publishes an `InquiryEvent` (message / read / thread) to the Redis channel `inquiry:events` after each mutation; every backend replica subscribes and dispatches to its locally-connected emitters, so events fan out correctly across the 2-replica deployment.

## Details

- New `inquiry/sse` package: `InquirySseRegistry` (installation- and admin-keyed emitters with completion/timeout/error cleanup and failed-send eviction), `InquiryEventPublisher` (Redis `convertAndSend`), `InquiryEventListener` (`MessageListener` → deserialize → dispatch).
- `InquiryEvent` domain type plus a shared `InquiryMessage.toMessageResponse()` extension (deduplicates the mapper that was in the controllers).
- `RedisConfig` gains a `RedisMessageListenerContainer` bound to the `inquiry:events` topic.
- Events are published from send/reply, user/admin read, status change, close, and the entry-screen SYSTEM message.
- No `SecurityConfig` change: the stream paths fall under the existing `/api/v1/inquiry/**` (permitAll) and `/api/v1/inquiry/admin/**` (`INQUIRY`) matchers.
- No server-side keep-alive ping; relies on `EventSource` auto-reconnect (the reverse proxy needs SSE buffering off and a long read timeout on the stream paths — infrastructure-side, out of this repo).

## Validation

- `./gradlew ktlintCheck`
- `./gradlew clean test jacocoTestCoverageVerification` — 100% line and branch coverage (gate), instruction coverage also 100% for the new/changed classes.
