### PR TITLE
fix: Scale departure log clustering window to each route's headway

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/bus/service/BusRealtimeService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/bus/service/BusRealtimeService.kt
@@ -40,6 +40,24 @@ class BusRealtimeService(
         return if (seconds >= threshold) seconds else seconds + 24 * 60 * 60
     }
 
+    /** Median gap (minutes) between consecutive scheduled departures — this route's typical dispatch interval. */
+    internal fun estimateHeadwayMinutes(departureTimes: List<LocalTime>): Int? {
+        if (departureTimes.size < 2) return null
+        val sortedSeconds = departureTimes.map { toServiceSeconds(it) }.sorted()
+        val gapMinutes = sortedSeconds.zipWithNext { a, b -> (b - a) / 60 }.filter { it > 0 }
+        if (gapMinutes.isEmpty()) return null
+        val sortedGaps = gapMinutes.sorted()
+        val mid = sortedGaps.size / 2
+        return if (sortedGaps.size % 2 == 0) (sortedGaps[mid - 1] + sortedGaps[mid]) / 2 else sortedGaps[mid]
+    }
+
+    /**
+     * Departure-log clustering window: a fraction of the route's own headway, so frequent routes
+     * (short headway) don't blur two distinct dispatches together, while infrequent routes get more
+     * slack to absorb day-to-day timing jitter.
+     */
+    internal fun clusterThresholdMinutes(headwayMinutes: Int?): Int = (((headwayMinutes ?: 12) / 3).coerceIn(2, 12))
+
     internal fun clusterDepartureTimes(
         times: List<LocalTime>,
         thresholdMinutes: Int = 3,
@@ -137,15 +155,16 @@ class BusRealtimeService(
                         isRealtime = true,
                     )
                 }
+            val timetableEntries = timetableGrouped[key.routeID to key.startStopID] ?: emptyList()
+            val headwayMinutes = estimateHeadwayMinutes(timetableEntries.map { it.departureTime })
             val rawLogTimes =
                 (logGrouped[key.routeID to key.stopID] ?: emptyList())
                     .map { it.departureTime }
             val logArrivals =
