### PR TITLE
feat: Localize subway station names

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/database/repository/SubwayStationTranslationRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/SubwayStationTranslationRepository.kt
@@ -1,0 +1,25 @@
+package app.hyuabot.backend.database.repository
+
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class SubwayStationTranslationRepository(
+    private val jdbcTemplate: JdbcTemplate,
+) {
+    fun findName(
+        stationID: String,
+        language: String,
+    ): String? =
+        jdbcTemplate
+            .queryForList(
+                """
+                SELECT name
+                FROM subway_station_translation
+                WHERE station_id = ? AND language = ?
+                """.trimIndent(),
+                String::class.java,
+                stationID,
+                language,
+            ).firstOrNull()
+}

--- a/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
@@ -11,6 +11,7 @@ import app.hyuabot.backend.database.entity.SubwayRouteStation
 import app.hyuabot.backend.holiday.service.PublicHolidayService
 import app.hyuabot.backend.subway.domain.SubwayTimetableKey
 import app.hyuabot.backend.subway.service.SubwayService
+import app.hyuabot.backend.subway.service.SubwayStationNameService
 import app.hyuabot.backend.utility.LocalDateTimeBuilder
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsData
@@ -24,6 +25,7 @@ import java.util.concurrent.CompletableFuture
 class SubwayDataFetcher(
     private val subwayService: SubwayService,
     private val publicHolidayService: PublicHolidayService,
+    private val subwayStationNameService: SubwayStationNameService,
 ) {
     @DgsQuery
     fun subway(
@@ -46,12 +48,33 @@ class SubwayDataFetcher(
                 it.stationID to it.limit
             }
         dfe.graphQlContext.put("limitMap", limitMap)
+        input.language?.let { dfe.graphQlContext.put("subwayLanguage", it) }
         // distinct + sorted so the cache key is insensitive to request order/duplicates
         return subwayService.getStationViews(
             input.keys
                 .map { it.stationID }
                 .distinct()
                 .sorted(),
+        )
+    }
+
+    @DgsData(parentType = "SubwayStation", field = "name")
+    fun stationName(dfe: DgsDataFetchingEnvironment): String {
+        val station = dfe.getSource<SubwayStation>()!!
+        return subwayStationNameService.displayName(
+            station.stationID,
+            dfe.graphQlContext.get("subwayLanguage"),
+            station.name,
+        )
+    }
+
+    @DgsData(parentType = "SubwayOriginTerminal", field = "name")
+    fun terminalName(dfe: DgsDataFetchingEnvironment): String {
+        val station = dfe.getSource<SubwayOriginTerminal>()!!
+        return subwayStationNameService.displayName(
+            station.stationID,
+            dfe.graphQlContext.get("subwayLanguage"),
+            station.name,
         )
     }
 

--- a/src/main/kotlin/app/hyuabot/backend/subway/service/SubwayStationNameService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/service/SubwayStationNameService.kt
@@ -1,0 +1,40 @@
+package app.hyuabot.backend.subway.service
+
+import app.hyuabot.backend.database.repository.SubwayStationTranslationRepository
+import org.springframework.stereotype.Service
+
+@Service
+class SubwayStationNameService(
+    private val repository: SubwayStationTranslationRepository,
+) {
+    fun displayName(
+        stationID: String,
+        language: String?,
+        fallback: String,
+    ): String {
+        val normalizedLanguage = normalizeLanguage(language)
+        return repository.findName(stationID, normalizedLanguage)
+            ?: repository.findName(stationID, DEFAULT_LANGUAGE)
+            ?: fallback
+    }
+
+    internal fun normalizeLanguage(language: String?): String {
+        val tag =
+            language
+                .orEmpty()
+                .trim()
+                .replace('_', '-')
+                .lowercase()
+        return when {
+            tag.startsWith("zh-hant") || tag.startsWith("zh-tw") || tag.startsWith("zh-hk") -> "zh-Hant"
+            tag.startsWith("zh") -> "zh-Hans"
+            tag.startsWith("en") -> "en"
+            tag.startsWith("ja") -> "ja"
+            else -> DEFAULT_LANGUAGE
+        }
+    }
+
+    companion object {
+        const val DEFAULT_LANGUAGE = "ko"
+    }
+}

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -310,6 +310,7 @@ type BusArrival {
 # 전철 정보를 반환하는 쿼리입니다.
 input SubwayInput {
     keys: [SubwayStationInput!]!
+    language: String
 }
 
 input SubwayStationInput {

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
@@ -12,12 +12,15 @@ import app.hyuabot.backend.subway.controller.SubwayDataFetcher
 import app.hyuabot.backend.subway.controller.SubwayTimetableDataLoader
 import app.hyuabot.backend.subway.domain.SubwayTimetableKey
 import app.hyuabot.backend.subway.service.SubwayService
+import app.hyuabot.backend.subway.service.SubwayStationNameService
 import app.hyuabot.backend.utility.ScalarRegistration
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.test.EnableDgsTest
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.assertNotNull
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.whenever
@@ -44,6 +47,15 @@ class SubwayDataFetcherTest {
     @MockitoBean private lateinit var subwayService: SubwayService
 
     @MockitoBean private lateinit var publicHolidayService: PublicHolidayService
+
+    @MockitoBean private lateinit var subwayStationNameService: SubwayStationNameService
+
+    @BeforeEach
+    fun configureStationNameFallback() {
+        whenever(subwayStationNameService.displayName(any(), anyOrNull(), any())).thenAnswer { invocation ->
+            invocation.getArgument(2)
+        }
+    }
 
     private fun createRoute(
         id: Int = 1004,
@@ -175,6 +187,7 @@ class SubwayDataFetcherTest {
                 """
                 {
                     subway(input: {
+                        language: "en-US",
                         keys: [{
                             stationID: "K449",
                             direction: ["up"],
@@ -913,7 +926,7 @@ class SubwayDataFetcherTest {
     @Test
     @DisplayName("전철 도착 정보 필터 - 실시간이 없으면 원본 목록 반환")
     fun testFilterKeepsTimetableWhenRealtimeIsEmpty() {
-        val fetcher = SubwayDataFetcher(subwayService, publicHolidayService)
+        val fetcher = SubwayDataFetcher(subwayService, publicHolidayService, subwayStationNameService)
         val method =
             SubwayDataFetcher::class.java.getDeclaredMethod(
                 "filterTimetableAfterRealtime",
@@ -940,7 +953,7 @@ class SubwayDataFetcherTest {
     @Test
     @DisplayName("전철 도착 정보 필터 - 첫 실시간 값이 최대여도 시간표 간격 적용")
     fun testFilterUsesFirstRealtimeWhenItIsMaximum() {
-        val fetcher = SubwayDataFetcher(subwayService, publicHolidayService)
+        val fetcher = SubwayDataFetcher(subwayService, publicHolidayService, subwayStationNameService)
         val method =
             SubwayDataFetcher::class.java.getDeclaredMethod(
                 "filterTimetableAfterRealtime",

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayStationNameServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayStationNameServiceTest.kt
@@ -1,0 +1,60 @@
+package app.hyuabot.backend.subway
+
+import app.hyuabot.backend.database.repository.SubwayStationTranslationRepository
+import app.hyuabot.backend.subway.service.SubwayStationNameService
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class SubwayStationNameServiceTest {
+    @Mock
+    lateinit var repository: SubwayStationTranslationRepository
+
+    @ParameterizedTest
+    @CsvSource(
+        "zh-Hant-TW, zh-Hant",
+        "zh-HK, zh-Hant",
+        "zh-CN, zh-Hans",
+        "en-US, en",
+        "ja-JP, ja",
+        "ko-KR, ko",
+        "'', ko",
+    )
+    fun `normalizes supported language tags`(
+        language: String,
+        expected: String,
+    ) {
+        assertEquals(expected, SubwayStationNameService(repository).normalizeLanguage(language))
+    }
+
+    @Test
+    fun `defaults a missing language to Korean`() {
+        assertEquals("ko", SubwayStationNameService(repository).normalizeLanguage(null))
+    }
+
+    @Test
+    fun `normalizes regional language tags and returns translated name`() {
+        val service = SubwayStationNameService(repository)
+        whenever(repository.findName("K453", "zh-Hant")).thenReturn("安山")
+
+        assertEquals("安山", service.displayName("K453", "zh_TW", "안산"))
+    }
+
+    @Test
+    fun `falls back to Korean and then source name`() {
+        val service = SubwayStationNameService(repository)
+        whenever(repository.findName("K453", "ja")).thenReturn(null)
+        whenever(repository.findName("K453", "ko")).thenReturn("안산")
+        assertEquals("안산", service.displayName("K453", "ja-JP", "fallback"))
+
+        whenever(repository.findName("S07", "en")).thenReturn(null)
+        whenever(repository.findName("S07", "ko")).thenReturn(null)
+        assertEquals("일산", service.displayName("S07", "en-US", "일산"))
+    }
+}

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayStationTranslationRepositoryTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayStationTranslationRepositoryTest.kt
@@ -1,0 +1,44 @@
+package app.hyuabot.backend.subway
+
+import app.hyuabot.backend.database.repository.SubwayStationTranslationRepository
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.jdbc.core.JdbcTemplate
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SubwayStationTranslationRepositoryTest {
+    private val jdbcTemplate = mock<JdbcTemplate>()
+    private val repository = SubwayStationTranslationRepository(jdbcTemplate)
+
+    @Test
+    fun `returns translated station name`() {
+        whenever(
+            jdbcTemplate.queryForList(
+                any<String>(),
+                eq(String::class.java),
+                eq("K453"),
+                eq("en"),
+            ),
+        ).thenReturn(listOf("Ansan"))
+
+        assertEquals("Ansan", repository.findName("K453", "en"))
+    }
+
+    @Test
+    fun `returns null when translation is missing`() {
+        whenever(
+            jdbcTemplate.queryForList(
+                any<String>(),
+                eq(String::class.java),
+                eq("K453"),
+                eq("en"),
+            ),
+        ).thenReturn(emptyList())
+
+        assertNull(repository.findName("K453", "en"))
+    }
+}


### PR DESCRIPTION
## Summary

- Accept an optional language tag in subway GraphQL requests.
- Resolve station and terminal names from stable station-ID translations with Korean and source-name fallbacks.
- Normalize regional English, Japanese, and Simplified/Traditional Chinese language tags.
- Read translations through a focused JDBC repository so the table does not become part of Hibernate schema validation.

## Impact

Existing clients remain compatible and receive Korean names when no language is supplied. Updated clients receive localized station and terminal names without maintaining station-name maps locally. The required database migration and multilingual seed data are already deployed.

## Validation

- `./gradlew ktlintCheck`
- `./gradlew clean test jacocoTestReport`
- `./gradlew jacocoTestCoverageVerification`
- All 1,615 tests passed locally.
- JaCoCo project line and branch coverage gates passed at 100%.
