### PR TITLE
test: Cover StopViewerCount property getters

### DIFF
--- a/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/presence/ShuttlePresenceServiceTest.kt
@@ -64,6 +64,10 @@ class ShuttlePresenceServiceTest {
             ),
             response.stops,
         )
+        val firstStop = response.stops.first()
+        assertEquals("dormitory_o", firstStop.stopId)
+        assertEquals(5L, firstStop.viewerCount)
+        assertTrue(firstStop.visible)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Close a pre-existing 0.02% overall instruction coverage gap (visible on prior PRs as `Overall Project 99.98% :x:`, e.g. #119, #120).
- `ShuttlePresenceCountsResponse.StopViewerCount`'s generated `getStopId()`/`getViewerCount()`/`getVisible()` getters were never invoked: the only assertion compared the whole `stops` list by structural equality (`equals()`, which reads fields directly rather than through the public getters).

## Details

- `ShuttlePresenceServiceTest.kt`: after the existing list-equality assertion, read the first stop's properties directly and assert their values.

## Validation

- `./gradlew ktlintCheck test jacocoTestReport jacocoTestCoverageVerification`
- JaCoCo: 100.0000% overall INSTRUCTION/LINE/BRANCH/METHOD/CLASS coverage (verified directly against the XML report, not just the enforced LINE+BRANCH gate)