### PR TITLE
feat: Expose shuttle presence counts for riders

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceController.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceController.kt
@@ -3,6 +3,7 @@ package app.hyuabot.backend.presence
 import app.hyuabot.backend.utility.ResponseBuilder
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -13,6 +14,9 @@ import org.springframework.web.bind.annotation.RestController
 class ShuttlePresenceController(
     private val shuttlePresenceService: ShuttlePresenceService,
 ) {
+    @GetMapping
+    fun getViewerCounts(): ResponseEntity<ShuttlePresenceCountsResponse> = ResponseEntity.ok(shuttlePresenceService.getViewerCounts())
+
     @PostMapping
     fun heartbeat(
         @RequestBody request: ShuttlePresenceRequest,

--- a/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceResponse.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceResponse.kt
@@ -8,3 +8,14 @@ data class ShuttlePresenceResponse(
     val updatedAt: Instant,
     val activeWindowSeconds: Long,
 )
+
+data class ShuttlePresenceCountsResponse(
+    val stops: List<StopViewerCount>,
+    val updatedAt: Instant,
+) {
+    data class StopViewerCount(
+        val stopId: String,
+        val viewerCount: Long?,
+        val visible: Boolean,
+    )
+}

--- a/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/presence/ShuttlePresenceService.kt
@@ -62,6 +62,27 @@ class ShuttlePresenceService(
         return responseFor(count, now, nowEpoch - window.startEpoch)
     }
 
+    fun getViewerCounts(): ShuttlePresenceCountsResponse {
+        val now = Instant.now(watchAnalyticsClock)
+        val nowEpoch = now.epochSecond
+        val counts =
+            Stop.entries.map { stop ->
+                val window = shuttleDemandWindowService.demandWindow(stop.value, now)
+                val count =
+                    if (window == null) {
+                        0L
+                    } else {
+                        redisTemplate
+                            .opsForZSet()
+                            .count("presence:shuttle:${stop.value}", window.startEpoch.toDouble(), Double.POSITIVE_INFINITY) ?: 0L
+                    }
+                val activeWindowSeconds = window?.let { nowEpoch - it.startEpoch } ?: 0L
+                val response = responseFor(count, now, activeWindowSeconds)
+                ShuttlePresenceCountsResponse.StopViewerCount(stop.value, response.viewerCount, response.visible)
+            }
+        return ShuttlePresenceCountsResponse(stops = counts, updatedAt = now)
+    }
+
     internal fun responseFor(
         count: Long,
         now: Instant,

--- a/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceControllerTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceControllerTest.kt
@@ -21,6 +21,22 @@ class ShuttlePresenceControllerTest {
         )
 
     @Test
+    fun `returns all visible viewer counts without recording a heartbeat`() {
+        val counts =
+            ShuttlePresenceCountsResponse(
+                stops = listOf(ShuttlePresenceCountsResponse.StopViewerCount("station", 4L, true)),
+                updatedAt = Instant.parse("2026-07-21T03:00:00Z"),
+            )
+        whenever(service.getViewerCounts()).thenReturn(counts)
+
+        val response = controller.getViewerCounts()
+
+        assertEquals(200, response.statusCode.value())
+        assertEquals(counts, response.body)
+        verify(service).getViewerCounts()
+    }
+
+    @Test
     fun `returns the presence response for a valid heartbeat`() {
         val presence =
             ShuttlePresenceResponse(

--- a/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceServiceTest.kt
@@ -7,6 +7,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ZSetOperations
 import org.springframework.data.redis.core.script.RedisScript
 import java.time.Clock
 import java.time.Instant
@@ -19,6 +20,7 @@ import kotlin.test.assertTrue
 class ShuttlePresenceServiceTest {
     private val now = Instant.parse("2026-07-21T03:00:00Z")
     private val redisTemplate = mock<RedisTemplate<String, String>>()
+    private val zSetOps = mock<ZSetOperations<String, String>>()
     private val meterRegistry = SimpleMeterRegistry()
     private val demandWindowService = mock<ShuttleDemandWindowService>()
     private val service =
@@ -28,6 +30,41 @@ class ShuttlePresenceServiceTest {
             Clock.fixed(now, ZoneOffset.UTC),
             demandWindowService,
         )
+
+    @Test
+    fun `returns visible viewer counts for every stop without writing a heartbeat`() {
+        whenever(redisTemplate.opsForZSet()).thenReturn(zSetOps)
+        val activeWindow = ShuttleDemandWindowService.DemandWindow(now.epochSecond - 600, 300)
+        whenever(demandWindowService.demandWindow("dormitory_o", now)).thenReturn(activeWindow)
+        whenever(demandWindowService.demandWindow("shuttlecock_o", now)).thenReturn(activeWindow)
+        whenever(demandWindowService.demandWindow("station", now)).thenReturn(null)
+        whenever(demandWindowService.demandWindow("terminal", now)).thenReturn(activeWindow)
+        whenever(demandWindowService.demandWindow("jungang_stn", now)).thenReturn(null)
+        whenever(demandWindowService.demandWindow("shuttlecock_i", now)).thenReturn(activeWindow)
+        whenever(zSetOps.count("presence:shuttle:dormitory_o", activeWindow.startEpoch.toDouble(), Double.POSITIVE_INFINITY))
+            .thenReturn(5L)
+        whenever(zSetOps.count("presence:shuttle:shuttlecock_o", activeWindow.startEpoch.toDouble(), Double.POSITIVE_INFINITY))
+            .thenReturn(2L)
+        whenever(zSetOps.count("presence:shuttle:terminal", activeWindow.startEpoch.toDouble(), Double.POSITIVE_INFINITY))
+            .thenReturn(null)
+        whenever(zSetOps.count("presence:shuttle:shuttlecock_i", activeWindow.startEpoch.toDouble(), Double.POSITIVE_INFINITY))
+            .thenReturn(3L)
+
+        val response = service.getViewerCounts()
+
+        assertEquals(now, response.updatedAt)
+        assertEquals(
+            listOf(
+                ShuttlePresenceCountsResponse.StopViewerCount("dormitory_o", 5L, true),
+                ShuttlePresenceCountsResponse.StopViewerCount("shuttlecock_o", null, false),
+                ShuttlePresenceCountsResponse.StopViewerCount("station", null, false),
+                ShuttlePresenceCountsResponse.StopViewerCount("terminal", null, false),
+                ShuttlePresenceCountsResponse.StopViewerCount("jungang_stn", null, false),
+                ShuttlePresenceCountsResponse.StopViewerCount("shuttlecock_i", 3L, true),
+            ),
+            response.stops,
+        )
+    }
 
     @Test
     fun `records a valid heartbeat and returns the demand count until the next departure`() {


### PR DESCRIPTION
## Summary

- Add a public read-only shuttle-presence snapshot for the rider apps.
- Return every supported stop in one response without recording a heartbeat or extending a user session.
- Preserve the existing privacy threshold: counts below three remain hidden.

## Details

- `GET /api/v1/presence/shuttle` returns the six stop IDs, their visible viewer counts, and a common update time.
- The endpoint uses each stop's current departure window when reading Redis, so stopped routes and small groups produce hidden counts.
- Existing `POST /api/v1/presence/shuttle` heartbeat behavior is unchanged.

## Validation

- `./gradlew ktlintCheck test jacocoTestCoverageVerification`
- JaCoCo: 100% project line and branch coverage (gate)
