### PR TITLE
fix: Clean up Buildx builders after deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:
-          keep-state: true
-          cleanup: false
+          keep-state: false
+          cleanup: true
       - name: Build image
         uses: docker/build-push-action@v7
         with:


### PR DESCRIPTION
## Summary

- Stop preserving Buildx state after deployment image builds.
- Enable the setup action cleanup hook so the self-hosted Mac runner does not retain BuildKit containers or volumes.

## Validation

- Ran `git diff --check`.
- Confirmed the workflow selects the online `Jeongin-MBP` container-build runner.