-                clusterDepartureTimes(rawLogTimes)
+                clusterDepartureTimes(rawLogTimes, clusterThresholdMinutes(headwayMinutes))
                     .filter { time -> (toServiceSeconds(time) - toServiceSeconds(currentTime)) / 60 > cutoffMinutes }
                     .map { logTime ->
                         val estimatedTerminalTime = logTime.minusMinutes(key.minuteFromStart.toLong())
-                        val timetableEntries = timetableGrouped[key.routeID to key.startStopID] ?: emptyList()
                         var terminalTime = estimatedTerminalTime
                         var bestDiff = Int.MAX_VALUE
                         for (entry in timetableEntries) {
@@ -159,7 +178,7 @@ class BusRealtimeService(
                     }.sortedBy { toServiceSeconds(it.time!!) }
             val scheduledArrivals =
                 if (logArrivals.isEmpty()) {
-                    (timetableGrouped[key.routeID to key.startStopID] ?: emptyList())
+                    timetableEntries
                         .filter { timetable ->
                             val estimatedArrival = timetable.departureTime.plusMinutes(key.minuteFromStart.toLong())
                             (toServiceSeconds(estimatedArrival) - toServiceSeconds(currentTime)) / 60 > cutoffMinutes

--- a/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/bus/BusServiceTest.kt
@@ -3675,6 +3675,74 @@ class BusServiceTest {
     }
 
     @Test
+    @DisplayName("배차 간격 추정 - 시간표 항목이 1개 이하면 null")
+    fun testEstimateHeadwayMinutesNotEnoughData() {
+        assertEquals(null, realtimeService.estimateHeadwayMinutes(emptyList()))
+        assertEquals(null, realtimeService.estimateHeadwayMinutes(listOf(LocalTime.parse("08:00:00"))))
+    }
+
+    @Test
+    @DisplayName("배차 간격 추정 - 모든 시각이 동일하면(간격 0) null")
+    fun testEstimateHeadwayMinutesAllSameTime() {
+        val result =
+            realtimeService.estimateHeadwayMinutes(
+                listOf(LocalTime.parse("08:00:00"), LocalTime.parse("08:00:00")),
+            )
+        assertEquals(null, result)
+    }
+
+    @Test
+    @DisplayName("배차 간격 추정 - 홀수 개 간격의 중앙값")
+    fun testEstimateHeadwayMinutesOddGapCount() {
+        // gaps: 10, 20, 30 (odd count) -> median = 20
+        val result =
+            realtimeService.estimateHeadwayMinutes(
+                listOf(
+                    LocalTime.parse("08:00:00"),
+                    LocalTime.parse("08:10:00"),
+                    LocalTime.parse("08:30:00"),
+                    LocalTime.parse("09:00:00"),
+                ),
+            )
+        assertEquals(20, result)
+    }
+
+    @Test
+    @DisplayName("배차 간격 추정 - 짝수 개 간격의 중앙값(평균)")
+    fun testEstimateHeadwayMinutesEvenGapCount() {
+        // gaps: 10, 20 (even count) -> median = (10 + 20) / 2 = 15
+        val result =
+            realtimeService.estimateHeadwayMinutes(
+                listOf(LocalTime.parse("08:00:00"), LocalTime.parse("08:10:00"), LocalTime.parse("08:30:00")),
+            )
+        assertEquals(15, result)
+    }
+
+    @Test
+    @DisplayName("클러스터링 임계값 - 배차 간격 정보 없으면 기본값(4분) 사용")
+    fun testClusterThresholdMinutesFallback() {
+        assertEquals(4, realtimeService.clusterThresholdMinutes(null))
+    }
+
+    @Test
+    @DisplayName("클러스터링 임계값 - 배차 간격이 좁으면 하한(2분)으로 clamp")
+    fun testClusterThresholdMinutesLowerClamp() {
+        assertEquals(2, realtimeService.clusterThresholdMinutes(3))
+    }
+
+    @Test
+    @DisplayName("클러스터링 임계값 - 배차 간격이 넓으면 상한(12분)으로 clamp")
+    fun testClusterThresholdMinutesUpperClamp() {
+        assertEquals(12, realtimeService.clusterThresholdMinutes(100))
+    }
+
+    @Test
+    @DisplayName("클러스터링 임계값 - clamp 범위 내에서는 배차 간격 / 3")
+    fun testClusterThresholdMinutesNormalRange() {
+        assertEquals(10, realtimeService.clusterThresholdMinutes(30))
+    }
+
+    @Test
     @DisplayName("버스 도착 정보 배치 조회 - 도착 로그가 cutoff 이내로 필터링됨 (시간표 fallback 사용)")
     fun testGetArrivalBatchLogFilteredByCutoff() {
         val fixedNow = LocalDateTime.of(2025, 3, 3, 7, 0)


### PR DESCRIPTION
## Summary

- Replace the fixed 3-minute departure-log clustering window with one derived from each route's own scheduled headway.
- A fixed window either blurred distinct dispatches together on frequent routes or failed to absorb day-to-day timing jitter on infrequent ones.

## Details

- `BusRealtimeService.kt`: add `estimateHeadwayMinutes()` (median gap between a route's scheduled timetable departures) and `clusterThresholdMinutes()` (`headway / 3`, clamped to 2–12 minutes; falls back to 4 minutes when headway can't be estimated).
- `getArrivalBatch()` now computes the threshold per `(routeID, startStopID)` key and passes it into `clusterDepartureTimes()` instead of relying on the fixed default.
- Validated against live production data across several routes with different headways (10-1, 3102, 3100, 3101, 50) — the derived thresholds track each route's actual timing jitter more closely than the old fixed value.

## Validation

- `./gradlew ktlintCheck test jacocoTestCoverageVerification`
- JaCoCo: 100% project line and branch coverage (gate)