### PR TITLE
fix: Cache watch analytics gauges instead of querying Redis per scrape

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,9 +92,8 @@ jobs:
           image: ${{ env.IMAGE_NAME }}
 
   deploy:
-    # Merged pull requests publish and sync the immutable SHA image only.
-    # Production rollout remains an explicit manual action.
-    if: github.event_name == 'workflow_dispatch'
+    # Runs on workflow_dispatch, and automatically after a pull request merges to main.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     needs: sync
     runs-on: [self-hosted, ARM64, Linux, 1st]
     environment: production

--- a/src/main/kotlin/app/hyuabot/backend/HyuabotBackendKotlinApplication.kt
+++ b/src/main/kotlin/app/hyuabot/backend/HyuabotBackendKotlinApplication.kt
@@ -2,8 +2,10 @@ package app.hyuabot.backend
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling
 class HyuabotBackendKotlinApplication {
     companion object {
         @JvmStatic

--- a/src/main/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsService.kt
@@ -3,11 +3,13 @@ package app.hyuabot.backend.watchanalytics
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 @Service
 class WatchAnalyticsService(
@@ -15,9 +17,20 @@ class WatchAnalyticsService(
     private val meterRegistry: MeterRegistry,
     private val watchAnalyticsClock: Clock,
 ) {
+    private val activeInstallationCounts = ConcurrentHashMap<String, Double>()
+
     init {
-        Platform.entries.forEach { platform -> registerActiveInstallationGauge(platform.value) }
-        registerActiveInstallationGauge(ALL_PLATFORMS)
+        val platforms = Platform.entries.map { it.value } + ALL_PLATFORMS
+        platforms.forEach { activeInstallationCounts[it] = 0.0 }
+        platforms.forEach { platform -> registerActiveInstallationGauge(platform) }
+    }
+
+    @Scheduled(fixedDelay = ACTIVE_INSTALLATION_REFRESH_INTERVAL_MS, initialDelay = 0)
+    internal fun refreshActiveInstallationCounts() {
+        activeInstallationCounts.keys.forEach { platform ->
+            activeInstallationCounts[platform] =
+                redisTemplate.opsForHyperLogLog().size(*activeInstallationKeys(platform).toTypedArray()).toDouble()
+        }
     }
 
     fun record(request: WatchAnalyticsEventRequest) {
@@ -62,9 +75,8 @@ class WatchAnalyticsService(
 
     private fun registerActiveInstallationGauge(platform: String) {
         Gauge
-            .builder("hyuabot.watch.active.installations") {
-                redisTemplate.opsForHyperLogLog().size(*activeInstallationKeys(platform).toTypedArray()).toDouble()
-            }.description("Estimated distinct Watch installations active during the rolling window")
+            .builder("hyuabot.watch.active.installations") { activeInstallationCounts.getValue(platform) }
+            .description("Estimated distinct Watch installations active during the rolling window")
             .tag("platform", platform)
             .tag("window", "${ACTIVE_WINDOW_DAYS}d")
             .register(meterRegistry)
@@ -131,6 +143,7 @@ class WatchAnalyticsService(
         private const val ACTIVE_WINDOW_DAYS = 28
         private const val ALL_PLATFORMS = "all"
         private const val NONE = "none"
+        private const val ACTIVE_INSTALLATION_REFRESH_INTERVAL_MS = 300_000L
         private val ACTIVE_KEY_TTL = Duration.ofDays(35)
         private val APP_VERSION_REGEX = Regex("[0-9A-Za-z][0-9A-Za-z.+_-]{0,31}")
     }

--- a/src/test/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/watchanalytics/WatchAnalyticsServiceTest.kt
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.data.redis.core.HyperLogLogOperations
@@ -121,18 +122,49 @@ class WatchAnalyticsServiceTest {
     }
 
     @Test
-    fun `reports rolling active installations through the platform gauge`() {
-        val gauge =
-            meterRegistry
-                .get("hyuabot.watch.active.installations")
-                .tag("platform", "watchos")
-                .tag("window", "28d")
-                .gauge()
-
-        assertEquals(0.0, gauge.value())
-        verify(hyperLogLogOperations).size(
+    fun `gauge starts at zero before the scheduled refresh runs`() {
+        listOf("watchos", "wear_os", "all").forEach { platform ->
+            assertEquals(
+                0.0,
+                meterRegistry
+                    .get("hyuabot.watch.active.installations")
+                    .tag("platform", platform)
+                    .tag("window", "28d")
+                    .gauge()
+                    .value(),
+            )
+        }
+        verify(hyperLogLogOperations, never()).size(
             *service.activeInstallationKeys("watchos", LocalDate.of(2026, 7, 13)).toTypedArray(),
         )
+    }
+
+    @Test
+    fun `refreshes gauges from redis on schedule`() {
+        val today = LocalDate.of(2026, 7, 13)
+        val watchosKeys = service.activeInstallationKeys("watchos", today).toTypedArray()
+        val wearOsKeys = service.activeInstallationKeys("wear_os", today).toTypedArray()
+        val allKeys = service.activeInstallationKeys("all", today).toTypedArray()
+        whenever(hyperLogLogOperations.size(*watchosKeys)).thenReturn(7L)
+        whenever(hyperLogLogOperations.size(*wearOsKeys)).thenReturn(7L)
+        whenever(hyperLogLogOperations.size(*allKeys)).thenReturn(7L)
+
+        service.refreshActiveInstallationCounts()
+
+        listOf("watchos", "wear_os", "all").forEach { platform ->
+            assertEquals(
+                7.0,
+                meterRegistry
+                    .get("hyuabot.watch.active.installations")
+                    .tag("platform", platform)
+                    .tag("window", "28d")
+                    .gauge()
+                    .value(),
+            )
+        }
+        verify(hyperLogLogOperations).size(*watchosKeys)
+        verify(hyperLogLogOperations).size(*wearOsKeys)
+        verify(hyperLogLogOperations).size(*allKeys)
     }
 
     private fun validRequest(


### PR DESCRIPTION
## Summary

- Move the Redis PFCOUNT lookup behind a 5-minute scheduled refresh instead of running it on every metrics scrape.
- Gauges now read a cached value; Redis is no longer touched at scrape time.
- Auto-run the production deploy job on merge to main instead of requiring a manual `workflow_dispatch`.

## Details

- `hyuabot.watch.active.installations` gauges (per platform + `all`) previously re-ran `PFCOUNT` across 28 days of HyperLogLog keys inside the Micrometer value-supplier lambda, so every Prometheus scrape (~15-20s) hit Redis directly. With low/zero traffic on some platforms, this generated a large, steady stream of Redis keyspace misses that dragged down the server-level hit ratio shown in Grafana.
- `WatchAnalyticsService` now caches counts in memory and refreshes them via `@Scheduled(fixedDelay = 5min)`; gauge reads are a plain map lookup.
- `deploy.yml`: the `deploy` job now also runs when a pull request merges to `main`, in addition to `workflow_dispatch`.

## Validation

- `./gradlew ktlintCheck test jacocoTestCoverageVerification`
- JaCoCo: 100% project line and branch coverage (gate)