### PR TITLE
feat: Localize subway realtime locations

### DIFF
--- a/src/main/kotlin/app/hyuabot/backend/database/repository/SubwayStationTranslationRepository.kt
+++ b/src/main/kotlin/app/hyuabot/backend/database/repository/SubwayStationTranslationRepository.kt
@@ -22,4 +22,25 @@ class SubwayStationTranslationRepository(
                 stationID,
                 language,
             ).firstOrNull()
+
+    fun findNameByKoreanName(
+        koreanName: String,
+        language: String,
+    ): String? =
+        jdbcTemplate
+            .queryForList(
+                """
+                SELECT target.name
+                FROM subway_station_translation source
+                JOIN subway_station_translation target ON target.station_id = source.station_id
+                WHERE source.language = 'ko'
+                  AND source.name = ?
+                  AND target.language = ?
+                ORDER BY target.station_id
+                LIMIT 1
+                """.trimIndent(),
+                String::class.java,
+                koreanName,
+                language,
+            ).firstOrNull()
 }

--- a/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/controller/SubwayDataFetcher.kt
@@ -92,7 +92,7 @@ class SubwayDataFetcher(
         return entries.map {
             SubwayRealtime(
                 order = it.order,
-                location = it.location,
+                location = localizedLocation(it.location, dfe)!!,
                 stops = it.remainingStop,
                 minutes = it.remainingTime.toMinutes().toInt(),
                 direction = normalizeSubwayDirection(it.heading),
@@ -149,6 +149,7 @@ class SubwayDataFetcher(
                         weekday = weekday,
                         limit = null,
                     ).flatMap { it.entries }
+                    .map { it.withLocalizedLocation(dfe) }
                     .distinctBy {
                         listOf(
                             it.isRealtime,
@@ -166,6 +167,31 @@ class SubwayDataFetcher(
             )
         }
     }
+
+    private fun SubwayArrival.withLocalizedLocation(dfe: DgsDataFetchingEnvironment) =
+        SubwayArrival(
+            minutes = minutes,
+            origin = origin,
+            terminal = terminal,
+            isRealtime = isRealtime,
+            location = localizedLocation(location, dfe),
+            stops = stops,
+            trainNumber = trainNumber,
+            isExpress = isExpress,
+            isLast = isLast,
+            status = status,
+        )
+
+    private fun localizedLocation(
+        location: String?,
+        dfe: DgsDataFetchingEnvironment,
+    ): String? =
+        location?.let {
+            subwayStationNameService.displayNameByKoreanName(
+                it,
+                dfe.graphQlContext.get("subwayLanguage"),
+            )
+        }
 
     private fun SubwayRouteStation.toSubwayStation() =
         SubwayOriginTerminal(

--- a/src/main/kotlin/app/hyuabot/backend/subway/service/SubwayStationNameService.kt
+++ b/src/main/kotlin/app/hyuabot/backend/subway/service/SubwayStationNameService.kt
@@ -18,6 +18,16 @@ class SubwayStationNameService(
             ?: fallback
     }
 
+    fun displayNameByKoreanName(
+        koreanName: String,
+        language: String?,
+    ): String {
+        val normalizedLanguage = normalizeLanguage(language)
+        return repository.findNameByKoreanName(koreanName, normalizedLanguage)
+            ?: repository.findNameByKoreanName(koreanName, DEFAULT_LANGUAGE)
+            ?: koreanName
+    }
+
     internal fun normalizeLanguage(language: String?): String {
         val tag =
             language

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayDataFetcherTest.kt
@@ -55,6 +55,9 @@ class SubwayDataFetcherTest {
         whenever(subwayStationNameService.displayName(any(), anyOrNull(), any())).thenAnswer { invocation ->
             invocation.getArgument(2)
         }
+        whenever(subwayStationNameService.displayNameByKoreanName(any(), anyOrNull())).thenAnswer { invocation ->
+            invocation.getArgument(0)
+        }
     }
 
     private fun createRoute(
@@ -214,6 +217,7 @@ class SubwayDataFetcherTest {
     @DisplayName("전철 도착 정보 조회 (정상, 역 정보 + 실시간 정보 + 시간표 + 도착 정보)")
     fun testSubwayFullInfo() {
         whenever(subwayService.getStationViews(listOf(station.id))).thenReturn(listOf(createStationView()))
+        whenever(subwayStationNameService.displayNameByKoreanName("중앙", "en-US")).thenReturn("Jungang")
         whenever(subwayService.getRealtimeList(station.id, directions = listOf("up", "0"))).thenReturn(
             listOf(
                 createRealtime(
@@ -272,6 +276,7 @@ class SubwayDataFetcherTest {
                 """
                 {
                     subway(input: {
+                        language: "en-US",
                         keys: [{
                             stationID: "K449",
                             direction: ["up"],
@@ -318,6 +323,11 @@ class SubwayDataFetcherTest {
         assertEquals("K449", result[0]["stationID"])
         assertEquals("한대앞", result[0]["name"])
         assertEquals(49, result[0]["order"])
+        val realtime = result[0]["realtime"] as List<*>
+        assertEquals("Jungang", (realtime[0] as Map<*, *>)["location"])
+        val arrival = result[0]["arrival"] as List<*>
+        val arrivalEntries = ((arrival[0] as Map<*, *>)["entries"] as List<*>)
+        assertEquals("Jungang", (arrivalEntries[0] as Map<*, *>)["location"])
     }
 
     @Test

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayStationNameServiceTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayStationNameServiceTest.kt
@@ -57,4 +57,30 @@ class SubwayStationNameServiceTest {
         whenever(repository.findName("S07", "ko")).thenReturn(null)
         assertEquals("일산", service.displayName("S07", "en-US", "일산"))
     }
+
+    @Test
+    fun `returns translated name from Korean realtime location`() {
+        val service = SubwayStationNameService(repository)
+        whenever(repository.findNameByKoreanName("중앙", "en")).thenReturn("Jungang")
+
+        assertEquals("Jungang", service.displayNameByKoreanName("중앙", "en-US"))
+    }
+
+    @Test
+    fun `falls back to source realtime location`() {
+        val service = SubwayStationNameService(repository)
+        whenever(repository.findNameByKoreanName("임시역", "ja")).thenReturn(null)
+        whenever(repository.findNameByKoreanName("임시역", "ko")).thenReturn(null)
+
+        assertEquals("임시역", service.displayNameByKoreanName("임시역", "ja-JP"))
+    }
+
+    @Test
+    fun `falls back to Korean realtime location translation`() {
+        val service = SubwayStationNameService(repository)
+        whenever(repository.findNameByKoreanName("중앙", "ja")).thenReturn(null)
+        whenever(repository.findNameByKoreanName("중앙", "ko")).thenReturn("중앙")
+
+        assertEquals("중앙", service.displayNameByKoreanName("중앙", "ja-JP"))
+    }
 }

--- a/src/test/kotlin/app/hyuabot/backend/subway/SubwayStationTranslationRepositoryTest.kt
+++ b/src/test/kotlin/app/hyuabot/backend/subway/SubwayStationTranslationRepositoryTest.kt
@@ -41,4 +41,18 @@ class SubwayStationTranslationRepositoryTest {
 
         assertNull(repository.findName("K453", "en"))
     }
+
+    @Test
+    fun `returns translated station name by Korean name`() {
+        whenever(
+            jdbcTemplate.queryForList(
+                any<String>(),
+                eq(String::class.java),
+                eq("중앙"),
+                eq("en"),
+            ),
+        ).thenReturn(listOf("Jungang"))
+
+        assertEquals("Jungang", repository.findNameByKoreanName("중앙", "en"))
+    }
 }


### PR DESCRIPTION
## Summary
- Resolve Korean realtime location names through the station translation table.
- Return localized locations for both realtime and arrival GraphQL fields.
- Preserve Korean source text as the final fallback when a translation is unavailable.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test jacocoTestReport jacocoTestCoverageVerification`